### PR TITLE
Runtime Reliability v3: bound market data failures

### DIFF
--- a/PROJECT_HANDOFF.md
+++ b/PROJECT_HANDOFF.md
@@ -37,6 +37,8 @@ Provide the user a completion update after each implemented milestone with commi
 
 The July 22 mid-day compact self-check passed with `overall: pass`, `status: ok`, no warnings, stable recursion-safe direct-core entry pipeline, paper equity of 10893.98, 85 execution rows, 35 wins, 17 losses, and no newly timestamped runtime error. The historical duplicate-reason TypeError remains dated July 20 and is not new.
 
+Railway later recorded a `/paper/run` Gunicorn worker timeout while the runtime was blocked inside `run_cycle`, together with yfinance/curl timeout and HTTP 401 failures for individual symbols. This shifted the immediate engineering priority from deeper Scanner v2 work to bounded market-data reliability.
+
 Use `/paper/full-self-check` only for fail, missing critical fields, or a newly timestamped runtime error.
 
 ## Scanner v2 Evidence
@@ -73,6 +75,37 @@ Validated findings:
    - Propagates cycle metadata through transactional scanner, decision, blocker, X-Ray, journal, rotation, and post-harvest state updates.
    - Stamps only records changed during the associated cycle.
    - Does not alter scanner inputs/results, candidates, thresholds, risk, sizing, orders, ML authority, or live authority.
+
+## Runtime Reliability v3 — Market Data Guard
+
+Version:
+
+`market-data-resilience-2026-07-22-v1`
+
+Route:
+
+`/paper/provider-health-status`
+
+Behavior:
+
+- wraps the core `download_prices` helper used by the paper runtime;
+- passes a bounded yfinance timeout, default 8 seconds;
+- disables yfinance internal threaded fan-out for the guarded request;
+- returns `None` on timeout, HTTP/provider error, or empty data, preserving the legacy unavailable-data contract;
+- records per-symbol duration, status, period, interval, and bounded recent events;
+- tracks successes, failures, timeouts, empty responses, and circuit skips;
+- opens a short 60-second circuit after three consecutive failures by default;
+- skips additional provider calls while the circuit is open so one failing provider cannot consume the entire Gunicorn worker budget;
+- resets the failure streak and closes the circuit after a successful response.
+
+Environment controls:
+
+- `MARKET_DATA_REQUEST_TIMEOUT_SECONDS` default `8`
+- `MARKET_DATA_FAILURE_THRESHOLD` default `3`
+- `MARKET_DATA_CIRCUIT_OPEN_SECONDS` default `60`
+- `MARKET_DATA_MAX_EVENTS` default `200`
+
+This milestone changes failure timing and provider availability handling only. It does not change signal formulas, thresholds, sizing, risk controls, order logic, executable universe, ML authority, or live authority.
 
 ## Shared Cycle Identity Milestone
 
@@ -125,41 +158,50 @@ Executable-universe expansion remains deferred until repeated evidence supports 
   - `31b96cf50e0876bc97ce002610a795c1eb2a2f59`
 - `shared_cycle_identity.py`
   - `964d32c3370468c4532e11ce87e11ffae32f0c3c`
+- `market_data_resilience.py`
+  - `b3f9d86bdceb23b43bcaf3817bc5634582abfb4b`
 - `usercustomize.py`
   - `147101f2c34a3be6b33611549271fc8d5d730757`
   - `54c49869cd90ce6812821ad3cb75bdf7249fe9d8`
+  - `3e034bdc1100653472a80d5fc255195601082515`
 - `PROJECT_HANDOFF.md`
-  - this commit documents autonomous workflow and the shared-cycle milestone.
+  - this branch update documents Runtime Reliability v3.
 
 ## Validation
 
-After Railway redeploys, run:
+After the branch is merged and Railway redeploys, run:
 
 1. `https://trading-bot-clean.up.railway.app/paper/self-check`
-2. `https://trading-bot-clean.up.railway.app/paper/shared-cycle-identity-status`
-3. After at least one normal scanner/entry cycle, run both links again.
+2. `https://trading-bot-clean.up.railway.app/paper/provider-health-status`
+3. Trigger one authenticated `/paper/run` using the `X-Run-Key` header rather than a query-string key.
+4. Re-run `/paper/provider-health-status` and inspect durations, statuses, counters, and circuit state.
 
-Expected shared-cycle route fields:
+Expected provider-health fields:
 
 - `status: ok`
 - `overall: pass`
-- `version: shared-cycle-identity-2026-07-22-v1`
-- `scan_signals_patched_for_identity_only: true` in installation status or runtime registration
-- all authority fields false
-- a non-null `last_cycle_id` after a scanner cycle
-- increasing `records_with_cycle_id` as decision and blocker records are written
-- `same_cycle_alignment: true` once at least two relevant records share the same ID
+- `installed: true`
+- `request_timeout_seconds: 8.0` unless overridden
+- `authority` fields all false
+- bounded `recent_events`
+- no Gunicorn worker timeout caused by a single 30-second yfinance symbol request
+
+Expected legacy behavior:
+
+- failed or empty symbol downloads remain unavailable and are skipped by downstream logic;
+- successful symbols continue through unchanged;
+- strategy, thresholds, sizing, risk, order, ML, and live authority remain unchanged.
 
 ## Next Steps
 
 Proceed autonomously in this order:
 
-1. Validate routine self-check after redeploy.
-2. Validate shared-cycle route before and after a normal cycle.
-3. Confirm decision and blocker records receive the same cycle ID.
-4. If alignment remains incomplete, identify which producer bypasses transactional state updates and add metadata-only instrumentation at that producer.
-5. Replace remaining `reason_detail_missing` rows with explicit underlying blocker attribution.
-6. Expand candidate lifecycle persistence and repeated candidate-to-entry/outcome evidence.
+1. Merge the Runtime Reliability v3 branch after diff review.
+2. Validate `/paper/self-check` and `/paper/provider-health-status` after Railway redeploy.
+3. Trigger a controlled authenticated paper run and confirm the worker completes within the platform timeout.
+4. Inspect whether any direct yfinance calls outside `core.download_prices` remain on the critical run path; guard only those proven to be runtime-critical.
+5. Add phase-level run-cycle timing only if provider telemetry does not fully explain remaining latency.
+6. Resume shared-cycle alignment and blocker taxonomy work after runtime completion is stable.
 7. Keep strategy, thresholds, sizing, risk, ML authority, and live authority unchanged until evidence supports a separately reviewed proposal.
 
 No filter should be relaxed solely because a stock finished strongly.

--- a/market_data_resilience.py
+++ b/market_data_resilience.py
@@ -1,0 +1,204 @@
+"""Bounded market-data reliability guard for the paper runtime.
+
+Wraps the core ``download_prices`` helper with a yfinance request timeout,
+per-symbol timing, bounded telemetry, and a short provider circuit breaker.
+It does not change signal rules, thresholds, sizing, risk controls, order logic,
+or live/ML authority. Failed or empty downloads remain unavailable exactly as
+before; they now fail quickly instead of consuming the Gunicorn worker budget.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import os
+import sys
+import threading
+import time
+from typing import Any, Dict, List
+
+VERSION = "market-data-resilience-2026-07-22-v1"
+REQUEST_TIMEOUT_SECONDS = max(2.0, float(os.environ.get("MARKET_DATA_REQUEST_TIMEOUT_SECONDS", "8")))
+FAILURE_THRESHOLD = max(1, int(os.environ.get("MARKET_DATA_FAILURE_THRESHOLD", "3")))
+CIRCUIT_OPEN_SECONDS = max(5, int(os.environ.get("MARKET_DATA_CIRCUIT_OPEN_SECONDS", "60")))
+MAX_EVENTS = max(20, int(os.environ.get("MARKET_DATA_MAX_EVENTS", "200")))
+
+_LOCK = threading.RLock()
+_PATCHED_MODULE_IDS: set[int] = set()
+_REGISTERED_APP_IDS: set[int] = set()
+_EVENTS: List[Dict[str, Any]] = []
+_TOTALS: Dict[str, int] = {"requests": 0, "successes": 0, "failures": 0, "timeouts": 0, "empty": 0, "circuit_skips": 0}
+_CONSECUTIVE_FAILURES = 0
+_CIRCUIT_OPEN_UNTIL = 0.0
+_LAST_ERROR: Dict[str, Any] = {}
+
+
+def _mod() -> Any | None:
+    for name in ("app", "__main__"):
+        module = sys.modules.get(name)
+        if module is not None and hasattr(module, "download_prices"):
+            return module
+    for module in list(sys.modules.values()):
+        if module is not None and getattr(module, "app", None) is not None and hasattr(module, "download_prices"):
+            return module
+    return None
+
+
+def _now() -> str:
+    return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _record(symbol: str, period: str, interval: str, started: float, status: str, error: str = "") -> None:
+    global _LAST_ERROR
+    row = {
+        "generated_local": _now(),
+        "symbol": str(symbol),
+        "period": str(period),
+        "interval": str(interval),
+        "duration_ms": round((time.monotonic() - started) * 1000.0, 1),
+        "status": status,
+    }
+    if error:
+        row["error"] = error[:500]
+        _LAST_ERROR = dict(row)
+    with _LOCK:
+        _EVENTS.append(row)
+        del _EVENTS[:-MAX_EVENTS]
+
+
+def _is_empty(frame: Any) -> bool:
+    return frame is None or bool(getattr(frame, "empty", True))
+
+
+def install(core: Any = None) -> Dict[str, Any]:
+    core = core or _mod()
+    if core is None:
+        return {"status": "pending", "version": VERSION, "reason": "app_module_not_ready"}
+    current = getattr(core, "download_prices", None)
+    if not callable(current):
+        return {"status": "pending", "version": VERSION, "reason": "download_prices_missing"}
+    if getattr(current, "_market_data_resilience_version", None) == VERSION:
+        return status_payload(core)
+
+    original = getattr(current, "_market_data_resilience_original", current)
+
+    def guarded_download_prices(symbol: str, period: str = "5d", interval: str = "5m"):
+        global _CONSECUTIVE_FAILURES, _CIRCUIT_OPEN_UNTIL
+        started = time.monotonic()
+        now = time.time()
+        with _LOCK:
+            _TOTALS["requests"] += 1
+            if now < _CIRCUIT_OPEN_UNTIL:
+                _TOTALS["circuit_skips"] += 1
+                _record(symbol, period, interval, started, "circuit_open")
+                return None
+
+        try:
+            # Call yfinance directly so the timeout is guaranteed even when the
+            # legacy helper does not expose a timeout parameter.
+            frame = core.yf.download(
+                symbol,
+                period=period,
+                interval=interval,
+                progress=False,
+                auto_adjust=True,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+                threads=False,
+            )
+            if _is_empty(frame):
+                with _LOCK:
+                    _TOTALS["empty"] += 1
+                    _TOTALS["failures"] += 1
+                    _CONSECUTIVE_FAILURES += 1
+                    if _CONSECUTIVE_FAILURES >= FAILURE_THRESHOLD:
+                        _CIRCUIT_OPEN_UNTIL = time.time() + CIRCUIT_OPEN_SECONDS
+                _record(symbol, period, interval, started, "empty")
+                return None
+            with _LOCK:
+                _TOTALS["successes"] += 1
+                _CONSECUTIVE_FAILURES = 0
+                _CIRCUIT_OPEN_UNTIL = 0.0
+            _record(symbol, period, interval, started, "ok")
+            return frame
+        except Exception as exc:
+            text = f"{type(exc).__name__}: {exc}"
+            timeout_like = "timeout" in text.lower() or "curl: (28)" in text.lower()
+            with _LOCK:
+                _TOTALS["failures"] += 1
+                if timeout_like:
+                    _TOTALS["timeouts"] += 1
+                _CONSECUTIVE_FAILURES += 1
+                if _CONSECUTIVE_FAILURES >= FAILURE_THRESHOLD:
+                    _CIRCUIT_OPEN_UNTIL = time.time() + CIRCUIT_OPEN_SECONDS
+            _record(symbol, period, interval, started, "timeout" if timeout_like else "error", text)
+            return None
+
+    guarded_download_prices._market_data_resilience_version = VERSION  # type: ignore[attr-defined]
+    guarded_download_prices._market_data_resilience_original = original  # type: ignore[attr-defined]
+    core.download_prices = guarded_download_prices
+    _PATCHED_MODULE_IDS.add(id(core))
+    return status_payload(core)
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    core = core or _mod()
+    now = time.time()
+    with _LOCK:
+        recent = list(_EVENTS[-50:])
+        totals = dict(_TOTALS)
+        consecutive = int(_CONSECUTIVE_FAILURES)
+        open_until = float(_CIRCUIT_OPEN_UNTIL)
+        last_error = dict(_LAST_ERROR)
+    durations = [float(row.get("duration_ms") or 0.0) for row in recent if row.get("status") == "ok"]
+    return {
+        "status": "ok" if core is not None else "pending",
+        "overall": "pass" if core is not None else "pending",
+        "type": "market_data_resilience_status",
+        "version": VERSION,
+        "installed": bool(core is not None and getattr(getattr(core, "download_prices", None), "_market_data_resilience_version", None) == VERSION),
+        "request_timeout_seconds": REQUEST_TIMEOUT_SECONDS,
+        "failure_threshold": FAILURE_THRESHOLD,
+        "circuit_open_seconds": CIRCUIT_OPEN_SECONDS,
+        "circuit_open": bool(now < open_until),
+        "circuit_seconds_remaining": max(0, round(open_until - now, 1)),
+        "consecutive_failures": consecutive,
+        "totals": totals,
+        "average_success_duration_ms": round(sum(durations) / len(durations), 1) if durations else None,
+        "last_error": last_error,
+        "recent_events": recent,
+        "authority": {
+            "changes_live_authority": False,
+            "changes_ml_authority": False,
+            "changes_risk_or_sizing": False,
+            "changes_thresholds": False,
+            "places_orders": False,
+        },
+        "logic_changed": False,
+    }
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    return install(core)
+
+
+def apply_runtime_overrides(core: Any = None) -> Dict[str, Any]:
+    return install(core)
+
+
+def register_routes(flask_app: Any, core: Any = None) -> None:
+    if flask_app is None or id(flask_app) in _REGISTERED_APP_IDS:
+        return
+    from flask import jsonify
+    try:
+        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+    except Exception:
+        existing = set()
+    path = "/paper/provider-health-status"
+    if path not in existing:
+        flask_app.add_url_rule(path, "provider_health_status", lambda: jsonify(status_payload(core or _mod())))
+    _REGISTERED_APP_IDS.add(id(flask_app))
+    install(core or _mod())
+
+
+try:
+    install(_mod())
+except Exception:
+    pass

--- a/usercustomize.py
+++ b/usercustomize.py
@@ -5,7 +5,7 @@ import threading
 import time
 from typing import Any
 
-VERSION = "usercustomize-entry-pipeline-composition-2026-07-22-v36-shared-cycle-identity"
+VERSION = "usercustomize-entry-pipeline-composition-2026-07-22-v37-market-data-resilience"
 _REGISTERED_APP_IDS: set[int] = set()
 
 
@@ -38,6 +38,7 @@ def _patch_self_check_endpoints() -> None:
             {"path": "/paper/scanner-v2-theme-confidence-status", "category": "governance", "required": False},
             {"path": "/paper/scanner-v2-candidate-lifecycle-trace-status", "category": "governance", "required": False},
             {"path": "/paper/shared-cycle-identity-status", "category": "governance", "required": False},
+            {"path": "/paper/provider-health-status", "category": "market_data", "required": False},
             {"path": "/paper/regime-flip-entry-guard-status", "category": "governance", "required": False},
             {"path": "/paper/core-entry-pipeline-status", "category": "governance", "required": False},
             {"path": "/paper/extended-leader-starter-valve-status", "category": "governance", "required": False},
@@ -94,6 +95,7 @@ MODULES = (
     ("self_check", "app_and_module"),
     ("state_transaction_manager", "app_and_module"),
     ("shared_cycle_identity", "app_and_module"),
+    ("market_data_resilience", "app_and_module"),
     ("breakout_participation_layer", "app_only"),
     ("fmp_limited_access_guard", "app_and_module"),
     ("fmp_cached_profile_label_guard", "app_and_module"),
@@ -153,7 +155,7 @@ def _watchdog() -> None:
             if flask_app is not None:
                 _register_auxiliary_routes(flask_app, core)
                 for name in (
-                    "state_transaction_manager", "shared_cycle_identity", "symbol_hygiene_guard",
+                    "state_transaction_manager", "shared_cycle_identity", "market_data_resilience", "symbol_hygiene_guard",
                     "scanner_v2_shadow_universe", "missed_opportunity_post_close_audit",
                     "scanner_v2_shadow_quality_trace", "scanner_v2_shadow_composite_score",
                     "scanner_v2_theme_confidence_overlay", "scanner_v2_candidate_lifecycle_trace",


### PR DESCRIPTION
## Summary
- add a bounded yfinance timeout around the core paper-runtime `download_prices` helper
- add per-symbol duration/status telemetry and provider-health counters
- add a short circuit breaker after repeated provider failures
- register `/paper/provider-health-status` and include it in the self-check registry
- update `PROJECT_HANDOFF.md`

## Safety boundary
No changes to scanner results, entry/exit formulas, thresholds, sizing, risk controls, executable universe, order placement, ML authority, or live authority. Failed/empty downloads remain unavailable as before; they now fail fast.

## Validation after merge
1. `/paper/self-check`
2. `/paper/provider-health-status`
3. one authenticated `/paper/run` using the `X-Run-Key` header
4. confirm no single 30-second yfinance call causes a Gunicorn worker timeout