### PR TITLE
Harden state provenance and blocker diagnostics

### DIFF
--- a/PROJECT_HANDOFF.md
+++ b/PROJECT_HANDOFF.md
@@ -1,4 +1,4 @@
-# Automated Trading Project Handoff — Updated July 23, 2026
+# Automated Trading Project Handoff — Updated July 24, 2026
 
 ## Standing Rule
 
@@ -19,42 +19,40 @@ Continue sequential diagnostic, observability, reliability, documentation, and a
 - ML live authority: none
 - Stronger-authority benchmark: 150 execution rows and 100 observed outcomes
 
-## July 23 Morning Baseline
+## July 23 Baselines
 
-The morning compact self-check passed with equity `10970.12`, realized total `970.14`, 88 execution rows, 36 wins, 18 losses, zero open positions, stable recursion-safe entry composition, no current pipeline error, and 54 matching decision/blocker signals. Cycle IDs were missing at that time.
+The July 23 morning compact self-check passed with equity `10970.12`, realized total `970.14`, 88 execution rows, 36 wins, 18 losses, zero open positions, stable recursion-safe entry composition, no current pipeline error, and 54 matching decision/blocker signals.
 
-## July 23 Afternoon Baseline
-
-The afternoon compact self-check generated at `2026-07-23 18:30:47` passed with:
-
-- equity: `11005.46`
-- cash: `9812.33`
-- open positions: `DELL`, `SNDK`
-- unrealized P&L: `151.44`
-- realized today: `-3.65`
-- realized total: `854.03`
-- execution rows: `83`
-- wins/losses: `34 / 17`
-- stable, recursion-safe entry pipeline
-- no required-path failures or warnings
-- ML advisory-only, no live authority
-
-Cycle alignment was successfully validated:
-
-- matching decision/blocker ID: `cycle-20260723T182756095055Z-1b50f934`
-- `same_cycle_comparison: true`
-- `snapshot_alignment: same_cycle`
-- `count_difference: 0`
-- `source_mismatch: false`
-
-However, cumulative account metrics moved backward from the morning snapshot:
+The afternoon compact self-check generated at `2026-07-23 18:30:47` also passed, with matching same-cycle decision and blocker counts, but cumulative append-only counters moved backward:
 
 - execution rows: `88 -> 83`
 - wins: `36 -> 34`
 - losses: `18 -> 17`
-- realized total: `970.14 -> 854.03`
 
-The execution-row and outcome-counter decreases remain state provenance/persistence consistency evidence. Net realized P&L is now treated as contextual rather than monotonic because legitimate losing exits can reduce it.
+Net realized P&L also changed, but it is contextual rather than monotonic because legitimate losing exits can reduce it.
+
+## July 24 Morning Validation
+
+The compact self-check generated at `2026-07-24 15:19:30` passed:
+
+- equity: `10954.26`
+- cash: `10954.26`
+- open positions: `0`
+- realized today: `100.25`
+- realized total: `954.28`
+- execution rows: `85`
+- wins/losses: `35 / 18`
+- entry pipeline stable and recursion-safe
+- no required-path failures or warnings
+- decision/blocker cycle ID: `cycle-20260724T151539135164Z-93656e7c`
+- same-cycle comparison: `true`
+- count difference: `0`
+- source mismatch: `false`
+- blocker reason coverage: `96.55%`
+- missing reason rows: `1`
+- ML remains advisory-only with no live authority
+
+The compact test passed, so `/paper/full-self-check` was not warranted.
 
 ## Runtime Reliability v3
 
@@ -70,7 +68,7 @@ Version: `cycle-alignment-overlay-2026-07-23-v1`
 
 Route: `/paper/cycle-alignment-status`
 
-The afternoon test confirms the cycle-alignment milestone is working. Decision and blocker producers now report the same cycle, and same-cycle count comparison is active.
+Decision and blocker producers report the same cycle, and same-cycle count comparison is active.
 
 ## State Provenance and Monotonicity Monitor v2
 
@@ -87,11 +85,27 @@ The v2 monitor:
 - reports state-file hash and path changes between observations;
 - serializes sidecar read/compute/write operations under a re-entrant lock;
 - uses process- and thread-specific temporary files for atomic sidecar replacement;
-- exposes sidecar persistence failures as warnings instead of silently reporting success;
+- exposes sidecar persistence failures as warnings;
 - maintains persistent high-water marks in a separate diagnostic sidecar;
 - never restores, overwrites, merges, or modifies trading state.
 
 The sidecar file remains `state_provenance_status.json` in the active state directory. It is diagnostic only and is not used as a trading-state source.
+
+## Missing Blocker-Reason Trace v1
+
+Version: `missing-reason-trace-2026-07-24-v1`
+
+Route: `/paper/missing-reason-trace-status`
+
+The trace overlay addresses the remaining single missing blocker-reason row without fabricating a reason. It:
+
+- reads the existing blocked-entry reason audit;
+- exposes a bounded sample containing symbol, source, source key, placeholder, and category;
+- adds `missing_reason_symbols`, `missing_reason_sample`, and `missing_reason_trace_version` to the compact scanner section;
+- identifies which producer contract omitted terminal reason detail;
+- does not alter scanner results, blocker decisions, thresholds, filters, risk, sizing, orders, executable universe, ML authority, or live authority.
+
+The next routine compact test should identify the exact source of the remaining placeholder. Repair the producer contract only after that evidence is visible; do not infer or synthesize a trading reason.
 
 ## Safety and Authority Boundary
 
@@ -105,39 +119,46 @@ Current work preserves:
 - no executable-universe mutation;
 - no scanner-result modification;
 - no automatic state restoration;
-- no mutation of account history or current positions.
+- no mutation of account history or current positions;
+- no fabricated blocker attribution.
 
 ## Files and Commits
 
-- `market_data_resilience.py`
-  - `b3f9d86bdceb23b43bcaf3817bc5634582abfb4b`
-- `cycle_alignment_overlay.py`
-  - `a95fab9d449723e13270ec3b4d53d2b164fb8360`
 - `state_provenance_monitor.py`
-  - v1: `966a10e42c283f63e99e28c0c538137aa13cdc57`
   - v2 branch commit: `9ce6ddc4e03c38a7c9c4f5e103c2fbbad7f0892b`
+- `missing_reason_trace_overlay.py`
+  - initial trace overlay: `f42f4c985a7f1a7695c6cafdc46584ab379a63d8`
 - `usercustomize.py`
-  - state provenance registration: `28a0d407638e9e7451d8c004036b8752820f4959`
+  - missing-reason trace registration: `e0cbdd54775e2e6f17ced686b4e31e3f619d159f`
 - `PROJECT_HANDOFF.md`
-  - updated in the same branch to document v2 semantics, validation, and safety impact.
+  - updated in the same branch with July 24 runtime evidence and the trace validation contract.
 
 ## Validation Status
 
 - Source branch: `agent/state-provenance-v2`
 - Base commit: `cd42d0d6637ccb79a2f795140eb5b805a5a7b38b`
-- Python syntax validation: passed for `state_provenance_monitor.py`
-- Deployment validation: not completed because the Railway hostname could not be resolved from the execution environment during this work session.
-- `/paper/full-self-check` was not used because no deployed compact self-check result was available to justify escalation.
+- Morning deployed `/paper/self-check`: passed
+- `/paper/full-self-check`: not used because the compact check passed without missing critical fields, required-path failures, runtime errors, or warnings
+- Source-level safety review: trace overlay is read-only and bounded
+- Deployment validation for the new branch changes remains pending merge and Railway redeploy
 
 ## Validation After Merge and Railway Redeploy
 
-Run:
+Run in this order:
 
 1. `https://trading-bot-clean.up.railway.app/paper/self-check`
 2. `https://trading-bot-clean.up.railway.app/paper/state-provenance-status`
-3. `https://trading-bot-clean.up.railway.app/paper/state-transaction-status`
-4. `https://trading-bot-clean.up.railway.app/paper/cycle-alignment-status`
-5. `https://trading-bot-clean.up.railway.app/paper/provider-health-status`
+3. `https://trading-bot-clean.up.railway.app/paper/missing-reason-trace-status`
+4. `https://trading-bot-clean.up.railway.app/paper/state-transaction-status`
+5. `https://trading-bot-clean.up.railway.app/paper/cycle-alignment-status`
+6. `https://trading-bot-clean.up.railway.app/paper/provider-health-status`
+
+Expected compact scanner fields:
+
+- `missing_reason_rows`
+- `missing_reason_symbols`
+- `missing_reason_sample`
+- `missing_reason_trace_version: missing-reason-trace-2026-07-24-v1`
 
 Expected provenance fields:
 
@@ -162,17 +183,15 @@ Expected provenance fields:
 - `regressions`
 - all authority fields false
 
-The first observation establishes a deployment-local high-water baseline. Subsequent observations should reveal whether append-only counters regress and whether file identity, revision, state path, source hint, or sidecar persistence changes at the same time.
-
 Use `/paper/full-self-check` only for a failed routine check, missing critical fields, a newly timestamped runtime error, or an unexpected warning.
 
 ## Next Steps
 
-1. Review and merge the v2 diagnostic branch.
+1. Review and merge draft PR #6.
 2. Validate `/paper/self-check` first after Railway redeploy.
-3. Validate the provenance route and capture at least two observations around a normal paper cycle.
-4. If an append-only counter regresses, compare revision, state path, file hash, source hint, transaction status, and backup event before considering restoration behavior.
-5. Do not automatically restore or merge state until the precise source of divergence is proven.
-6. Resume the remaining single missing blocker-reason attribution after state consistency is understood.
+3. Capture the new `missing_reason_sample` and repair only the identified diagnostic producer contract.
+4. Capture at least two state-provenance observations around a normal paper cycle.
+5. If an append-only counter regresses, compare revision, state path, file hash, source hint, transaction status, and backup event before considering restoration behavior.
+6. Do not automatically restore or merge state until the precise source of divergence is proven.
 
 No filter should be relaxed solely because a stock finished strongly.

--- a/PROJECT_HANDOFF.md
+++ b/PROJECT_HANDOFF.md
@@ -54,7 +54,7 @@ However, cumulative account metrics moved backward from the morning snapshot:
 - losses: `18 -> 17`
 - realized total: `970.14 -> 854.03`
 
-This is treated as a state provenance/persistence consistency defect, not a trading-strategy signal. Possible causes include an older state snapshot, a different state path, backup fallback, worker-local memory divergence, or recalculation from a different source contract.
+The execution-row and outcome-counter decreases remain state provenance/persistence consistency evidence. Net realized P&L is now treated as contextual rather than monotonic because legitimate losing exits can reduce it.
 
 ## Runtime Reliability v3
 
@@ -72,24 +72,26 @@ Route: `/paper/cycle-alignment-status`
 
 The afternoon test confirms the cycle-alignment milestone is working. Decision and blocker producers now report the same cycle, and same-cycle count comparison is active.
 
-## State Provenance and Monotonicity Monitor
+## State Provenance and Monotonicity Monitor v2
 
-Version: `state-provenance-monitor-2026-07-23-v1`
+Version: `state-provenance-monitor-2026-07-23-v2`
 
 Route: `/paper/state-provenance-status`
 
-The monitor:
+The v2 monitor:
 
 - wraps `load_state` passively and returns the original state unchanged;
-- records state revision, state update timestamp/source, persistence mode, file path, file size, modification time, and a short SHA-256 identity;
-- records execution rows, wins, losses, realized total, equity, and position count;
-- maintains persistent high-water marks in a separate sidecar file beside the state file;
-- flags backward movement in revision, execution rows, wins, losses, or realized total;
-- reports whether the latest read appears to come from the primary state file or a backup fallback based on state I/O telemetry;
-- never restores, overwrites, merges, or modifies trading state;
-- does not change positions, signals, risk, sizing, orders, ML authority, or live authority.
+- treats only state revision, execution rows, wins, and losses as monotonic counters;
+- records realized total, equity, and position count as context-only metrics;
+- reports deltas from the previous observation;
+- reports state-file hash and path changes between observations;
+- serializes sidecar read/compute/write operations under a re-entrant lock;
+- uses process- and thread-specific temporary files for atomic sidecar replacement;
+- exposes sidecar persistence failures as warnings instead of silently reporting success;
+- maintains persistent high-water marks in a separate diagnostic sidecar;
+- never restores, overwrites, merges, or modifies trading state.
 
-The sidecar file is `state_provenance_status.json` in the active state directory. It is diagnostic only and is not used as a trading-state source.
+The sidecar file remains `state_provenance_status.json` in the active state directory. It is diagnostic only and is not used as a trading-state source.
 
 ## Safety and Authority Boundary
 
@@ -112,11 +114,20 @@ Current work preserves:
 - `cycle_alignment_overlay.py`
   - `a95fab9d449723e13270ec3b4d53d2b164fb8360`
 - `state_provenance_monitor.py`
-  - `966a10e42c283f63e99e28c0c538137aa13cdc57`
+  - v1: `966a10e42c283f63e99e28c0c538137aa13cdc57`
+  - v2 branch commit: `9ce6ddc4e03c38a7c9c4f5e103c2fbbad7f0892b`
 - `usercustomize.py`
   - state provenance registration: `28a0d407638e9e7451d8c004036b8752820f4959`
 - `PROJECT_HANDOFF.md`
-  - this commit documents the afternoon regression evidence and validation contract.
+  - updated in the same branch to document v2 semantics, validation, and safety impact.
+
+## Validation Status
+
+- Source branch: `agent/state-provenance-v2`
+- Base commit: `cd42d0d6637ccb79a2f795140eb5b805a5a7b38b`
+- Python syntax validation: passed for `state_provenance_monitor.py`
+- Deployment validation: not completed because the Railway hostname could not be resolved from the execution environment during this work session.
+- `/paper/full-self-check` was not used because no deployed compact self-check result was available to justify escalation.
 
 ## Validation After Merge and Railway Redeploy
 
@@ -130,31 +141,37 @@ Run:
 
 Expected provenance fields:
 
-- `version: state-provenance-monitor-2026-07-23-v1`
+- `version: state-provenance-monitor-2026-07-23-v2`
 - `current.metrics.state_revision`
 - `current.metrics.execution_rows`
 - `current.metrics.wins_total`
 - `current.metrics.losses_total`
 - `current.metrics.realized_total`
+- `current.metric_deltas_from_previous`
 - `current.state_file.path`
 - `current.state_file.sha256_prefix`
+- `current.state_file_identity_changed`
+- `current.state_file_path_changed`
 - `current.source_hint.source`
 - `current.persistence_mode`
 - `high_water_marks`
+- `monotonic_fields`
+- `context_only_fields`
+- `sidecar_persistence.ok`
 - `regression_detected`
 - `regressions`
 - all authority fields false
 
-The first observation establishes a deployment-local high-water baseline. Subsequent observations should reveal whether cumulative metrics regress again and whether the file identity, revision, state path, or source hint changes at the same time.
+The first observation establishes a deployment-local high-water baseline. Subsequent observations should reveal whether append-only counters regress and whether file identity, revision, state path, source hint, or sidecar persistence changes at the same time.
 
 Use `/paper/full-self-check` only for a failed routine check, missing critical fields, a newly timestamped runtime error, or an unexpected warning.
 
 ## Next Steps
 
-1. Merge the state provenance branch after diff review.
-2. Validate the provenance and transaction routes after Railway redeploy.
-3. Capture at least two observations around a normal paper cycle.
-4. If a regression is detected, compare revision, state path, file hash, source hint, and backup event before considering any restoration behavior.
+1. Review and merge the v2 diagnostic branch.
+2. Validate `/paper/self-check` first after Railway redeploy.
+3. Validate the provenance route and capture at least two observations around a normal paper cycle.
+4. If an append-only counter regresses, compare revision, state path, file hash, source hint, transaction status, and backup event before considering restoration behavior.
 5. Do not automatically restore or merge state until the precise source of divergence is proven.
 6. Resume the remaining single missing blocker-reason attribution after state consistency is understood.
 

--- a/missing_reason_trace_overlay.py
+++ b/missing_reason_trace_overlay.py
@@ -1,0 +1,154 @@
+"""Advisory-only trace for blocker rows that lack terminal reason detail.
+
+The overlay augments the compact paper self-check with a bounded sample describing
+which diagnostic producer/source emitted a placeholder. It never synthesizes a
+trading reason and does not alter scanner results, entry decisions, thresholds,
+risk controls, sizing, orders, executable universe, ML authority, or live authority.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import sys
+from typing import Any, Dict, List
+
+VERSION = "missing-reason-trace-2026-07-24-v1"
+_PATCHED = False
+_REGISTERED_APP_IDS: set[int] = set()
+_LAST: Dict[str, Any] = {}
+
+
+def _mod() -> Any | None:
+    for name in ("app", "__main__"):
+        module = sys.modules.get(name)
+        if module is not None and hasattr(module, "load_state"):
+            return module
+    for module in list(sys.modules.values()):
+        if module is not None and getattr(module, "app", None) is not None and hasattr(module, "load_state"):
+            return module
+    return None
+
+
+def _now() -> str:
+    return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _audit_payload(core: Any = None) -> Dict[str, Any]:
+    try:
+        import blocked_entry_reason_audit as audit
+        value = audit.build_payload(core or _mod())
+        return value if isinstance(value, dict) else {}
+    except Exception as exc:
+        return {"trace_error": f"{type(exc).__name__}: {exc}"[:300]}
+
+
+def _bounded_sample(audit: Dict[str, Any], limit: int = 5) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    rows = audit.get("missing_reason_rows_sample")
+    if not isinstance(rows, list):
+        return out
+    for row in rows[:limit]:
+        if not isinstance(row, dict):
+            continue
+        out.append({
+            "symbol": row.get("symbol"),
+            "source": row.get("source"),
+            "source_key": row.get("source_key"),
+            "placeholder": row.get("reason"),
+            "category": row.get("category"),
+        })
+    return out
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    global _LAST
+    audit = _audit_payload(core)
+    sample = _bounded_sample(audit)
+    missing_count = audit.get("missing_reason_detail_count")
+    payload = {
+        "status": "warn" if missing_count else "ok",
+        "overall": "warn" if missing_count else "pass",
+        "type": "missing_reason_trace_status",
+        "version": VERSION,
+        "generated_local": _now(),
+        "missing_reason_rows": missing_count,
+        "missing_reason_symbols": audit.get("missing_reason_detail_symbols") or [],
+        "missing_reason_sample": sample,
+        "trace_error": audit.get("trace_error"),
+        "advisory_only": True,
+        "reason_synthesized": False,
+        "authority": {
+            "changes_scanner_results": False,
+            "changes_trading_logic": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "changes_orders": False,
+            "changes_executable_universe": False,
+            "changes_ml_authority": False,
+            "changes_live_authority": False,
+        },
+        "next_action": "Use symbol/source/source_key to repair the producer contract; do not infer or fabricate a blocker reason.",
+    }
+    _LAST = payload
+    return payload
+
+
+def install(core: Any = None) -> Dict[str, Any]:
+    global _PATCHED
+    try:
+        import daily_self_check_compactor as compact
+    except Exception as exc:
+        return {"status": "pending", "version": VERSION, "reason": f"compactor_import_failed: {exc}"[:300]}
+
+    current = getattr(compact, "compact_daily", None)
+    if callable(current) and getattr(current, "_missing_reason_trace_version", None) != VERSION:
+        original = current
+
+        def wrapped_compact_daily(payload: Dict[str, Any] | None = None) -> Dict[str, Any]:
+            result = original(payload)
+            if not isinstance(result, dict):
+                return result
+            trace = status_payload(core or _mod())
+            scanner = result.get("scanner")
+            if isinstance(scanner, dict):
+                scanner["missing_reason_symbols"] = trace.get("missing_reason_symbols")
+                scanner["missing_reason_sample"] = trace.get("missing_reason_sample")
+                scanner["missing_reason_trace_version"] = VERSION
+            return result
+
+        wrapped_compact_daily._missing_reason_trace_version = VERSION  # type: ignore[attr-defined]
+        wrapped_compact_daily._missing_reason_trace_original = original  # type: ignore[attr-defined]
+        compact.compact_daily = wrapped_compact_daily
+    _PATCHED = True
+    return {"status": "ok", "overall": "pass", "version": VERSION, "patched": True}
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    return install(core)
+
+
+def apply_runtime_overrides(core: Any = None) -> Dict[str, Any]:
+    return install(core)
+
+
+def register_routes(flask_app: Any, core: Any = None) -> None:
+    if flask_app is None or id(flask_app) in _REGISTERED_APP_IDS:
+        return
+    from flask import jsonify
+    try:
+        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+    except Exception:
+        existing = set()
+    if "/paper/missing-reason-trace-status" not in existing:
+        flask_app.add_url_rule(
+            "/paper/missing-reason-trace-status",
+            "missing_reason_trace_status",
+            lambda: jsonify(status_payload(core or _mod())),
+        )
+    _REGISTERED_APP_IDS.add(id(flask_app))
+    install(core or _mod())
+
+
+try:
+    install(_mod())
+except Exception:
+    pass

--- a/state_provenance_monitor.py
+++ b/state_provenance_monitor.py
@@ -1,6 +1,6 @@
 """Diagnostic-only state provenance and monotonicity monitor.
 
-Tracks state source metadata, revision, file identity, and cumulative metric high-water
+Tracks state source metadata, revision, file identity, and cumulative counter high-water
 marks in a sidecar file. It detects backward movement without mutating trading state,
 positions, signals, risk controls, sizing, orders, or authority.
 """
@@ -14,7 +14,7 @@ import sys
 import threading
 from typing import Any, Dict
 
-VERSION = "state-provenance-monitor-2026-07-23-v1"
+VERSION = "state-provenance-monitor-2026-07-23-v2"
 _REGISTERED_APP_IDS: set[int] = set()
 _PATCHED_MODULE_IDS: set[int] = set()
 _LOCK = threading.RLock()
@@ -101,17 +101,25 @@ def _read_sidecar(path: str) -> Dict[str, Any]:
         return {}
 
 
-def _write_sidecar(path: str, payload: Dict[str, Any]) -> None:
+def _write_sidecar(path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    result = {"ok": False, "path": path, "error": None}
+    tmp = f"{path}.{os.getpid()}.{threading.get_ident()}.tmp"
     try:
         os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-        tmp = path + ".tmp"
         with open(tmp, "w", encoding="utf-8") as handle:
             json.dump(payload, handle, indent=2, sort_keys=True, default=str)
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(tmp, path)
-    except Exception:
-        pass
+        result["ok"] = True
+    except Exception as exc:
+        result["error"] = f"{type(exc).__name__}: {exc}"[:300]
+        try:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+        except Exception:
+            pass
+    return result
 
 
 def _source_hint(core: Any, state_path: str) -> Dict[str, Any]:
@@ -130,6 +138,18 @@ def _source_hint(core: Any, state_path: str) -> Dict[str, Any]:
     return hint
 
 
+def _metric_deltas(current: Dict[str, Any], previous: Dict[str, Any]) -> Dict[str, Any]:
+    prior_metrics = previous.get("metrics") if isinstance(previous.get("metrics"), dict) else {}
+    deltas: Dict[str, Any] = {}
+    for field, value in current.items():
+        prior = prior_metrics.get(field)
+        if isinstance(value, (int, float)) and isinstance(prior, (int, float)):
+            deltas[field] = round(float(value) - float(prior), 6)
+        else:
+            deltas[field] = None
+    return deltas
+
+
 def observe(core: Any = None, state: Dict[str, Any] | None = None, trigger: str = "status") -> Dict[str, Any]:
     global _LAST
     core = core or _mod()
@@ -145,59 +165,87 @@ def observe(core: Any = None, state: Dict[str, Any] | None = None, trigger: str 
     state_path = _state_path(core)
     sidecar_path = _sidecar_path(core)
     current = _metrics(state)
-    prior_doc = _read_sidecar(sidecar_path)
-    high = prior_doc.get("high_water_marks") if isinstance(prior_doc.get("high_water_marks"), dict) else {}
-    previous = prior_doc.get("last_observation") if isinstance(prior_doc.get("last_observation"), dict) else {}
-
-    monotonic_fields = ("state_revision", "execution_rows", "wins_total", "losses_total", "realized_total")
-    regressions = []
-    next_high: Dict[str, Any] = dict(high)
-    for field in monotonic_fields:
-        value = current.get(field)
-        prior_high = high.get(field)
-        if prior_high is not None and value is not None and float(value) < float(prior_high):
-            regressions.append({"field": field, "current": value, "high_water": prior_high, "delta": round(float(value) - float(prior_high), 6)})
-        if value is not None and (prior_high is None or float(value) > float(prior_high)):
-            next_high[field] = value
-
     file_meta = _file_meta(state_path)
     source = _source_hint(core, state_path)
-    observation = {
-        "generated_local": _now(),
-        "trigger": trigger,
-        "metrics": current,
-        "state_file": file_meta,
-        "source_hint": source,
-        "state_updated_local": state.get("_state_updated_local"),
-        "state_update_source": state.get("_state_update_source"),
-        "persistence_mode": getattr(core, "STATE_PERSISTENCE_MODE", None),
-    }
-    payload = {
-        "status": "warn" if regressions else "ok",
-        "overall": "warn" if regressions else "pass",
-        "type": "state_provenance_status",
-        "version": VERSION,
-        "generated_local": observation["generated_local"],
-        "regression_detected": bool(regressions),
-        "regressions": regressions,
-        "current": observation,
-        "previous_observation": previous,
-        "high_water_marks": next_high,
-        "sidecar_file": sidecar_path,
-        "authority": {
-            "changes_trading_logic": False,
-            "changes_risk_or_sizing": False,
-            "changes_orders": False,
-            "changes_state_payload": False,
-            "changes_ml_authority": False,
-            "changes_live_authority": False,
-        },
-        "next_action": "Inspect state path/source and backup fallback if a regression is detected; do not overwrite trading state from this monitor.",
-    }
-    _write_sidecar(sidecar_path, {"version": VERSION, "high_water_marks": next_high, "last_observation": observation, "last_regressions": regressions})
+
     with _LOCK:
+        prior_doc = _read_sidecar(sidecar_path)
+        high = prior_doc.get("high_water_marks") if isinstance(prior_doc.get("high_water_marks"), dict) else {}
+        previous = prior_doc.get("last_observation") if isinstance(prior_doc.get("last_observation"), dict) else {}
+
+        # These are append-only/state-generation counters. Net realized P&L is intentionally
+        # excluded because legitimate losing exits can reduce it.
+        monotonic_fields = ("state_revision", "execution_rows", "wins_total", "losses_total")
+        regressions = []
+        next_high: Dict[str, Any] = dict(high)
+        for field in monotonic_fields:
+            value = current.get(field)
+            prior_high = high.get(field)
+            if prior_high is not None and value is not None and float(value) < float(prior_high):
+                regressions.append({"field": field, "current": value, "high_water": prior_high, "delta": round(float(value) - float(prior_high), 6)})
+            if value is not None and (prior_high is None or float(value) > float(prior_high)):
+                next_high[field] = value
+
+        previous_file = previous.get("state_file") if isinstance(previous.get("state_file"), dict) else {}
+        identity_changed = bool(
+            previous_file.get("sha256_prefix")
+            and file_meta.get("sha256_prefix")
+            and previous_file.get("sha256_prefix") != file_meta.get("sha256_prefix")
+        )
+        path_changed = bool(previous_file.get("path") and previous_file.get("path") != file_meta.get("path"))
+        observation = {
+            "generated_local": _now(),
+            "trigger": trigger,
+            "metrics": current,
+            "metric_deltas_from_previous": _metric_deltas(current, previous),
+            "state_file": file_meta,
+            "state_file_identity_changed": identity_changed,
+            "state_file_path_changed": path_changed,
+            "source_hint": source,
+            "state_updated_local": state.get("_state_updated_local"),
+            "state_update_source": state.get("_state_update_source"),
+            "persistence_mode": getattr(core, "STATE_PERSISTENCE_MODE", None),
+        }
+        sidecar_doc = {
+            "version": VERSION,
+            "high_water_marks": next_high,
+            "last_observation": observation,
+            "last_regressions": regressions,
+        }
+        persistence = _write_sidecar(sidecar_path, sidecar_doc)
+        warnings = []
+        if not persistence.get("ok"):
+            warnings.append({"type": "sidecar_persistence_failed", "error": persistence.get("error")})
+        status = "warn" if regressions or warnings else "ok"
+        overall = "warn" if regressions or warnings else "pass"
+        payload = {
+            "status": status,
+            "overall": overall,
+            "type": "state_provenance_status",
+            "version": VERSION,
+            "generated_local": observation["generated_local"],
+            "regression_detected": bool(regressions),
+            "regressions": regressions,
+            "warnings": warnings,
+            "current": observation,
+            "previous_observation": previous,
+            "high_water_marks": next_high,
+            "monotonic_fields": list(monotonic_fields),
+            "context_only_fields": ["realized_total", "equity", "positions_count"],
+            "sidecar_file": sidecar_path,
+            "sidecar_persistence": persistence,
+            "authority": {
+                "changes_trading_logic": False,
+                "changes_risk_or_sizing": False,
+                "changes_orders": False,
+                "changes_state_payload": False,
+                "changes_ml_authority": False,
+                "changes_live_authority": False,
+            },
+            "next_action": "Inspect state path/source, file identity, and backup fallback if an append-only counter regresses; do not overwrite trading state from this monitor.",
+        }
         _LAST = payload
-    return payload
+        return payload
 
 
 def install(core: Any = None) -> Dict[str, Any]:

--- a/usercustomize.py
+++ b/usercustomize.py
@@ -5,7 +5,7 @@ import threading
 import time
 from typing import Any
 
-VERSION = "usercustomize-entry-pipeline-composition-2026-07-23-v39-state-provenance"
+VERSION = "usercustomize-entry-pipeline-composition-2026-07-24-v40-missing-reason-trace"
 _REGISTERED_APP_IDS: set[int] = set()
 
 
@@ -30,6 +30,7 @@ def _patch_self_check_endpoints() -> None:
             {"path": "/paper/symbol-hygiene-guard-status", "category": "governance", "required": False},
             {"path": "/paper/blocked-entry-reason-audit-status", "category": "governance", "required": False},
             {"path": "/paper/blocked-entry-reason-selfcheck-overlay-status", "category": "governance", "required": False},
+            {"path": "/paper/missing-reason-trace-status", "category": "governance", "required": False},
             {"path": "/paper/dynamic-universe-builder-status", "category": "governance", "required": False},
             {"path": "/paper/scanner-v2-shadow-universe-status", "category": "governance", "required": False},
             {"path": "/paper/missed-opportunity-post-close-audit-status", "category": "governance", "required": False},
@@ -128,6 +129,7 @@ MODULES = (
     ("ml_phase3a_early_paper_gate", "app_and_module"),
     ("ml_vs_rules_shadow_log", "app_and_module"),
     ("daily_self_check_compactor", "app_and_module"),
+    ("missing_reason_trace_overlay", "app_and_module"),
     ("runtime_reliability_overlay", "app_and_module"),
     ("cycle_alignment_overlay", "app_and_module"),
 )
@@ -170,7 +172,7 @@ def _watchdog() -> None:
                     "controlled_redeployment_starter_sleeve", "quality_blocker_diagnostics",
                     "ml_pre3a_shadow_validation", "ml_phase3a_early_paper_gate",
                     "ml_vs_rules_shadow_log", "entry_pipeline_ownership_guard",
-                    "daily_self_check_compactor", "runtime_reliability_overlay", "cycle_alignment_overlay",
+                    "daily_self_check_compactor", "missing_reason_trace_overlay", "runtime_reliability_overlay", "cycle_alignment_overlay",
                 ):
                     _register_module(flask_app, core, name, route_args="app_and_module")
         except Exception:


### PR DESCRIPTION
## What changed
- Corrected the provenance monitor so only append-only counters (`state_revision`, execution rows, wins, losses) are evaluated for backward movement.
- Kept net realized P&L, equity, and position count as contextual metrics because legitimate trading outcomes can move them down.
- Added previous-observation deltas, state-file identity/path change indicators, serialized sidecar updates, unique atomic temp files, and explicit sidecar persistence warnings.
- Added an advisory-only missing-reason trace overlay that exposes the symbol, source, source key, and placeholder for blocker rows lacking terminal reason detail.
- Augmented the compact scanner response with `missing_reason_symbols`, `missing_reason_sample`, and `missing_reason_trace_version`.
- Updated `PROJECT_HANDOFF.md` with the July 24 compact validation, versions, commits, safety impact, validation sequence, and next actions.

## Runtime evidence
The July 24 morning `/paper/self-check` passed with no required-path failures or warnings, stable recursion-safe entry composition, matching same-cycle decision/blocker counts, and ML remaining advisory-only. It reported one missing blocker-reason row with 96.55% reason coverage. Because the compact check passed, `/paper/full-self-check` was not warranted.

## Why
The provenance v1 monitor could flag a normal reduction in cumulative net realized P&L as a state regression. Separately, the compact route exposed only the number of missing blocker reasons, not the source row needed to repair the producer contract. The new trace records that evidence without inventing a reason or altering scanner behavior.

## Safety boundary
No trading logic, signal thresholds, filters, risk controls, sizing, orders, executable universe, scanner results, ML authority, live authority, or trading-state payload behavior changed.

## Validation
- Branch is five commits ahead of `cd42d0d6637ccb79a2f795140eb5b805a5a7b38b` and touches only `state_provenance_monitor.py`, `missing_reason_trace_overlay.py`, `usercustomize.py`, and `PROJECT_HANDOFF.md`.
- Source-level review confirms the new overlay is bounded and read-only.
- Railway validation of branch changes remains pending merge/redeploy.
- After redeploy, run `/paper/self-check` first. Use `/paper/full-self-check` only if the compact check fails, reports missing critical fields, a newly timestamped error, or an unexpected warning.