### PR TITLE
State provenance v1: detect snapshot regression

### DIFF
--- a/PROJECT_HANDOFF.md
+++ b/PROJECT_HANDOFF.md
@@ -21,99 +21,75 @@ Continue sequential diagnostic, observability, reliability, documentation, and a
 
 ## July 23 Morning Baseline
 
-The July 23 compact self-check generated at `2026-07-23 15:28:59` passed with:
+The morning compact self-check passed with equity `10970.12`, realized total `970.14`, 88 execution rows, 36 wins, 18 losses, zero open positions, stable recursion-safe entry composition, no current pipeline error, and 54 matching decision/blocker signals. Cycle IDs were missing at that time.
 
-- `overall: pass`
-- `status: ok`
-- service running with no required-path failures or warnings
-- cash/equity: `10970.12`
-- realized today: `112.74`
-- realized total: `970.14`
-- execution rows: `88`
-- wins/losses: `36 / 18`
-- open positions: `0`
-- entry pipeline stable, recursion-safe, and direct-core based
-- no newly timestamped entry-pipeline error
-- ML remains advisory-only with no live authority
+## July 23 Afternoon Baseline
 
-Scanner reporting showed:
+The afternoon compact self-check generated at `2026-07-23 18:30:47` passed with:
 
-- decision signals: `54`
-- blocker-audit signals: `54`
-- count difference: `0`
-- reason coverage: `97.44%`
-- missing reason rows: `1`
+- equity: `11005.46`
+- cash: `9812.33`
+- open positions: `DELL`, `SNDK`
+- unrealized P&L: `151.44`
+- realized today: `-3.65`
+- realized total: `854.03`
+- execution rows: `83`
+- wins/losses: `34 / 17`
+- stable, recursion-safe entry pipeline
+- no required-path failures or warnings
+- ML advisory-only, no live authority
 
-The remaining observability defect was explicit:
+Cycle alignment was successfully validated:
 
-- `decision_cycle_id: null`
-- `blocker_cycle_id: null`
-- `same_cycle_comparison: false`
-- `snapshot_alignment: unverified_without_shared_cycle_id`
+- matching decision/blocker ID: `cycle-20260723T182756095055Z-1b50f934`
+- `same_cycle_comparison: true`
+- `snapshot_alignment: same_cycle`
+- `count_difference: 0`
+- `source_mismatch: false`
 
-The test also contained stale-looking cross-cycle telemetry: the starter valve's last reason referenced too many positions while the current account had zero positions, and historical blocker rows referenced self-defense while the current risk snapshot reported the feedback loop clear. These are treated as freshness/cycle-alignment issues, not evidence for changing trading rules.
+However, cumulative account metrics moved backward from the morning snapshot:
 
-## Runtime Reliability v3 — Market Data Guard
+- execution rows: `88 -> 83`
+- wins: `36 -> 34`
+- losses: `18 -> 17`
+- realized total: `970.14 -> 854.03`
+
+This is treated as a state provenance/persistence consistency defect, not a trading-strategy signal. Possible causes include an older state snapshot, a different state path, backup fallback, worker-local memory divergence, or recalculation from a different source contract.
+
+## Runtime Reliability v3
 
 Version: `market-data-resilience-2026-07-22-v1`
 
 Route: `/paper/provider-health-status`
 
-Behavior:
+The guard bounds yfinance requests, records per-symbol latency/outcomes, opens a short circuit after repeated failures, and preserves the legacy unavailable-data contract. It does not alter strategy, thresholds, sizing, risk, orders, executable universe, ML authority, or live authority.
 
-- bounds the core yfinance request timeout at 8 seconds by default;
-- records per-symbol timing and outcomes;
-- tracks successes, failures, timeouts, empty responses, and circuit skips;
-- opens a short circuit after repeated provider failures;
-- preserves the legacy unavailable-data contract by returning `None` on failed/empty downloads;
-- does not alter signals, thresholds, sizing, risk, order logic, executable universe, ML authority, or live authority.
-
-The July 23 routine self-check passed after deployment. Direct provider-health validation remains required because the compact self-check does not expose provider counters.
-
-## Shared Cycle Identity
-
-Base version: `shared-cycle-identity-2026-07-22-v1`
-
-Route: `/paper/shared-cycle-identity-status`
-
-The base module creates one immutable cycle ID at scanner invocation and stamps transactional state updates. The morning evidence showed that two diagnostic producers bypass that transactional path:
-
-- `decision_audit_consolidation.build_payload` writes directly to in-memory diagnostic state;
-- `blocked_entry_reason_audit.build_payload` is a derived read-only producer.
-
-Therefore the scanner-generated ID existed at runtime but was not reaching the compact decision/blocker comparison.
-
-## Cycle Alignment Overlay — July 23
+## Cycle Alignment v2
 
 Version: `cycle-alignment-overlay-2026-07-23-v1`
 
 Route: `/paper/cycle-alignment-status`
 
-The overlay:
+The afternoon test confirms the cycle-alignment milestone is working. Decision and blocker producers now report the same cycle, and same-cycle count comparison is active.
 
-- stamps the decision-audit payload and its latest-cycle section with the scanner runtime cycle ID;
-- stamps the derived blocker-audit payload with the matching decision/scanner runtime cycle ID;
-- repairs the outer daily compactor after the runtime reliability wrapper has executed;
-- reports non-null decision and blocker cycle IDs when a scanner cycle exists;
-- compares counts only when the producer IDs match;
-- reports the metadata source for each ID (`producer`, runtime fallback, or unavailable);
-- augments the shared-cycle status route with producer-level cycle IDs;
-- preserves the runtime reliability wrapper marker to prevent watchdog wrapper accumulation.
+## State Provenance and Monotonicity Monitor
 
-This is metadata/reporting behavior only. It does not change scanner arguments or results, candidate selection, thresholds, entries, exits, risk controls, sizing, orders, ML authority, or live authority.
+Version: `state-provenance-monitor-2026-07-23-v1`
 
-## Current Scanner v2 Modules
+Route: `/paper/state-provenance-status`
 
-1. `scanner-v2-shadow-universe-2026-07-21-v2-leadership-clusters`
-2. `missed-opportunity-post-close-audit-2026-07-21-v2-failure-modes`
-3. `scanner-v2-shadow-quality-trace-2026-07-21-v1`
-4. `scanner-v2-shadow-composite-score-2026-07-21-v1`
-5. `scanner-v2-theme-confidence-overlay-2026-07-21-v1`
-6. `scanner-v2-candidate-lifecycle-trace-2026-07-21-v1`
-7. `shared-cycle-identity-2026-07-22-v1`
-8. `cycle-alignment-overlay-2026-07-23-v1`
+The monitor:
 
-Executable-universe expansion remains deferred until repeated paper evidence supports a separately reviewed promotion gate.
+- wraps `load_state` passively and returns the original state unchanged;
+- records state revision, state update timestamp/source, persistence mode, file path, file size, modification time, and a short SHA-256 identity;
+- records execution rows, wins, losses, realized total, equity, and position count;
+- maintains persistent high-water marks in a separate sidecar file beside the state file;
+- flags backward movement in revision, execution rows, wins, losses, or realized total;
+- reports whether the latest read appears to come from the primary state file or a backup fallback based on state I/O telemetry;
+- never restores, overwrites, merges, or modifies trading state;
+- does not change positions, signals, risk, sizing, orders, ML authority, or live authority.
+
+The sidecar file is `state_provenance_status.json` in the active state directory. It is diagnostic only and is not used as a trading-state source.
 
 ## Safety and Authority Boundary
 
@@ -126,7 +102,8 @@ Current work preserves:
 - no sizing or risk-control changes;
 - no executable-universe mutation;
 - no scanner-result modification;
-- all existing cooldown, self-defense, drawdown, regime, trend, volume, relative-edge, extension, quality, and futures-bias controls.
+- no automatic state restoration;
+- no mutation of account history or current positions.
 
 ## Files and Commits
 
@@ -134,54 +111,51 @@ Current work preserves:
   - `b3f9d86bdceb23b43bcaf3817bc5634582abfb4b`
 - `cycle_alignment_overlay.py`
   - `a95fab9d449723e13270ec3b4d53d2b164fb8360`
+- `state_provenance_monitor.py`
+  - `966a10e42c283f63e99e28c0c538137aa13cdc57`
 - `usercustomize.py`
-  - Runtime Reliability registration: `3e034bdc1100653472a80d5fc255195601082515`
-  - Cycle alignment registration: `2e85f1dbe3c14f372b9fe4c4cf5a375bad2be9b2`
+  - state provenance registration: `28a0d407638e9e7451d8c004036b8752820f4959`
 - `PROJECT_HANDOFF.md`
-  - this branch commit documents the July 23 baseline and cycle-alignment repair.
+  - this commit documents the afternoon regression evidence and validation contract.
 
 ## Validation After Merge and Railway Redeploy
 
-Run in this order:
+Run:
 
 1. `https://trading-bot-clean.up.railway.app/paper/self-check`
-2. `https://trading-bot-clean.up.railway.app/paper/cycle-alignment-status`
-3. `https://trading-bot-clean.up.railway.app/paper/shared-cycle-identity-status`
-4. `https://trading-bot-clean.up.railway.app/paper/provider-health-status`
+2. `https://trading-bot-clean.up.railway.app/paper/state-provenance-status`
+3. `https://trading-bot-clean.up.railway.app/paper/state-transaction-status`
+4. `https://trading-bot-clean.up.railway.app/paper/cycle-alignment-status`
+5. `https://trading-bot-clean.up.railway.app/paper/provider-health-status`
 
-Expected cycle-alignment fields after at least one normal scanner cycle:
+Expected provenance fields:
 
-- `cycle_alignment_overlay_version: cycle-alignment-overlay-2026-07-23-v1`
-- non-null `scanner.decision_cycle_id`
-- non-null `scanner.blocker_cycle_id`
-- `scanner.same_cycle_comparison: true`
-- `scanner.snapshot_alignment: same_cycle`
-- `scanner.count_difference: 0` when both producers still report 54 signals
-- `scanner.source_mismatch: false` when counts match
-- installation flags true on `/paper/cycle-alignment-status`
-- producer IDs visible on `/paper/shared-cycle-identity-status`
+- `version: state-provenance-monitor-2026-07-23-v1`
+- `current.metrics.state_revision`
+- `current.metrics.execution_rows`
+- `current.metrics.wins_total`
+- `current.metrics.losses_total`
+- `current.metrics.realized_total`
+- `current.state_file.path`
+- `current.state_file.sha256_prefix`
+- `current.source_hint.source`
+- `current.persistence_mode`
+- `high_water_marks`
+- `regression_detected`
+- `regressions`
+- all authority fields false
 
-Expected provider-health fields:
-
-- `status: ok`
-- `overall: pass`
-- `installed: true`
-- `request_timeout_seconds: 8.0` unless overridden
-- authority fields false
-- bounded recent events and no single-symbol 30-second worker stall
+The first observation establishes a deployment-local high-water baseline. Subsequent observations should reveal whether cumulative metrics regress again and whether the file identity, revision, state path, or source hint changes at the same time.
 
 Use `/paper/full-self-check` only for a failed routine check, missing critical fields, a newly timestamped runtime error, or an unexpected warning.
 
 ## Next Steps
 
-Proceed autonomously in this order:
-
-1. Merge the cycle-alignment branch after diff review.
-2. Validate the four routes above after Railway redeploy.
-3. Confirm producer-level cycle IDs remain aligned across at least two normal cycles.
-4. Replace the remaining single `reason_detail_missing` row with its explicit underlying blocker source.
-5. Add freshness metadata to last-known starter-valve and blocker summaries so historical telemetry cannot be mistaken for current account state.
-6. Continue candidate lifecycle and opportunity-attribution evidence collection.
-7. Keep strategy, thresholds, sizing, risk, ML authority, and live authority unchanged until evidence supports a separately reviewed proposal.
+1. Merge the state provenance branch after diff review.
+2. Validate the provenance and transaction routes after Railway redeploy.
+3. Capture at least two observations around a normal paper cycle.
+4. If a regression is detected, compare revision, state path, file hash, source hint, and backup event before considering any restoration behavior.
+5. Do not automatically restore or merge state until the precise source of divergence is proven.
+6. Resume the remaining single missing blocker-reason attribution after state consistency is understood.
 
 No filter should be relaxed solely because a stock finished strongly.

--- a/state_provenance_monitor.py
+++ b/state_provenance_monitor.py
@@ -1,0 +1,253 @@
+"""Diagnostic-only state provenance and monotonicity monitor.
+
+Tracks state source metadata, revision, file identity, and cumulative metric high-water
+marks in a sidecar file. It detects backward movement without mutating trading state,
+positions, signals, risk controls, sizing, orders, or authority.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import os
+import sys
+import threading
+from typing import Any, Dict
+
+VERSION = "state-provenance-monitor-2026-07-23-v1"
+_REGISTERED_APP_IDS: set[int] = set()
+_PATCHED_MODULE_IDS: set[int] = set()
+_LOCK = threading.RLock()
+_LAST: Dict[str, Any] = {}
+
+
+def _mod() -> Any | None:
+    for name in ("app", "__main__"):
+        module = sys.modules.get(name)
+        if module is not None and hasattr(module, "load_state"):
+            return module
+    for module in list(sys.modules.values()):
+        if module is not None and getattr(module, "app", None) is not None and hasattr(module, "load_state"):
+            return module
+    return None
+
+
+def _now() -> str:
+    return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _state_path(core: Any) -> str:
+    return str(getattr(core, "STATE_FILE", None) or os.environ.get("STATE_FILE") or "state.json")
+
+
+def _sidecar_path(core: Any) -> str:
+    state_path = _state_path(core)
+    folder = os.path.dirname(os.path.abspath(state_path)) or "."
+    return os.path.join(folder, "state_provenance_status.json")
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(float(value))
+    except Exception:
+        return default
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+def _metrics(state: Dict[str, Any]) -> Dict[str, Any]:
+    trades = state.get("trades") if isinstance(state.get("trades"), list) else []
+    perf = state.get("performance") if isinstance(state.get("performance"), dict) else {}
+    journal = state.get("trade_journal") if isinstance(state.get("trade_journal"), dict) else {}
+    summary = journal.get("journal_summary") if isinstance(journal.get("journal_summary"), dict) else {}
+    realized = state.get("realized_pnl") if isinstance(state.get("realized_pnl"), dict) else {}
+    return {
+        "state_revision": _safe_int(state.get("_state_revision"), 0),
+        "execution_rows": _safe_int(summary.get("execution_rows_count"), len(trades)),
+        "wins_total": _safe_int(perf.get("wins_total"), _safe_int(summary.get("wins_total"), _safe_int(state.get("wins_total"), 0))),
+        "losses_total": _safe_int(perf.get("losses_total"), _safe_int(summary.get("losses_total"), _safe_int(state.get("losses_total"), 0))),
+        "realized_total": _safe_float(perf.get("realized_pnl_total"), _safe_float(summary.get("realized_total"), _safe_float(realized.get("total"), _safe_float(state.get("realized_pnl_total"), 0.0)))),
+        "equity": _safe_float(state.get("equity"), 0.0),
+        "positions_count": len(state.get("positions")) if isinstance(state.get("positions"), dict) else 0,
+    }
+
+
+def _file_meta(path: str) -> Dict[str, Any]:
+    out = {"path": path, "exists": False, "size_bytes": 0, "mtime_ns": None, "sha256_prefix": None}
+    try:
+        stat = os.stat(path)
+        out.update({"exists": True, "size_bytes": int(stat.st_size), "mtime_ns": int(stat.st_mtime_ns)})
+        h = hashlib.sha256()
+        with open(path, "rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                h.update(chunk)
+        out["sha256_prefix"] = h.hexdigest()[:16]
+    except Exception as exc:
+        out["error"] = f"{type(exc).__name__}: {exc}"[:300]
+    return out
+
+
+def _read_sidecar(path: str) -> Dict[str, Any]:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            value = json.load(handle)
+        return value if isinstance(value, dict) else {}
+    except Exception:
+        return {}
+
+
+def _write_sidecar(path: str, payload: Dict[str, Any]) -> None:
+    try:
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        tmp = path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True, default=str)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        pass
+
+
+def _source_hint(core: Any, state_path: str) -> Dict[str, Any]:
+    hint = {"source": "core.load_state", "confidence": "medium"}
+    try:
+        import state_io_hardening as io
+        event = getattr(io, "_LAST_STATUS", {}) if isinstance(getattr(io, "_LAST_STATUS", {}), dict) else {}
+        if event.get("event") == "backup_read":
+            hint = {"source": "backup_fallback", "path": event.get("source"), "confidence": "high"}
+        elif os.path.exists(state_path):
+            hint = {"source": "primary_state_file", "path": state_path, "confidence": "medium"}
+        hint["state_io_last_event"] = event.get("event")
+    except Exception:
+        if os.path.exists(state_path):
+            hint = {"source": "primary_state_file", "path": state_path, "confidence": "low"}
+    return hint
+
+
+def observe(core: Any = None, state: Dict[str, Any] | None = None, trigger: str = "status") -> Dict[str, Any]:
+    global _LAST
+    core = core or _mod()
+    if core is None:
+        return {"status": "pending", "overall": "pending", "version": VERSION, "reason": "app_module_not_ready"}
+    if not isinstance(state, dict):
+        try:
+            loaded = core.load_state()
+            state = loaded if isinstance(loaded, dict) else {}
+        except Exception:
+            state = getattr(core, "portfolio", {}) if isinstance(getattr(core, "portfolio", {}), dict) else {}
+
+    state_path = _state_path(core)
+    sidecar_path = _sidecar_path(core)
+    current = _metrics(state)
+    prior_doc = _read_sidecar(sidecar_path)
+    high = prior_doc.get("high_water_marks") if isinstance(prior_doc.get("high_water_marks"), dict) else {}
+    previous = prior_doc.get("last_observation") if isinstance(prior_doc.get("last_observation"), dict) else {}
+
+    monotonic_fields = ("state_revision", "execution_rows", "wins_total", "losses_total", "realized_total")
+    regressions = []
+    next_high: Dict[str, Any] = dict(high)
+    for field in monotonic_fields:
+        value = current.get(field)
+        prior_high = high.get(field)
+        if prior_high is not None and value is not None and float(value) < float(prior_high):
+            regressions.append({"field": field, "current": value, "high_water": prior_high, "delta": round(float(value) - float(prior_high), 6)})
+        if value is not None and (prior_high is None or float(value) > float(prior_high)):
+            next_high[field] = value
+
+    file_meta = _file_meta(state_path)
+    source = _source_hint(core, state_path)
+    observation = {
+        "generated_local": _now(),
+        "trigger": trigger,
+        "metrics": current,
+        "state_file": file_meta,
+        "source_hint": source,
+        "state_updated_local": state.get("_state_updated_local"),
+        "state_update_source": state.get("_state_update_source"),
+        "persistence_mode": getattr(core, "STATE_PERSISTENCE_MODE", None),
+    }
+    payload = {
+        "status": "warn" if regressions else "ok",
+        "overall": "warn" if regressions else "pass",
+        "type": "state_provenance_status",
+        "version": VERSION,
+        "generated_local": observation["generated_local"],
+        "regression_detected": bool(regressions),
+        "regressions": regressions,
+        "current": observation,
+        "previous_observation": previous,
+        "high_water_marks": next_high,
+        "sidecar_file": sidecar_path,
+        "authority": {
+            "changes_trading_logic": False,
+            "changes_risk_or_sizing": False,
+            "changes_orders": False,
+            "changes_state_payload": False,
+            "changes_ml_authority": False,
+            "changes_live_authority": False,
+        },
+        "next_action": "Inspect state path/source and backup fallback if a regression is detected; do not overwrite trading state from this monitor.",
+    }
+    _write_sidecar(sidecar_path, {"version": VERSION, "high_water_marks": next_high, "last_observation": observation, "last_regressions": regressions})
+    with _LOCK:
+        _LAST = payload
+    return payload
+
+
+def install(core: Any = None) -> Dict[str, Any]:
+    core = core or _mod()
+    if core is None:
+        return {"status": "pending", "version": VERSION, "reason": "app_module_not_ready"}
+    current = getattr(core, "load_state", None)
+    if callable(current) and getattr(current, "_state_provenance_monitor_version", None) != VERSION:
+        original = current
+        def wrapped_load_state(*args, **kwargs):
+            state = original(*args, **kwargs)
+            try:
+                observe(core, state if isinstance(state, dict) else {}, trigger="load_state")
+            except Exception:
+                pass
+            return state
+        wrapped_load_state._state_provenance_monitor_version = VERSION  # type: ignore[attr-defined]
+        wrapped_load_state._state_provenance_monitor_original = original  # type: ignore[attr-defined]
+        core.load_state = wrapped_load_state
+    _PATCHED_MODULE_IDS.add(id(core))
+    return {"status": "ok", "overall": "pass", "version": VERSION, "installed": True, "state_file": _state_path(core), "sidecar_file": _sidecar_path(core)}
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    return observe(core or _mod(), trigger="status")
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    return install(core)
+
+
+def apply_runtime_overrides(core: Any = None) -> Dict[str, Any]:
+    return install(core)
+
+
+def register_routes(flask_app: Any, core: Any = None) -> None:
+    if flask_app is None or id(flask_app) in _REGISTERED_APP_IDS:
+        return
+    from flask import jsonify
+    try:
+        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+    except Exception:
+        existing = set()
+    if "/paper/state-provenance-status" not in existing:
+        flask_app.add_url_rule("/paper/state-provenance-status", "state_provenance_status", lambda: jsonify(status_payload(core or _mod())))
+    _REGISTERED_APP_IDS.add(id(flask_app))
+    install(core or _mod())
+
+
+try:
+    install(_mod())
+except Exception:
+    pass

--- a/usercustomize.py
+++ b/usercustomize.py
@@ -5,7 +5,7 @@ import threading
 import time
 from typing import Any
 
-VERSION = "usercustomize-entry-pipeline-composition-2026-07-23-v38-cycle-alignment"
+VERSION = "usercustomize-entry-pipeline-composition-2026-07-23-v39-state-provenance"
 _REGISTERED_APP_IDS: set[int] = set()
 
 
@@ -40,6 +40,7 @@ def _patch_self_check_endpoints() -> None:
             {"path": "/paper/shared-cycle-identity-status", "category": "governance", "required": False},
             {"path": "/paper/cycle-alignment-status", "category": "governance", "required": False},
             {"path": "/paper/provider-health-status", "category": "market_data", "required": False},
+            {"path": "/paper/state-provenance-status", "category": "state", "required": False},
             {"path": "/paper/regime-flip-entry-guard-status", "category": "governance", "required": False},
             {"path": "/paper/core-entry-pipeline-status", "category": "governance", "required": False},
             {"path": "/paper/extended-leader-starter-valve-status", "category": "governance", "required": False},
@@ -95,6 +96,7 @@ MODULES = (
     ("live_volatility", "app_and_module"),
     ("self_check", "app_and_module"),
     ("state_transaction_manager", "app_and_module"),
+    ("state_provenance_monitor", "app_and_module"),
     ("shared_cycle_identity", "app_and_module"),
     ("market_data_resilience", "app_and_module"),
     ("breakout_participation_layer", "app_only"),
@@ -157,7 +159,7 @@ def _watchdog() -> None:
             if flask_app is not None:
                 _register_auxiliary_routes(flask_app, core)
                 for name in (
-                    "state_transaction_manager", "shared_cycle_identity", "market_data_resilience", "symbol_hygiene_guard",
+                    "state_transaction_manager", "state_provenance_monitor", "shared_cycle_identity", "market_data_resilience", "symbol_hygiene_guard",
                     "scanner_v2_shadow_universe", "missed_opportunity_post_close_audit",
                     "scanner_v2_shadow_quality_trace", "scanner_v2_shadow_composite_score",
                     "scanner_v2_theme_confidence_overlay", "scanner_v2_candidate_lifecycle_trace",


### PR DESCRIPTION
## Summary
- add a diagnostic-only state provenance and monotonicity monitor
- track revision, file identity, state path, persistence mode, source hint, and cumulative account high-water marks
- persist diagnostics to a separate sidecar file without mutating trading state
- expose `/paper/state-provenance-status`
- register the route in the one-link diagnostics registry
- update `PROJECT_HANDOFF.md` with the July 23 afternoon regression evidence

## Evidence addressed
Between the morning and afternoon passing self-checks, cumulative metrics moved backward: execution rows 88→83, wins 36→34, losses 18→17, and realized total 970.14→854.03.

## Safety boundary
This monitor never restores, merges, or writes trading state. It does not change signals, positions, entries/exits, thresholds, risk, sizing, orders, executable universe, ML authority, or live authority.

## Validation after merge
1. `/paper/self-check`
2. `/paper/state-provenance-status`
3. `/paper/state-transaction-status`
4. capture at least two observations around a normal paper cycle and compare revision, state path, file hash, source hint, and high-water marks