### PR TITLE
Repair morning audit telemetry and enforce broad scanner integrity

### DIFF
--- a/broad_momentum_discovery.py
+++ b/broad_momentum_discovery.py
@@ -1,18 +1,9 @@
-"""Paper-only broad market momentum discovery for the trading bot.
+"""Paper-only broad-market momentum discovery with bounded scanner ownership.
 
-The scanner previously depended heavily on a hand-maintained ticker universe and
-closed theme baskets.  This module adds a bounded two-stage discovery path:
-
-1. Yahoo/yfinance performs a broad US-market screen for liquid momentum and
-   most-active stocks.
-2. Only the best bounded candidate set is installed into ``core.UNIVERSE``.
-3. The existing scanner, strategy score, entry rules, sizing and hard-risk
-   controls perform the expensive intraday evaluation and decide what may trade.
-
-Current positions and SPY/QQQ/IWM/DIA are always preserved. Existing theme
-baskets remain fallback candidates and classification/risk labels; they are no
-longer the primary discovery boundary. The module does not place orders, lower
-entry thresholds, grant ML authority, or grant live authority.
+This module discovers liquid U.S. momentum leaders from market-wide Yahoo/yfinance
+screens, installs a bounded working universe, and leaves all trade decisions to
+the existing rules engine. Version 2 adds scanner-boundary enforcement, source
+attribution integrity, non-blocking sector enrichment, and ownership telemetry.
 """
 from __future__ import annotations
 
@@ -25,7 +16,7 @@ import threading
 import time
 from typing import Any, Dict, Iterable, List, Sequence, Tuple
 
-VERSION = "broad-momentum-discovery-2026-08-04-v1"
+VERSION = "broad-momentum-discovery-2026-08-05-v2-integrity"
 ENABLED = os.environ.get("BROAD_MOMENTUM_DISCOVERY_ENABLED", "true").lower() not in {
     "0", "false", "no", "off"
 }
@@ -45,16 +36,25 @@ MIN_MARKET_CAP = float(os.environ.get("BROAD_MOMENTUM_MIN_MARKET_CAP", "10000000
 CUSTOM_SCREEN_SIZE = int(os.environ.get("BROAD_MOMENTUM_CUSTOM_SCREEN_SIZE", "250"))
 PREDEFINED_SCREEN_COUNT = int(os.environ.get("BROAD_MOMENTUM_PREDEFINED_COUNT", "100"))
 WATCHDOG_SECONDS = int(os.environ.get("BROAD_MOMENTUM_WATCHDOG_SECONDS", "10"))
+SECTOR_ENRICH_PER_REFRESH = int(os.environ.get("BROAD_MOMENTUM_SECTOR_ENRICH_PER_REFRESH", "12"))
+SECTOR_CACHE_TTL_SECONDS = int(
+    os.environ.get("BROAD_MOMENTUM_SECTOR_CACHE_TTL_SECONDS", str(7 * 24 * 3600))
+)
 
 BENCHMARK_SYMBOLS = ("SPY", "QQQ", "IWM", "DIA")
 SECTOR_ETF = {
     "basic materials": "XLB",
+    "materials": "XLB",
     "communication services": "XLC",
     "consumer cyclical": "XLY",
+    "consumer discretionary": "XLY",
     "consumer defensive": "XLP",
+    "consumer staples": "XLP",
     "energy": "XLE",
     "financial services": "XLF",
+    "financial": "XLF",
     "healthcare": "XLV",
+    "health care": "XLV",
     "industrials": "XLI",
     "real estate": "XLRE",
     "technology": "XLK",
@@ -66,11 +66,32 @@ DYNAMIC_BUCKET_CONFIG = {"alloc_factor": 0.40, "max_exposure_pct": 0.20, "max_po
 _LOCK = threading.RLock()
 _REFRESH_EVENT = threading.Event()
 _REFRESH_THREAD: threading.Thread | None = None
+_SECTOR_THREAD: threading.Thread | None = None
 _CACHE: Dict[str, Any] = {"ts": 0.0, "payload": None}
+_SECTOR_CACHE: Dict[str, Dict[str, Any]] = {}
 _LAST: Dict[str, Any] = {}
 _BASE_UNIVERSE: Dict[int, List[str]] = {}
 _REGISTERED_APP_IDS: set[int] = set()
 _WATCHDOG_CORE_IDS: set[int] = set()
+
+_OWNER_MODULE_HINTS = (
+    "neutral_momentum_starter_extension",
+    "opening_surge_participation",
+    "dynamic_universe_builder",
+    "scanner_v2_shadow_universe",
+    "space_stock_basket",
+    "spacex_direct_overlay",
+    "breakout_participation_layer",
+)
+_OWNER_ATTR_HINTS = (
+    "_EXTRA_SYMBOLS",
+    "EXTRA",
+    "EXTRA_SYMBOLS",
+    "PREFERRED_SYMBOLS",
+    "UNIVERSE",
+    "THEME_SYMBOLS",
+    "SYMBOLS",
+)
 
 
 def _f(value: Any, default: float = 0.0) -> float:
@@ -99,6 +120,17 @@ def _unique(values: Iterable[Any]) -> List[str]:
         if symbol and symbol not in seen:
             seen.add(symbol)
             output.append(symbol)
+    return output
+
+
+def _unique_labels(values: Iterable[Any]) -> List[str]:
+    output: List[str] = []
+    seen: set[str] = set()
+    for value in values or []:
+        label = str(value or "").strip()
+        if label and label not in seen:
+            seen.add(label)
+            output.append(label)
     return output
 
 
@@ -133,6 +165,14 @@ def _quote_value(quote: Dict[str, Any], *keys: str) -> Any:
     return None
 
 
+def _normalize_sector(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _sector_proxy(value: Any) -> str | None:
+    return SECTOR_ETF.get(_normalize_sector(value).lower())
+
+
 def _normalize_quote(quote: Dict[str, Any], source: str) -> Dict[str, Any] | None:
     if not isinstance(quote, dict):
         return None
@@ -146,10 +186,12 @@ def _normalize_quote(quote: Dict[str, Any], source: str) -> Dict[str, Any] | Non
     market_cap = _f(_quote_value(quote, "marketCap", "intradaymarketcap"))
     dollar_volume = max(0.0, price * volume)
     relative_volume = volume / avg_volume if avg_volume > 0 else 0.0
-    sector = str(_quote_value(quote, "sector", "sectorName") or "").strip()
+    sector = _normalize_sector(_quote_value(quote, "sector", "sectorName", "sectorDisp"))
+    industry = str(_quote_value(quote, "industry", "industryName", "industryDisp") or "").strip()
     return {
         "symbol": symbol,
         "source": source,
+        "sources": [source],
         "price": round(price, 4),
         "percent_change": round(pct, 4),
         "day_volume": int(volume) if volume > 0 else 0,
@@ -158,7 +200,9 @@ def _normalize_quote(quote: Dict[str, Any], source: str) -> Dict[str, Any] | Non
         "dollar_volume": round(dollar_volume, 2),
         "market_cap": round(market_cap, 2),
         "sector_name": sector,
-        "sector_proxy": SECTOR_ETF.get(sector.lower()),
+        "industry_name": industry,
+        "sector_proxy": _sector_proxy(sector),
+        "classification_source": "screen_payload" if sector else None,
     }
 
 
@@ -220,7 +264,6 @@ def _screen_calls() -> List[Tuple[str, Any]]:
             calls.append((name, _predefined_screen(yf, name)))
         except Exception as exc:
             calls.append((name, {"_error": f"{type(exc).__name__}: {exc}"}))
-
     try:
         EquityQuery = getattr(yf, "EquityQuery")
         query = EquityQuery(
@@ -237,17 +280,46 @@ def _screen_calls() -> List[Tuple[str, Any]]:
         calls.append(
             (
                 "market_wide_momentum",
-                yf.screen(
-                    query,
-                    size=CUSTOM_SCREEN_SIZE,
-                    sortField="percentchange",
-                    sortAsc=False,
-                ),
+                yf.screen(query, size=CUSTOM_SCREEN_SIZE, sortField="percentchange", sortAsc=False),
             )
         )
     except Exception as exc:
         calls.append(("market_wide_momentum", {"_error": f"{type(exc).__name__}: {exc}"}))
     return calls
+
+
+def _cached_classification(symbol: str) -> Dict[str, Any]:
+    with _LOCK:
+        row = dict(_SECTOR_CACHE.get(symbol) or {})
+    age = time.time() - _f(row.get("ts")) if row else float("inf")
+    return row if row and age <= SECTOR_CACHE_TTL_SECONDS else {}
+
+
+def _merge_classification(row: Dict[str, Any], core: Any = None) -> Dict[str, Any]:
+    symbol = _symbol(row.get("symbol"))
+    if row.get("sector_proxy"):
+        return row
+    cached = _cached_classification(symbol)
+    if cached:
+        row["sector_name"] = cached.get("sector_name") or row.get("sector_name") or ""
+        row["industry_name"] = cached.get("industry_name") or row.get("industry_name") or ""
+        row["sector_proxy"] = cached.get("sector_proxy") or _sector_proxy(row.get("sector_name"))
+        row["classification_source"] = cached.get("classification_source") or "yfinance_profile_cache"
+        return row
+    try:
+        existing = (getattr(core, "SYMBOL_SECTOR", {}) or {}).get(symbol)
+    except Exception:
+        existing = None
+    if existing:
+        value = str(existing)
+        if value.upper().startswith("XL"):
+            row["sector_proxy"] = value.upper()
+            row["classification_source"] = "existing_runtime_sector_map"
+        else:
+            row["sector_name"] = value
+            row["sector_proxy"] = _sector_proxy(value)
+            row["classification_source"] = "existing_runtime_sector_map"
+    return row
 
 
 def _build_payload(core: Any = None) -> Dict[str, Any]:
@@ -279,20 +351,24 @@ def _build_payload(core: Any = None) -> Dict[str, Any]:
             symbol = str(row["symbol"])
             existing = rows_by_symbol.get(symbol)
             if existing is None:
-                row["sources"] = [source]
                 rows_by_symbol[symbol] = row
-            else:
-                sources = _unique(list(existing.get("sources") or []) + [source])
-                if _f(row.get("day_volume")) >= _f(existing.get("day_volume")):
-                    row["sources"] = sources
-                    rows_by_symbol[symbol] = row
-                else:
-                    existing["sources"] = sources
+                continue
+            sources = _unique_labels(list(existing.get("sources") or []) + list(row.get("sources") or []) + [source])
+            keep_new = _f(row.get("day_volume")) >= _f(existing.get("day_volume"))
+            winner = row if keep_new else existing
+            loser = existing if keep_new else row
+            winner["sources"] = sources
+            winner["source"] = str(winner.get("source") or source)
+            for key in ("sector_name", "industry_name", "sector_proxy", "classification_source"):
+                if not winner.get(key) and loser.get(key):
+                    winner[key] = loser.get(key)
+            rows_by_symbol[symbol] = winner
 
-    rows = list(rows_by_symbol.values())
+    rows = [_merge_classification(dict(row), core) for row in rows_by_symbol.values()]
     for row in rows:
-        score = _discovery_score(row) + min(0.06, 0.02 * max(0, len(row.get("sources") or []) - 1))
-        row["discovery_score"] = round(float(score), 6)
+        source_confirmation = min(0.06, 0.02 * max(0, len(row.get("sources") or []) - 1))
+        row["source_confirmation_bonus"] = round(source_confirmation, 6)
+        row["discovery_score"] = round(_discovery_score(row) + source_confirmation, 6)
     rows.sort(
         key=lambda row: (
             _f(row.get("discovery_score")),
@@ -303,6 +379,7 @@ def _build_payload(core: Any = None) -> Dict[str, Any]:
         reverse=True,
     )
     selected = rows[:MAX_DISCOVERY_SYMBOLS]
+    classified = sum(1 for row in selected if row.get("sector_proxy"))
     return {
         "status": "ok" if selected else "warn",
         "overall": "pass" if selected else "warn",
@@ -318,6 +395,12 @@ def _build_payload(core: Any = None) -> Dict[str, Any]:
         "selected_symbols": [row["symbol"] for row in selected],
         "candidates": selected,
         "top_candidates": selected[:50],
+        "classification": {
+            "classified_count": classified,
+            "unclassified_count": max(0, len(selected) - classified),
+            "coverage_pct": round(100.0 * classified / len(selected), 2) if selected else 0.0,
+            "enrichment_non_blocking": True,
+        },
         "policy": {
             "cache_ttl_seconds": CACHE_TTL_SECONDS,
             "max_discovery_symbols": MAX_DISCOVERY_SYMBOLS,
@@ -330,17 +413,22 @@ def _build_payload(core: Any = None) -> Dict[str, Any]:
             "min_market_cap": MIN_MARKET_CAP,
             "benchmark_symbols": list(BENCHMARK_SYMBOLS),
             "theme_baskets_are_fallback_and_classification": True,
+            "scanner_boundary_enforced": True,
         },
-        "authority": {
-            "places_orders": False,
-            "changes_entry_rules": False,
-            "changes_hard_risk": False,
-            "changes_sizing": False,
-            "changes_ml_authority": False,
-            "changes_live_authority": False,
-            "execution_authority": "existing_rules_only",
-            "ml_authority": "shadow_recommendation_only",
-        },
+        "authority": _authority(),
+    }
+
+
+def _authority() -> Dict[str, Any]:
+    return {
+        "places_orders": False,
+        "changes_entry_rules": False,
+        "changes_hard_risk": False,
+        "changes_sizing": False,
+        "changes_ml_authority": False,
+        "changes_live_authority": False,
+        "execution_authority": "existing_rules_only",
+        "ml_authority": "shadow_recommendation_only",
     }
 
 
@@ -359,6 +447,7 @@ def _refresh_worker(core: Any = None) -> None:
             "selected_symbols": [],
             "candidates": [],
             "top_candidates": [],
+            "authority": _authority(),
         }
     with _LOCK:
         _CACHE.update({"ts": time.time(), "payload": payload})
@@ -409,11 +498,7 @@ def discover(core: Any = None, force: bool = False, wait: bool = True) -> Dict[s
         "selected_symbols": [],
         "candidates": [],
         "top_candidates": [],
-        "authority": {
-            "places_orders": False,
-            "execution_authority": "existing_rules_only",
-            "ml_authority": "shadow_recommendation_only",
-        },
+        "authority": _authority(),
     }
 
 
@@ -447,12 +532,35 @@ def _compose_universe(
     return _unique(protected + broad_slots + base_slots)[:cap]
 
 
+def _infer_append_owner(symbol: str, base: set[str], broad: set[str], protected: set[str]) -> str:
+    if symbol in protected:
+        return "protected_position_or_benchmark"
+    if symbol in broad:
+        return "broad_momentum_discovery"
+    if symbol in base:
+        return "base_or_legacy_overlay"
+    for module_name in _OWNER_MODULE_HINTS:
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        for attr in _OWNER_ATTR_HINTS:
+            try:
+                values = getattr(module, attr, None)
+                if isinstance(values, dict):
+                    values = values.keys()
+                if symbol in set(_unique(values or [])):
+                    return module_name
+            except Exception:
+                continue
+    return "unknown_runtime_overlay"
+
+
 def _apply_classification(core: Any, candidates: Sequence[Dict[str, Any]], final_universe: Sequence[str]) -> None:
     sector_map = getattr(core, "SYMBOL_SECTOR", None)
     bucket_map = getattr(core, "SYMBOL_BUCKET", None)
     bucket_cfg = getattr(core, "BUCKET_CONFIG", None)
     by_symbol = {
-        _symbol(row.get("symbol")): row
+        _symbol(row.get("symbol")): _merge_classification(dict(row), core)
         for row in candidates or []
         if isinstance(row, dict) and _symbol(row.get("symbol"))
     }
@@ -463,73 +571,223 @@ def _apply_classification(core: Any, candidates: Sequence[Dict[str, Any]], final
         if isinstance(bucket_map, dict):
             bucket_map.setdefault(symbol, DYNAMIC_BUCKET)
         if isinstance(sector_map, dict):
-            sector_map.setdefault(symbol, str(row.get("sector_proxy") or "UNKNOWN"))
+            sector_map[symbol] = str(row.get("sector_proxy") or sector_map.get(symbol) or "UNKNOWN")
 
 
-def apply_universe(core: Any, payload: Dict[str, Any]) -> Dict[str, Any]:
-    base = _base_universe(core)
-    broad = list(payload.get("selected_symbols") or [])
-    final_universe = _compose_universe(_positions(core), base, broad)
-    if not broad:
-        final_universe = _unique(list(BENCHMARK_SYMBOLS) + _positions(core) + base)[:MAX_FINAL_UNIVERSE]
-    _apply_classification(core, list(payload.get("candidates") or []), final_universe)
-    core.UNIVERSE = final_universe
+def _sector_enrichment_worker(core: Any, candidates: Sequence[Dict[str, Any]]) -> None:
+    try:
+        import yfinance as yf  # type: ignore
+    except Exception:
+        return
+    processed = 0
+    for row in candidates:
+        if processed >= max(0, SECTOR_ENRICH_PER_REFRESH):
+            break
+        symbol = _symbol(row.get("symbol")) if isinstance(row, dict) else ""
+        if not symbol or row.get("sector_proxy") or _cached_classification(symbol):
+            continue
+        processed += 1
+        try:
+            info = yf.Ticker(symbol).get_info()
+            if not isinstance(info, dict):
+                continue
+            sector = _normalize_sector(info.get("sector") or info.get("sectorDisp"))
+            industry = str(info.get("industry") or info.get("industryDisp") or "").strip()
+            proxy = _sector_proxy(sector)
+            with _LOCK:
+                _SECTOR_CACHE[symbol] = {
+                    "ts": time.time(),
+                    "sector_name": sector,
+                    "industry_name": industry,
+                    "sector_proxy": proxy,
+                    "classification_source": "yfinance_profile_cache",
+                }
+            if proxy:
+                try:
+                    getattr(core, "SYMBOL_SECTOR", {})[symbol] = proxy
+                except Exception:
+                    pass
+        except Exception:
+            continue
+
+
+def _schedule_sector_enrichment(core: Any, candidates: Sequence[Dict[str, Any]]) -> None:
+    global _SECTOR_THREAD
+    with _LOCK:
+        if _SECTOR_THREAD is not None and _SECTOR_THREAD.is_alive():
+            return
+        missing = [
+            dict(row)
+            for row in candidates
+            if isinstance(row, dict)
+            and _symbol(row.get("symbol"))
+            and not row.get("sector_proxy")
+            and not _cached_classification(_symbol(row.get("symbol")))
+        ]
+        if not missing:
+            return
+        _SECTOR_THREAD = threading.Thread(
+            target=_sector_enrichment_worker,
+            args=(core, missing),
+            name="broad-momentum-sector-enrichment",
+            daemon=True,
+        )
+        _SECTOR_THREAD.start()
+
+
+def _record_boundary(
+    core: Any,
+    payload: Dict[str, Any],
+    *,
+    phase: str,
+    pre_universe: Sequence[str],
+    final_universe: Sequence[str],
+) -> Dict[str, Any]:
+    base = set(_base_universe(core))
+    broad = set(_unique(payload.get("selected_symbols") or []))
+    protected = set(_unique(list(BENCHMARK_SYMBOLS) + _positions(core)))
+    intended = set(final_universe)
+    extras = [symbol for symbol in _unique(pre_universe) if symbol not in intended]
+    appended = [
+        {"symbol": symbol, "owner_hint": _infer_append_owner(symbol, base, broad, protected)}
+        for symbol in extras[:100]
+    ]
     record = {
         "version": VERSION,
         "generated_local": _now(core),
-        "status": payload.get("status"),
-        "source_counts": payload.get("source_counts"),
-        "source_errors": payload.get("source_errors"),
-        "eligible_unique_count": payload.get("eligible_unique_count"),
-        "discovery_selected_count": len(broad),
-        "final_universe_count": len(final_universe),
-        "protected_symbols": _unique(list(BENCHMARK_SYMBOLS) + _positions(core)),
-        "broad_symbols_used": [s for s in broad if s in final_universe],
-        "base_fallback_symbols": [s for s in final_universe if s in set(base) and s not in set(broad)],
-        "final_universe": final_universe,
-        "theme_baskets_are_fallback_and_classification": True,
+        "phase": phase,
+        "discovery_pool_count": len(_unique(payload.get("selected_symbols") or [])),
+        "intended_working_universe_count": len(final_universe),
+        "scanner_input_universe_count": len(final_universe) if phase == "pre_scan" else None,
+        "pre_boundary_universe_count": len(_unique(pre_universe)),
+        "post_boundary_universe_count": len(final_universe),
+        "max_final_universe": MAX_FINAL_UNIVERSE,
+        "within_policy_cap": len(final_universe) <= MAX_FINAL_UNIVERSE,
+        "appended_after_discovery_count": len(extras),
+        "appended_after_discovery": appended,
+        "final_universe": list(final_universe),
         "execution_authority": "existing_rules_only",
         "ml_authority": "shadow_recommendation_only",
-        "changes_entry_rules": False,
-        "changes_hard_risk": False,
-        "changes_sizing": False,
     }
     try:
         portfolio = getattr(core, "portfolio", {})
         if isinstance(portfolio, dict):
-            portfolio["broad_momentum_discovery"] = record
+            state = portfolio.setdefault("broad_momentum_discovery", {})
+            if isinstance(state, dict):
+                state.update(record)
+                history = state.setdefault("boundary_history", [])
+                if isinstance(history, list):
+                    history.append(dict(record))
+                    del history[:-20]
     except Exception:
         pass
     return record
 
 
-def _chain_has_marker(fn: Any, limit: int = 40) -> bool:
+def apply_universe(core: Any, payload: Dict[str, Any], phase: str = "discovery") -> Dict[str, Any]:
+    base = _base_universe(core)
+    broad = list(payload.get("selected_symbols") or [])
+    pre_universe = _unique(getattr(core, "UNIVERSE", []) or [])
+    final_universe = _compose_universe(_positions(core), base, broad)
+    if not broad:
+        final_universe = _unique(list(BENCHMARK_SYMBOLS) + _positions(core) + base)[:MAX_FINAL_UNIVERSE]
+    _apply_classification(core, list(payload.get("candidates") or []), final_universe)
+    core.UNIVERSE = final_universe
+    _schedule_sector_enrichment(core, list(payload.get("candidates") or [])[:MAX_BROAD_SLOTS])
+    record = _record_boundary(
+        core,
+        payload,
+        phase=phase,
+        pre_universe=pre_universe,
+        final_universe=final_universe,
+    )
+    record.update(
+        {
+            "status": payload.get("status"),
+            "source_counts": payload.get("source_counts"),
+            "source_errors": payload.get("source_errors"),
+            "eligible_unique_count": payload.get("eligible_unique_count"),
+            "protected_symbols": _unique(list(BENCHMARK_SYMBOLS) + _positions(core)),
+            "broad_symbols_used": [s for s in broad if s in final_universe],
+            "base_fallback_symbols": [s for s in final_universe if s in set(base) and s not in set(broad)],
+            "theme_baskets_are_fallback_and_classification": True,
+        }
+    )
+    try:
+        state = (getattr(core, "portfolio", {}) or {}).get("broad_momentum_discovery")
+        if isinstance(state, dict):
+            state.update(record)
+    except Exception:
+        pass
+    return record
+
+
+def _linked_callable(current: Any, marker: str) -> bool:
     seen: set[int] = set()
-    current = fn
-    for _ in range(limit):
-        if not callable(current) or id(current) in seen:
-            return False
-        seen.add(id(current))
-        if getattr(current, "_broad_momentum_discovery_version", None) == VERSION:
+    queue: List[Any] = [current]
+    while queue and len(seen) < 80:
+        fn = queue.pop(0)
+        if not callable(fn) or id(fn) in seen:
+            continue
+        seen.add(id(fn))
+        if getattr(fn, marker, None) == VERSION:
             return True
-        current = getattr(current, "__wrapped__", None) or getattr(current, "_broad_momentum_original", None)
+        for attr in (
+            "__wrapped__",
+            "_broad_momentum_original",
+            "_broad_momentum_scan_original",
+            "_dynamic_universe_builder_original",
+            "_shared_cycle_identity_original",
+            "_scanner_v2_lifecycle_trace_original",
+        ):
+            linked = getattr(fn, attr, None)
+            if callable(linked):
+                queue.append(linked)
     return False
+
+
+def _patch_scan_signals(core: Any) -> bool:
+    current = getattr(core, "scan_signals", None)
+    if not callable(current) or _linked_callable(current, "_broad_momentum_scan_version"):
+        return False
+    original = current
+
+    @functools.wraps(original)
+    def wrapped_scan_signals(*args, **kwargs):
+        payload = discover(core, force=False, wait=True)
+        apply_universe(core, payload, phase="pre_scan")
+        result = original(*args, **kwargs)
+        try:
+            state = (getattr(core, "portfolio", {}) or {}).get("broad_momentum_discovery", {})
+            if isinstance(state, dict):
+                state["last_scan_completed_local"] = _now(core)
+                state["last_scan_result_count"] = len(result) if isinstance(result, list) else None
+                state["post_scan_universe_count"] = len(_unique(getattr(core, "UNIVERSE", []) or []))
+        except Exception:
+            pass
+        return result
+
+    wrapped_scan_signals._broad_momentum_scan_version = VERSION  # type: ignore[attr-defined]
+    wrapped_scan_signals._broad_momentum_scan_original = original  # type: ignore[attr-defined]
+    core.scan_signals = wrapped_scan_signals
+    return True
 
 
 def _patch_run_cycle(core: Any) -> bool:
     current = getattr(core, "run_cycle", None)
-    if not callable(current) or _chain_has_marker(current):
+    if not callable(current) or _linked_callable(current, "_broad_momentum_discovery_version"):
         return False
     original = current
 
     @functools.wraps(original)
     def wrapped_run_cycle(*args, **kwargs):
+        payload: Dict[str, Any] | None = None
         try:
             clock = core.market_clock() if callable(getattr(core, "market_clock", None)) else {}
             market_open = bool(clock.get("is_open", False)) if isinstance(clock, dict) else False
             if ENABLED and _paper_context() and market_open:
                 payload = discover(core, force=False, wait=True)
-                apply_universe(core, payload)
+                apply_universe(core, payload, phase="pre_cycle")
         except Exception as exc:
             try:
                 portfolio = getattr(core, "portfolio", {})
@@ -544,7 +802,14 @@ def _patch_run_cycle(core: Any) -> bool:
                     }
             except Exception:
                 pass
-        return original(*args, **kwargs)
+        try:
+            return original(*args, **kwargs)
+        finally:
+            if payload:
+                try:
+                    apply_universe(core, payload, phase="post_cycle")
+                except Exception:
+                    pass
 
     wrapped_run_cycle._broad_momentum_discovery_version = VERSION  # type: ignore[attr-defined]
     wrapped_run_cycle._broad_momentum_original = original  # type: ignore[attr-defined]
@@ -556,6 +821,7 @@ def _watchdog(core: Any) -> None:
     while True:
         try:
             _patch_run_cycle(core)
+            _patch_scan_signals(core)
         except Exception:
             pass
         time.sleep(max(5, WATCHDOG_SECONDS))
@@ -578,7 +844,6 @@ def _start_watchdog(core: Any) -> None:
 
 def status_payload(core: Any = None, force: bool = False) -> Dict[str, Any]:
     core = core or _module()
-    current = getattr(core, "run_cycle", None) if core is not None else None
     payload = discover(core, force=True, wait=True) if force else dict(_LAST or {})
     if not payload:
         payload = {
@@ -593,21 +858,38 @@ def status_payload(core: Any = None, force: bool = False) -> Dict[str, Any]:
             "top_candidates": [],
         }
     payload = dict(payload)
-    payload["enabled"] = bool(ENABLED)
-    payload["paper_context"] = bool(_paper_context())
-    payload["run_cycle_hook_active"] = _chain_has_marker(current) if callable(current) else False
-    payload["current_universe_count"] = len(_unique(getattr(core, "UNIVERSE", []) or [])) if core is not None else 0
-    payload["current_universe"] = _unique(getattr(core, "UNIVERSE", []) or [])[:MAX_FINAL_UNIVERSE] if core is not None else []
-    payload["authority"] = {
-        "places_orders": False,
-        "changes_entry_rules": False,
-        "changes_hard_risk": False,
-        "changes_sizing": False,
-        "changes_ml_authority": False,
-        "changes_live_authority": False,
-        "execution_authority": "existing_rules_only",
-        "ml_authority": "shadow_recommendation_only",
-    }
+    run_current = getattr(core, "run_cycle", None) if core is not None else None
+    scan_current = getattr(core, "scan_signals", None) if core is not None else None
+    current_universe = _unique(getattr(core, "UNIVERSE", []) or []) if core is not None else []
+    boundary = {}
+    if core is not None:
+        try:
+            boundary = dict((getattr(core, "portfolio", {}) or {}).get("broad_momentum_discovery") or {})
+        except Exception:
+            boundary = {}
+    classified = sum(1 for row in payload.get("candidates") or [] if isinstance(row, dict) and row.get("sector_proxy"))
+    selected_count = len(payload.get("selected_symbols") or [])
+    payload.update(
+        {
+            "enabled": bool(ENABLED),
+            "paper_context": bool(_paper_context()),
+            "run_cycle_hook_active": _linked_callable(run_current, "_broad_momentum_discovery_version"),
+            "scan_boundary_hook_active": _linked_callable(scan_current, "_broad_momentum_scan_version"),
+            "current_universe_count": len(current_universe),
+            "current_universe": current_universe[:MAX_FINAL_UNIVERSE],
+            "current_universe_over_policy_cap": max(0, len(current_universe) - MAX_FINAL_UNIVERSE),
+            "last_scanner_boundary": boundary,
+            "classification": {
+                "classified_count": classified,
+                "unclassified_count": max(0, selected_count - classified),
+                "coverage_pct": round(100.0 * classified / selected_count, 2) if selected_count else 0.0,
+                "sector_cache_count": len(_SECTOR_CACHE),
+                "enrichment_in_progress": bool(_SECTOR_THREAD and _SECTOR_THREAD.is_alive()),
+                "enrichment_non_blocking": True,
+            },
+            "authority": _authority(),
+        }
+    )
     return payload
 
 
@@ -616,7 +898,8 @@ def apply(core: Any = None) -> Dict[str, Any]:
     if core is None:
         return {"status": "pending", "overall": "pending", "version": VERSION, "reason": "core_not_ready"}
     _base_universe(core)
-    patched = _patch_run_cycle(core)
+    run_patched = _patch_run_cycle(core)
+    scan_patched = _patch_scan_signals(core)
     _start_watchdog(core)
     return {
         "status": "ok",
@@ -624,8 +907,10 @@ def apply(core: Any = None) -> Dict[str, Any]:
         "version": VERSION,
         "enabled": bool(ENABLED),
         "paper_context": bool(_paper_context()),
-        "run_cycle_hook_active": _chain_has_marker(getattr(core, "run_cycle", None)),
-        "patched_this_call": bool(patched),
+        "run_cycle_hook_active": _linked_callable(getattr(core, "run_cycle", None), "_broad_momentum_discovery_version"),
+        "scan_boundary_hook_active": _linked_callable(getattr(core, "scan_signals", None), "_broad_momentum_scan_version"),
+        "patched_run_cycle_this_call": bool(run_patched),
+        "patched_scan_this_call": bool(scan_patched),
         "watchdog_started": id(core) in _WATCHDOG_CORE_IDS,
         "authority_changed": False,
         "execution_authority": "existing_rules_only",
@@ -669,6 +954,8 @@ def register_routes(flask_app: Any, core: Any = None) -> None:
                 "selected_symbols": list(payload.get("selected_symbols") or [])[:limit],
                 "source_counts": payload.get("source_counts"),
                 "source_errors": payload.get("source_errors"),
+                "classification": payload.get("classification"),
+                "last_scanner_boundary": payload.get("last_scanner_boundary"),
                 "authority": payload.get("authority"),
             }
         )
@@ -679,12 +966,36 @@ def register_routes(flask_app: Any, core: Any = None) -> None:
             "broad_momentum_discovery_status",
             status_route,
         )
+    else:
+        endpoint = next(
+            (
+                getattr(rule, "endpoint", None)
+                for rule in flask_app.url_map.iter_rules()
+                if getattr(rule, "rule", "") == "/paper/broad-momentum-discovery-status"
+            ),
+            None,
+        )
+        if endpoint:
+            flask_app.view_functions[endpoint] = status_route
+
     if "/paper/broad-momentum-candidates" not in existing:
         flask_app.add_url_rule(
             "/paper/broad-momentum-candidates",
             "broad_momentum_candidates",
             candidates_route,
         )
+    else:
+        endpoint = next(
+            (
+                getattr(rule, "endpoint", None)
+                for rule in flask_app.url_map.iter_rules()
+                if getattr(rule, "rule", "") == "/paper/broad-momentum-candidates"
+            ),
+            None,
+        )
+        if endpoint:
+            flask_app.view_functions[endpoint] = candidates_route
+
     _REGISTERED_APP_IDS.add(id(flask_app))
     apply(core or _module())
 

--- a/broad_momentum_discovery.py
+++ b/broad_momentum_discovery.py
@@ -31,6 +31,8 @@ MIN_DOLLAR_VOLUME = float(os.getenv("BROAD_MOMENTUM_MIN_DOLLAR_VOLUME", "1000000
 MIN_MARKET_CAP = float(os.getenv("BROAD_MOMENTUM_MIN_MARKET_CAP", "100000000"))
 CUSTOM_SCREEN_SIZE = int(os.getenv("BROAD_MOMENTUM_CUSTOM_SCREEN_SIZE", "250"))
 PREDEFINED_SCREEN_COUNT = int(os.getenv("BROAD_MOMENTUM_PREDEFINED_COUNT", "100"))
+# Typed-configuration compatibility only. No broad-discovery watchdog loop is started.
+WATCHDOG_SECONDS = int(os.getenv("BROAD_MOMENTUM_WATCHDOG_SECONDS", "10"))
 SECTOR_ENRICH_PER_REFRESH = int(os.getenv("BROAD_MOMENTUM_SECTOR_ENRICH_PER_REFRESH", "12"))
 SECTOR_CACHE_TTL_SECONDS = int(os.getenv("BROAD_MOMENTUM_SECTOR_CACHE_TTL_SECONDS", str(7 * 86400)))
 
@@ -321,7 +323,8 @@ def _policy() -> Dict[str, Any]:
             "max_base_slots": MAX_BASE_SLOTS, "min_price": MIN_PRICE, "min_day_volume": MIN_DAY_VOLUME,
             "min_dollar_volume": MIN_DOLLAR_VOLUME, "min_market_cap": MIN_MARKET_CAP,
             "benchmark_symbols": list(BENCHMARK_SYMBOLS), "theme_baskets_are_fallback_and_classification": True,
-            "scanner_boundary_enforced": True, "scanner_boundary_owner": "scanner_runtime_contract"}
+            "scanner_boundary_enforced": True, "scanner_boundary_owner": "scanner_runtime_contract",
+            "watchdog_loop_active": False, "watchdog_seconds_compatibility_only": WATCHDOG_SECONDS}
 
 
 def _refresh_worker(core: Any = None) -> None:

--- a/broad_momentum_discovery.py
+++ b/broad_momentum_discovery.py
@@ -1,9 +1,9 @@
 """Paper-only broad-market momentum discovery with bounded scanner ownership.
 
-This module discovers liquid U.S. momentum leaders from market-wide Yahoo/yfinance
-screens, installs a bounded working universe, and leaves all trade decisions to
-the existing rules engine. Version 2 adds scanner-boundary enforcement, source
-attribution integrity, non-blocking sector enrichment, and ownership telemetry.
+Discovers liquid U.S. momentum leaders, composes a bounded working universe, and
+leaves all trade decisions to the existing rules engine. Scanner callable
+ownership remains with ``scanner_runtime_contract``; this module only supplies
+and assigns the universe immediately before that canonical scanner runs.
 """
 from __future__ import annotations
 
@@ -16,88 +16,59 @@ import threading
 import time
 from typing import Any, Dict, Iterable, List, Sequence, Tuple
 
-VERSION = "broad-momentum-discovery-2026-08-05-v2-integrity"
-ENABLED = os.environ.get("BROAD_MOMENTUM_DISCOVERY_ENABLED", "true").lower() not in {
-    "0", "false", "no", "off"
-}
-PAPER_ONLY = os.environ.get("BROAD_MOMENTUM_DISCOVERY_PAPER_ONLY", "true").lower() not in {
-    "0", "false", "no", "off"
-}
-CACHE_TTL_SECONDS = int(os.environ.get("BROAD_MOMENTUM_CACHE_TTL_SECONDS", "900"))
-REFRESH_WAIT_SECONDS = float(os.environ.get("BROAD_MOMENTUM_REFRESH_WAIT_SECONDS", "7"))
-MAX_DISCOVERY_SYMBOLS = int(os.environ.get("BROAD_MOMENTUM_MAX_DISCOVERY_SYMBOLS", "160"))
-MAX_FINAL_UNIVERSE = int(os.environ.get("BROAD_MOMENTUM_MAX_FINAL_UNIVERSE", "110"))
-MAX_BROAD_SLOTS = int(os.environ.get("BROAD_MOMENTUM_MAX_BROAD_SLOTS", "80"))
-MAX_BASE_SLOTS = int(os.environ.get("BROAD_MOMENTUM_MAX_BASE_SLOTS", "25"))
-MIN_PRICE = float(os.environ.get("BROAD_MOMENTUM_MIN_PRICE", "3.00"))
-MIN_DAY_VOLUME = float(os.environ.get("BROAD_MOMENTUM_MIN_DAY_VOLUME", "350000"))
-MIN_DOLLAR_VOLUME = float(os.environ.get("BROAD_MOMENTUM_MIN_DOLLAR_VOLUME", "10000000"))
-MIN_MARKET_CAP = float(os.environ.get("BROAD_MOMENTUM_MIN_MARKET_CAP", "100000000"))
-CUSTOM_SCREEN_SIZE = int(os.environ.get("BROAD_MOMENTUM_CUSTOM_SCREEN_SIZE", "250"))
-PREDEFINED_SCREEN_COUNT = int(os.environ.get("BROAD_MOMENTUM_PREDEFINED_COUNT", "100"))
-WATCHDOG_SECONDS = int(os.environ.get("BROAD_MOMENTUM_WATCHDOG_SECONDS", "10"))
-SECTOR_ENRICH_PER_REFRESH = int(os.environ.get("BROAD_MOMENTUM_SECTOR_ENRICH_PER_REFRESH", "12"))
-SECTOR_CACHE_TTL_SECONDS = int(
-    os.environ.get("BROAD_MOMENTUM_SECTOR_CACHE_TTL_SECONDS", str(7 * 24 * 3600))
-)
+VERSION = "broad-momentum-discovery-2026-08-05-v2.1-ownership-safe"
+ENABLED = os.getenv("BROAD_MOMENTUM_DISCOVERY_ENABLED", "true").lower() not in {"0", "false", "no", "off"}
+PAPER_ONLY = os.getenv("BROAD_MOMENTUM_DISCOVERY_PAPER_ONLY", "true").lower() not in {"0", "false", "no", "off"}
+CACHE_TTL_SECONDS = int(os.getenv("BROAD_MOMENTUM_CACHE_TTL_SECONDS", "900"))
+REFRESH_WAIT_SECONDS = float(os.getenv("BROAD_MOMENTUM_REFRESH_WAIT_SECONDS", "7"))
+MAX_DISCOVERY_SYMBOLS = int(os.getenv("BROAD_MOMENTUM_MAX_DISCOVERY_SYMBOLS", "160"))
+MAX_FINAL_UNIVERSE = int(os.getenv("BROAD_MOMENTUM_MAX_FINAL_UNIVERSE", "110"))
+MAX_BROAD_SLOTS = int(os.getenv("BROAD_MOMENTUM_MAX_BROAD_SLOTS", "80"))
+MAX_BASE_SLOTS = int(os.getenv("BROAD_MOMENTUM_MAX_BASE_SLOTS", "25"))
+MIN_PRICE = float(os.getenv("BROAD_MOMENTUM_MIN_PRICE", "3.00"))
+MIN_DAY_VOLUME = float(os.getenv("BROAD_MOMENTUM_MIN_DAY_VOLUME", "350000"))
+MIN_DOLLAR_VOLUME = float(os.getenv("BROAD_MOMENTUM_MIN_DOLLAR_VOLUME", "10000000"))
+MIN_MARKET_CAP = float(os.getenv("BROAD_MOMENTUM_MIN_MARKET_CAP", "100000000"))
+CUSTOM_SCREEN_SIZE = int(os.getenv("BROAD_MOMENTUM_CUSTOM_SCREEN_SIZE", "250"))
+PREDEFINED_SCREEN_COUNT = int(os.getenv("BROAD_MOMENTUM_PREDEFINED_COUNT", "100"))
+SECTOR_ENRICH_PER_REFRESH = int(os.getenv("BROAD_MOMENTUM_SECTOR_ENRICH_PER_REFRESH", "12"))
+SECTOR_CACHE_TTL_SECONDS = int(os.getenv("BROAD_MOMENTUM_SECTOR_CACHE_TTL_SECONDS", str(7 * 86400)))
 
 BENCHMARK_SYMBOLS = ("SPY", "QQQ", "IWM", "DIA")
 SECTOR_ETF = {
-    "basic materials": "XLB",
-    "materials": "XLB",
+    "basic materials": "XLB", "materials": "XLB",
     "communication services": "XLC",
-    "consumer cyclical": "XLY",
-    "consumer discretionary": "XLY",
-    "consumer defensive": "XLP",
-    "consumer staples": "XLP",
-    "energy": "XLE",
-    "financial services": "XLF",
-    "financial": "XLF",
-    "healthcare": "XLV",
-    "health care": "XLV",
-    "industrials": "XLI",
-    "real estate": "XLRE",
-    "technology": "XLK",
-    "utilities": "XLU",
+    "consumer cyclical": "XLY", "consumer discretionary": "XLY",
+    "consumer defensive": "XLP", "consumer staples": "XLP",
+    "energy": "XLE", "financial services": "XLF", "financial": "XLF",
+    "healthcare": "XLV", "health care": "XLV", "industrials": "XLI",
+    "real estate": "XLRE", "technology": "XLK", "utilities": "XLU",
 }
 DYNAMIC_BUCKET = "dynamic_momentum"
 DYNAMIC_BUCKET_CONFIG = {"alloc_factor": 0.40, "max_exposure_pct": 0.20, "max_positions": 3}
 
 _LOCK = threading.RLock()
-_REFRESH_EVENT = threading.Event()
-_REFRESH_THREAD: threading.Thread | None = None
-_SECTOR_THREAD: threading.Thread | None = None
 _CACHE: Dict[str, Any] = {"ts": 0.0, "payload": None}
-_SECTOR_CACHE: Dict[str, Dict[str, Any]] = {}
 _LAST: Dict[str, Any] = {}
 _BASE_UNIVERSE: Dict[int, List[str]] = {}
-_REGISTERED_APP_IDS: set[int] = set()
-_WATCHDOG_CORE_IDS: set[int] = set()
+_SECTOR_CACHE: Dict[str, Dict[str, Any]] = {}
+_REFRESH_THREAD: threading.Thread | None = None
+_REFRESH_EVENT = threading.Event()
+_SECTOR_THREAD: threading.Thread | None = None
+_REGISTERED_APPS: set[int] = set()
 
 _OWNER_MODULE_HINTS = (
-    "neutral_momentum_starter_extension",
-    "opening_surge_participation",
-    "dynamic_universe_builder",
-    "scanner_v2_shadow_universe",
-    "space_stock_basket",
-    "spacex_direct_overlay",
-    "breakout_participation_layer",
+    "neutral_momentum_starter_extension", "opening_surge_participation",
+    "dynamic_universe_builder", "scanner_v2_shadow_universe", "space_stock_basket",
+    "spacex_direct_overlay", "breakout_participation_layer",
 )
-_OWNER_ATTR_HINTS = (
-    "_EXTRA_SYMBOLS",
-    "EXTRA",
-    "EXTRA_SYMBOLS",
-    "PREFERRED_SYMBOLS",
-    "UNIVERSE",
-    "THEME_SYMBOLS",
-    "SYMBOLS",
-)
+_OWNER_ATTR_HINTS = ("_EXTRA_SYMBOLS", "EXTRA", "EXTRA_SYMBOLS", "PREFERRED_SYMBOLS", "UNIVERSE", "THEME_SYMBOLS", "SYMBOLS")
 
 
 def _f(value: Any, default: float = 0.0) -> float:
     try:
         if isinstance(value, dict) and "raw" in value:
-            value = value.get("raw")
+            value = value["raw"]
         if hasattr(value, "item"):
             value = value.item()
         number = float(value)
@@ -113,32 +84,32 @@ def _symbol(value: Any) -> str:
 
 
 def _unique(values: Iterable[Any]) -> List[str]:
-    output: List[str] = []
+    out: List[str] = []
     seen: set[str] = set()
     for value in values or []:
         symbol = _symbol(value)
         if symbol and symbol not in seen:
             seen.add(symbol)
-            output.append(symbol)
-    return output
+            out.append(symbol)
+    return out
 
 
 def _unique_labels(values: Iterable[Any]) -> List[str]:
-    output: List[str] = []
+    out: List[str] = []
     seen: set[str] = set()
     for value in values or []:
         label = str(value or "").strip()
         if label and label not in seen:
             seen.add(label)
-            output.append(label)
-    return output
+            out.append(label)
+    return out
 
 
 def _paper_context() -> bool:
     if not PAPER_ONLY:
         return True
-    live = os.environ.get("LIVE_TRADING_ENABLED", "false").lower() in {"1", "true", "yes", "on"}
-    broker_live = os.environ.get("BROKER_MODE", "").lower() in {"live", "real", "production"}
+    live = os.getenv("LIVE_TRADING_ENABLED", "false").lower() in {"1", "true", "yes", "on"}
+    broker_live = os.getenv("BROKER_MODE", "").lower() in {"live", "real", "production"}
     return not live and not broker_live
 
 
@@ -157,51 +128,40 @@ def _module() -> Any | None:
     return None
 
 
-def _quote_value(quote: Dict[str, Any], *keys: str) -> Any:
+def _value(row: Dict[str, Any], *keys: str) -> Any:
     for key in keys:
-        if key in quote and quote.get(key) is not None:
-            value = quote.get(key)
+        value = row.get(key)
+        if value is not None:
             return value.get("raw") if isinstance(value, dict) and "raw" in value else value
     return None
 
 
-def _normalize_sector(value: Any) -> str:
-    return str(value or "").strip()
-
-
 def _sector_proxy(value: Any) -> str | None:
-    return SECTOR_ETF.get(_normalize_sector(value).lower())
+    return SECTOR_ETF.get(str(value or "").strip().lower())
 
 
 def _normalize_quote(quote: Dict[str, Any], source: str) -> Dict[str, Any] | None:
     if not isinstance(quote, dict):
         return None
-    symbol = _symbol(_quote_value(quote, "symbol", "ticker"))
+    symbol = _symbol(_value(quote, "symbol", "ticker"))
     if not symbol:
         return None
-    price = _f(_quote_value(quote, "regularMarketPrice", "intradayprice", "regularMarketPreviousClose"))
-    pct = _f(_quote_value(quote, "regularMarketChangePercent", "percentchange"))
-    volume = _f(_quote_value(quote, "regularMarketVolume", "dayvolume", "eodvolume"))
-    avg_volume = _f(_quote_value(quote, "averageDailyVolume3Month", "avgdailyvol3m", "averageDailyVolume10Day"))
-    market_cap = _f(_quote_value(quote, "marketCap", "intradaymarketcap"))
-    dollar_volume = max(0.0, price * volume)
-    relative_volume = volume / avg_volume if avg_volume > 0 else 0.0
-    sector = _normalize_sector(_quote_value(quote, "sector", "sectorName", "sectorDisp"))
-    industry = str(_quote_value(quote, "industry", "industryName", "industryDisp") or "").strip()
+    price = _f(_value(quote, "regularMarketPrice", "intradayprice", "regularMarketPreviousClose"))
+    pct = _f(_value(quote, "regularMarketChangePercent", "percentchange"))
+    volume = _f(_value(quote, "regularMarketVolume", "dayvolume", "eodvolume"))
+    avg_volume = _f(_value(quote, "averageDailyVolume3Month", "avgdailyvol3m", "averageDailyVolume10Day"))
+    market_cap = _f(_value(quote, "marketCap", "intradaymarketcap"))
+    sector = str(_value(quote, "sector", "sectorName", "sectorDisp") or "").strip()
+    industry = str(_value(quote, "industry", "industryName", "industryDisp") or "").strip()
     return {
-        "symbol": symbol,
-        "source": source,
-        "sources": [source],
-        "price": round(price, 4),
-        "percent_change": round(pct, 4),
+        "symbol": symbol, "source": source, "sources": [source],
+        "price": round(price, 4), "percent_change": round(pct, 4),
         "day_volume": int(volume) if volume > 0 else 0,
         "avg_volume_3m": int(avg_volume) if avg_volume > 0 else 0,
-        "relative_volume": round(relative_volume, 4),
-        "dollar_volume": round(dollar_volume, 2),
-        "market_cap": round(market_cap, 2),
-        "sector_name": sector,
-        "industry_name": industry,
-        "sector_proxy": _sector_proxy(sector),
+        "relative_volume": round(volume / avg_volume, 4) if avg_volume > 0 else 0.0,
+        "dollar_volume": round(max(0.0, price * volume), 2),
+        "market_cap": round(market_cap, 2), "sector_name": sector,
+        "industry_name": industry, "sector_proxy": _sector_proxy(sector),
         "classification_source": "screen_payload" if sector else None,
     }
 
@@ -220,69 +180,47 @@ def _eligible(row: Dict[str, Any]) -> Tuple[bool, str]:
 
 
 def _discovery_score(row: Dict[str, Any]) -> float:
-    pct = _f(row.get("percent_change"))
-    relvol = _f(row.get("relative_volume"))
-    dollar_volume = _f(row.get("dollar_volume"))
-    market_cap = _f(row.get("market_cap"))
-    score = 0.0
-    score += max(-0.08, min(pct, 20.0) / 32.0)
+    pct, relvol = _f(row.get("percent_change")), _f(row.get("relative_volume"))
+    dollar_volume, market_cap = _f(row.get("dollar_volume")), _f(row.get("market_cap"))
+    score = max(-0.08, min(pct, 20.0) / 32.0)
     score += max(0.0, min(relvol - 1.0, 5.0)) / 10.0
     score += min(max(dollar_volume, 0.0), 500_000_000.0) / 2_500_000_000.0
-    if market_cap >= 2_000_000_000:
-        score += 0.035
-    elif market_cap >= 500_000_000:
-        score += 0.020
+    score += 0.035 if market_cap >= 2_000_000_000 else 0.020 if market_cap >= 500_000_000 else 0.0
     return round(score, 6)
 
 
-def _response_quotes(response: Any) -> List[Dict[str, Any]]:
+def _quotes(response: Any) -> List[Dict[str, Any]]:
     if not isinstance(response, dict):
         return []
-    candidates = response.get("quotes")
-    if not isinstance(candidates, list):
-        finance = response.get("finance")
-        if isinstance(finance, dict):
-            results = finance.get("result")
-            if isinstance(results, list) and results:
-                candidates = results[0].get("quotes") if isinstance(results[0], dict) else []
-    return [row for row in candidates or [] if isinstance(row, dict)]
-
-
-def _predefined_screen(yf: Any, name: str) -> Any:
-    try:
-        return yf.screen(name, count=PREDEFINED_SCREEN_COUNT)
-    except TypeError:
-        return yf.screen(name, size=PREDEFINED_SCREEN_COUNT)
+    rows = response.get("quotes")
+    if not isinstance(rows, list):
+        results = (response.get("finance") or {}).get("result") if isinstance(response.get("finance"), dict) else None
+        rows = results[0].get("quotes") if isinstance(results, list) and results and isinstance(results[0], dict) else []
+    return [row for row in rows or [] if isinstance(row, dict)]
 
 
 def _screen_calls() -> List[Tuple[str, Any]]:
     import yfinance as yf  # type: ignore
-
     calls: List[Tuple[str, Any]] = []
     for name in ("day_gainers", "most_actives"):
         try:
-            calls.append((name, _predefined_screen(yf, name)))
+            try:
+                response = yf.screen(name, count=PREDEFINED_SCREEN_COUNT)
+            except TypeError:
+                response = yf.screen(name, size=PREDEFINED_SCREEN_COUNT)
+            calls.append((name, response))
         except Exception as exc:
             calls.append((name, {"_error": f"{type(exc).__name__}: {exc}"}))
     try:
-        EquityQuery = getattr(yf, "EquityQuery")
-        query = EquityQuery(
-            "and",
-            [
-                EquityQuery("eq", ["region", "us"]),
-                EquityQuery("is-in", ["exchange", "NMS", "NYQ", "ASE"]),
-                EquityQuery("gte", ["intradayprice", MIN_PRICE]),
-                EquityQuery("gte", ["dayvolume", MIN_DAY_VOLUME]),
-                EquityQuery("gte", ["intradaymarketcap", MIN_MARKET_CAP]),
-                EquityQuery("gte", ["percentchange", 0.50]),
-            ],
-        )
-        calls.append(
-            (
-                "market_wide_momentum",
-                yf.screen(query, size=CUSTOM_SCREEN_SIZE, sortField="percentchange", sortAsc=False),
-            )
-        )
+        query = yf.EquityQuery("and", [
+            yf.EquityQuery("eq", ["region", "us"]),
+            yf.EquityQuery("is-in", ["exchange", "NMS", "NYQ", "ASE"]),
+            yf.EquityQuery("gte", ["intradayprice", MIN_PRICE]),
+            yf.EquityQuery("gte", ["dayvolume", MIN_DAY_VOLUME]),
+            yf.EquityQuery("gte", ["intradaymarketcap", MIN_MARKET_CAP]),
+            yf.EquityQuery("gte", ["percentchange", 0.50]),
+        ])
+        calls.append(("market_wide_momentum", yf.screen(query, size=CUSTOM_SCREEN_SIZE, sortField="percentchange", sortAsc=False)))
     except Exception as exc:
         calls.append(("market_wide_momentum", {"_error": f"{type(exc).__name__}: {exc}"}))
     return calls
@@ -291,20 +229,16 @@ def _screen_calls() -> List[Tuple[str, Any]]:
 def _cached_classification(symbol: str) -> Dict[str, Any]:
     with _LOCK:
         row = dict(_SECTOR_CACHE.get(symbol) or {})
-    age = time.time() - _f(row.get("ts")) if row else float("inf")
-    return row if row and age <= SECTOR_CACHE_TTL_SECONDS else {}
+    return row if row and time.time() - _f(row.get("ts")) <= SECTOR_CACHE_TTL_SECONDS else {}
 
 
 def _merge_classification(row: Dict[str, Any], core: Any = None) -> Dict[str, Any]:
-    symbol = _symbol(row.get("symbol"))
     if row.get("sector_proxy"):
         return row
+    symbol = _symbol(row.get("symbol"))
     cached = _cached_classification(symbol)
     if cached:
-        row["sector_name"] = cached.get("sector_name") or row.get("sector_name") or ""
-        row["industry_name"] = cached.get("industry_name") or row.get("industry_name") or ""
-        row["sector_proxy"] = cached.get("sector_proxy") or _sector_proxy(row.get("sector_name"))
-        row["classification_source"] = cached.get("classification_source") or "yfinance_profile_cache"
+        row.update({key: cached.get(key) or row.get(key) for key in ("sector_name", "industry_name", "sector_proxy", "classification_source")})
         return row
     try:
         existing = (getattr(core, "SYMBOL_SECTOR", {}) or {}).get(symbol)
@@ -312,124 +246,82 @@ def _merge_classification(row: Dict[str, Any], core: Any = None) -> Dict[str, An
         existing = None
     if existing:
         value = str(existing)
-        if value.upper().startswith("XL"):
-            row["sector_proxy"] = value.upper()
-            row["classification_source"] = "existing_runtime_sector_map"
-        else:
-            row["sector_name"] = value
-            row["sector_proxy"] = _sector_proxy(value)
-            row["classification_source"] = "existing_runtime_sector_map"
+        row["sector_proxy"] = value.upper() if value.upper().startswith("XL") else _sector_proxy(value)
+        row["sector_name"] = row.get("sector_name") or ("" if value.upper().startswith("XL") else value)
+        row["classification_source"] = "existing_runtime_sector_map"
     return row
 
 
 def _build_payload(core: Any = None) -> Dict[str, Any]:
     started = time.perf_counter()
-    rows_by_symbol: Dict[str, Dict[str, Any]] = {}
-    source_counts: Dict[str, int] = {}
+    by_symbol: Dict[str, Dict[str, Any]] = {}
+    counts: Dict[str, int] = {}
     errors: Dict[str, str] = {}
     try:
         calls = _screen_calls()
     except Exception as exc:
-        calls = []
-        errors["screen_bootstrap"] = f"{type(exc).__name__}: {exc}"
-
+        calls, errors["screen_bootstrap"] = [], f"{type(exc).__name__}: {exc}"
     for source, response in calls:
         if isinstance(response, dict) and response.get("_error"):
-            errors[source] = str(response.get("_error"))
+            errors[source] = str(response["_error"])
             continue
-        quotes = _response_quotes(response)
-        source_counts[source] = len(quotes)
-        for quote in quotes:
+        rows = _quotes(response)
+        counts[source] = len(rows)
+        for quote in rows:
             row = _normalize_quote(quote, source)
             if not row:
                 continue
             ok, reason = _eligible(row)
-            row["eligible"] = ok
-            row["eligibility_reason"] = reason
+            row.update({"eligible": ok, "eligibility_reason": reason})
             if not ok:
                 continue
-            symbol = str(row["symbol"])
-            existing = rows_by_symbol.get(symbol)
+            existing = by_symbol.get(row["symbol"])
             if existing is None:
-                rows_by_symbol[symbol] = row
+                by_symbol[row["symbol"]] = row
                 continue
-            sources = _unique_labels(list(existing.get("sources") or []) + list(row.get("sources") or []) + [source])
-            keep_new = _f(row.get("day_volume")) >= _f(existing.get("day_volume"))
-            winner = row if keep_new else existing
-            loser = existing if keep_new else row
+            sources = _unique_labels((existing.get("sources") or []) + (row.get("sources") or []))
+            winner, loser = (row, existing) if _f(row.get("day_volume")) >= _f(existing.get("day_volume")) else (existing, row)
             winner["sources"] = sources
-            winner["source"] = str(winner.get("source") or source)
             for key in ("sector_name", "industry_name", "sector_proxy", "classification_source"):
                 if not winner.get(key) and loser.get(key):
-                    winner[key] = loser.get(key)
-            rows_by_symbol[symbol] = winner
-
-    rows = [_merge_classification(dict(row), core) for row in rows_by_symbol.values()]
+                    winner[key] = loser[key]
+            by_symbol[winner["symbol"]] = winner
+    rows = [_merge_classification(dict(row), core) for row in by_symbol.values()]
     for row in rows:
-        source_confirmation = min(0.06, 0.02 * max(0, len(row.get("sources") or []) - 1))
-        row["source_confirmation_bonus"] = round(source_confirmation, 6)
-        row["discovery_score"] = round(_discovery_score(row) + source_confirmation, 6)
-    rows.sort(
-        key=lambda row: (
-            _f(row.get("discovery_score")),
-            _f(row.get("percent_change")),
-            _f(row.get("relative_volume")),
-            _f(row.get("dollar_volume")),
-        ),
-        reverse=True,
-    )
+        bonus = min(0.06, 0.02 * max(0, len(row.get("sources") or []) - 1))
+        row["source_confirmation_bonus"] = round(bonus, 6)
+        row["discovery_score"] = round(_discovery_score(row) + bonus, 6)
+    rows.sort(key=lambda row: (_f(row.get("discovery_score")), _f(row.get("percent_change")), _f(row.get("relative_volume")), _f(row.get("dollar_volume"))), reverse=True)
     selected = rows[:MAX_DISCOVERY_SYMBOLS]
     classified = sum(1 for row in selected if row.get("sector_proxy"))
     return {
-        "status": "ok" if selected else "warn",
-        "overall": "pass" if selected else "warn",
-        "type": "broad_momentum_discovery_status",
-        "version": VERSION,
-        "generated_local": _now(core),
-        "duration_seconds": round(time.perf_counter() - started, 4),
-        "mode": "paper_only_market_wide_prefilter",
-        "source_counts": source_counts,
-        "source_errors": errors,
-        "eligible_unique_count": len(rows),
-        "selected_count": len(selected),
-        "selected_symbols": [row["symbol"] for row in selected],
-        "candidates": selected,
+        "status": "ok" if selected else "warn", "overall": "pass" if selected else "warn",
+        "type": "broad_momentum_discovery_status", "version": VERSION,
+        "generated_local": _now(core), "duration_seconds": round(time.perf_counter() - started, 4),
+        "mode": "paper_only_market_wide_prefilter", "source_counts": counts, "source_errors": errors,
+        "eligible_unique_count": len(rows), "selected_count": len(selected),
+        "selected_symbols": [row["symbol"] for row in selected], "candidates": selected,
         "top_candidates": selected[:50],
-        "classification": {
-            "classified_count": classified,
-            "unclassified_count": max(0, len(selected) - classified),
-            "coverage_pct": round(100.0 * classified / len(selected), 2) if selected else 0.0,
-            "enrichment_non_blocking": True,
-        },
-        "policy": {
-            "cache_ttl_seconds": CACHE_TTL_SECONDS,
-            "max_discovery_symbols": MAX_DISCOVERY_SYMBOLS,
-            "max_final_universe": MAX_FINAL_UNIVERSE,
-            "max_broad_slots": MAX_BROAD_SLOTS,
-            "max_base_slots": MAX_BASE_SLOTS,
-            "min_price": MIN_PRICE,
-            "min_day_volume": MIN_DAY_VOLUME,
-            "min_dollar_volume": MIN_DOLLAR_VOLUME,
-            "min_market_cap": MIN_MARKET_CAP,
-            "benchmark_symbols": list(BENCHMARK_SYMBOLS),
-            "theme_baskets_are_fallback_and_classification": True,
-            "scanner_boundary_enforced": True,
-        },
-        "authority": _authority(),
+        "classification": {"classified_count": classified, "unclassified_count": len(selected) - classified,
+                           "coverage_pct": round(100.0 * classified / len(selected), 2) if selected else 0.0,
+                           "enrichment_non_blocking": True},
+        "policy": _policy(), "authority": _authority(),
     }
 
 
 def _authority() -> Dict[str, Any]:
-    return {
-        "places_orders": False,
-        "changes_entry_rules": False,
-        "changes_hard_risk": False,
-        "changes_sizing": False,
-        "changes_ml_authority": False,
-        "changes_live_authority": False,
-        "execution_authority": "existing_rules_only",
-        "ml_authority": "shadow_recommendation_only",
-    }
+    return {"places_orders": False, "changes_entry_rules": False, "changes_hard_risk": False,
+            "changes_sizing": False, "changes_ml_authority": False, "changes_live_authority": False,
+            "execution_authority": "existing_rules_only", "ml_authority": "shadow_recommendation_only"}
+
+
+def _policy() -> Dict[str, Any]:
+    return {"cache_ttl_seconds": CACHE_TTL_SECONDS, "max_discovery_symbols": MAX_DISCOVERY_SYMBOLS,
+            "max_final_universe": MAX_FINAL_UNIVERSE, "max_broad_slots": MAX_BROAD_SLOTS,
+            "max_base_slots": MAX_BASE_SLOTS, "min_price": MIN_PRICE, "min_day_volume": MIN_DAY_VOLUME,
+            "min_dollar_volume": MIN_DOLLAR_VOLUME, "min_market_cap": MIN_MARKET_CAP,
+            "benchmark_symbols": list(BENCHMARK_SYMBOLS), "theme_baskets_are_fallback_and_classification": True,
+            "scanner_boundary_enforced": True, "scanner_boundary_owner": "scanner_runtime_contract"}
 
 
 def _refresh_worker(core: Any = None) -> None:
@@ -437,18 +329,9 @@ def _refresh_worker(core: Any = None) -> None:
     try:
         payload = _build_payload(core)
     except Exception as exc:
-        payload = {
-            "status": "error",
-            "overall": "warn",
-            "type": "broad_momentum_discovery_status",
-            "version": VERSION,
-            "generated_local": _now(core),
-            "error": f"{type(exc).__name__}: {exc}",
-            "selected_symbols": [],
-            "candidates": [],
-            "top_candidates": [],
-            "authority": _authority(),
-        }
+        payload = {"status": "error", "overall": "warn", "type": "broad_momentum_discovery_status",
+                   "version": VERSION, "generated_local": _now(core), "error": f"{type(exc).__name__}: {exc}",
+                   "selected_symbols": [], "candidates": [], "top_candidates": [], "authority": _authority()}
     with _LOCK:
         _CACHE.update({"ts": time.time(), "payload": payload})
         _LAST = dict(payload)
@@ -457,49 +340,26 @@ def _refresh_worker(core: Any = None) -> None:
 
 def discover(core: Any = None, force: bool = False, wait: bool = True) -> Dict[str, Any]:
     global _REFRESH_THREAD
-    now = time.time()
     with _LOCK:
+        age = time.time() - _f(_CACHE.get("ts"))
         cached = _CACHE.get("payload")
-        age = now - float(_CACHE.get("ts", 0.0) or 0.0)
         if not force and isinstance(cached, dict) and age < CACHE_TTL_SECONDS:
-            result = dict(cached)
-            result["cache_hit"] = True
-            result["cache_age_seconds"] = round(max(0.0, age), 2)
-            return result
+            return {**cached, "cache_hit": True, "cache_age_seconds": round(max(0.0, age), 2)}
         if _REFRESH_THREAD is None or not _REFRESH_THREAD.is_alive():
             _REFRESH_EVENT.clear()
-            _REFRESH_THREAD = threading.Thread(
-                target=_refresh_worker,
-                args=(core,),
-                name="broad-momentum-discovery-refresh",
-                daemon=True,
-            )
+            _REFRESH_THREAD = threading.Thread(target=_refresh_worker, args=(core,), daemon=True, name="broad-momentum-refresh")
             _REFRESH_THREAD.start()
-        thread_alive = _REFRESH_THREAD.is_alive()
-
     completed = _REFRESH_EVENT.wait(max(0.0, REFRESH_WAIT_SECONDS)) if wait else False
     with _LOCK:
         cached = _CACHE.get("payload")
-        age = time.time() - float(_CACHE.get("ts", 0.0) or 0.0)
         if isinstance(cached, dict):
-            result = dict(cached)
-            result["cache_hit"] = not completed
-            result["cache_age_seconds"] = round(max(0.0, age), 2)
-            result["refresh_in_progress"] = bool(_REFRESH_THREAD and _REFRESH_THREAD.is_alive())
-            return result
-    return {
-        "status": "pending" if thread_alive else "warn",
-        "overall": "pending" if thread_alive else "warn",
-        "type": "broad_momentum_discovery_status",
-        "version": VERSION,
-        "generated_local": _now(core),
-        "reason": "initial_refresh_in_progress" if thread_alive else "no_discovery_payload",
-        "refresh_in_progress": thread_alive,
-        "selected_symbols": [],
-        "candidates": [],
-        "top_candidates": [],
-        "authority": _authority(),
-    }
+            return {**cached, "cache_hit": not completed,
+                    "cache_age_seconds": round(max(0.0, time.time() - _f(_CACHE.get("ts"))), 2),
+                    "refresh_in_progress": bool(_REFRESH_THREAD and _REFRESH_THREAD.is_alive())}
+    return {"status": "pending", "overall": "pending", "type": "broad_momentum_discovery_status",
+            "version": VERSION, "generated_local": _now(core), "reason": "initial_refresh_in_progress",
+            "refresh_in_progress": True, "selected_symbols": [], "candidates": [], "top_candidates": [],
+            "authority": _authority()}
 
 
 def _positions(core: Any) -> List[str]:
@@ -510,29 +370,22 @@ def _positions(core: Any) -> List[str]:
 
 
 def _base_universe(core: Any) -> List[str]:
-    key = id(core)
-    if key not in _BASE_UNIVERSE:
-        _BASE_UNIVERSE[key] = _unique(getattr(core, "UNIVERSE", []) or [])
-    return list(_BASE_UNIVERSE[key])
+    if id(core) not in _BASE_UNIVERSE:
+        _BASE_UNIVERSE[id(core)] = _unique(getattr(core, "UNIVERSE", []) or [])
+    return list(_BASE_UNIVERSE[id(core)])
 
 
-def _compose_universe(
-    positions: Sequence[str],
-    base: Sequence[str],
-    broad: Sequence[str],
-    cap: int = MAX_FINAL_UNIVERSE,
-    broad_cap: int = MAX_BROAD_SLOTS,
-    base_cap: int = MAX_BASE_SLOTS,
-) -> List[str]:
+def _compose_universe(positions: Sequence[str], base: Sequence[str], broad: Sequence[str],
+                      cap: int = MAX_FINAL_UNIVERSE, broad_cap: int = MAX_BROAD_SLOTS,
+                      base_cap: int = MAX_BASE_SLOTS) -> List[str]:
     protected = _unique(list(BENCHMARK_SYMBOLS) + list(positions))
-    protected_set = set(protected)
-    broad_slots = _unique([symbol for symbol in broad if _symbol(symbol) not in protected_set])[:broad_cap]
+    broad_slots = _unique([s for s in broad if _symbol(s) not in set(protected)])[:broad_cap]
     used = set(protected + broad_slots)
-    base_slots = _unique([symbol for symbol in base if _symbol(symbol) not in used])[:base_cap]
+    base_slots = _unique([s for s in base if _symbol(s) not in used])[:base_cap]
     return _unique(protected + broad_slots + base_slots)[:cap]
 
 
-def _infer_append_owner(symbol: str, base: set[str], broad: set[str], protected: set[str]) -> str:
+def _infer_owner(symbol: str, base: set[str], broad: set[str], protected: set[str]) -> str:
     if symbol in protected:
         return "protected_position_or_benchmark"
     if symbol in broad:
@@ -551,259 +404,134 @@ def _infer_append_owner(symbol: str, base: set[str], broad: set[str], protected:
                 if symbol in set(_unique(values or [])):
                     return module_name
             except Exception:
-                continue
+                pass
     return "unknown_runtime_overlay"
 
 
-def _apply_classification(core: Any, candidates: Sequence[Dict[str, Any]], final_universe: Sequence[str]) -> None:
-    sector_map = getattr(core, "SYMBOL_SECTOR", None)
-    bucket_map = getattr(core, "SYMBOL_BUCKET", None)
-    bucket_cfg = getattr(core, "BUCKET_CONFIG", None)
-    by_symbol = {
-        _symbol(row.get("symbol")): _merge_classification(dict(row), core)
-        for row in candidates or []
-        if isinstance(row, dict) and _symbol(row.get("symbol"))
-    }
-    if isinstance(bucket_cfg, dict):
-        bucket_cfg.setdefault(DYNAMIC_BUCKET, dict(DYNAMIC_BUCKET_CONFIG))
-    for symbol in final_universe:
-        row = by_symbol.get(_symbol(symbol), {})
-        if isinstance(bucket_map, dict):
-            bucket_map.setdefault(symbol, DYNAMIC_BUCKET)
-        if isinstance(sector_map, dict):
-            sector_map[symbol] = str(row.get("sector_proxy") or sector_map.get(symbol) or "UNKNOWN")
+def _apply_classification(core: Any, candidates: Sequence[Dict[str, Any]], universe: Sequence[str]) -> None:
+    sectors, buckets, configs = getattr(core, "SYMBOL_SECTOR", None), getattr(core, "SYMBOL_BUCKET", None), getattr(core, "BUCKET_CONFIG", None)
+    by_symbol = {_symbol(row.get("symbol")): _merge_classification(dict(row), core) for row in candidates if isinstance(row, dict) and _symbol(row.get("symbol"))}
+    if isinstance(configs, dict):
+        configs.setdefault(DYNAMIC_BUCKET, dict(DYNAMIC_BUCKET_CONFIG))
+    for symbol in universe:
+        row = by_symbol.get(symbol, {})
+        if isinstance(buckets, dict):
+            buckets.setdefault(symbol, DYNAMIC_BUCKET)
+        if isinstance(sectors, dict):
+            sectors[symbol] = str(row.get("sector_proxy") or sectors.get(symbol) or "UNKNOWN")
 
 
-def _sector_enrichment_worker(core: Any, candidates: Sequence[Dict[str, Any]]) -> None:
+def _enrich_worker(core: Any, candidates: Sequence[Dict[str, Any]]) -> None:
     try:
         import yfinance as yf  # type: ignore
     except Exception:
         return
     processed = 0
     for row in candidates:
-        if processed >= max(0, SECTOR_ENRICH_PER_REFRESH):
-            break
         symbol = _symbol(row.get("symbol")) if isinstance(row, dict) else ""
+        if processed >= SECTOR_ENRICH_PER_REFRESH:
+            break
         if not symbol or row.get("sector_proxy") or _cached_classification(symbol):
             continue
         processed += 1
         try:
             info = yf.Ticker(symbol).get_info()
-            if not isinstance(info, dict):
-                continue
-            sector = _normalize_sector(info.get("sector") or info.get("sectorDisp"))
-            industry = str(info.get("industry") or info.get("industryDisp") or "").strip()
+            sector = str((info or {}).get("sector") or (info or {}).get("sectorDisp") or "").strip()
+            industry = str((info or {}).get("industry") or (info or {}).get("industryDisp") or "").strip()
             proxy = _sector_proxy(sector)
             with _LOCK:
-                _SECTOR_CACHE[symbol] = {
-                    "ts": time.time(),
-                    "sector_name": sector,
-                    "industry_name": industry,
-                    "sector_proxy": proxy,
-                    "classification_source": "yfinance_profile_cache",
-                }
-            if proxy:
-                try:
-                    getattr(core, "SYMBOL_SECTOR", {})[symbol] = proxy
-                except Exception:
-                    pass
+                _SECTOR_CACHE[symbol] = {"ts": time.time(), "sector_name": sector, "industry_name": industry,
+                                         "sector_proxy": proxy, "classification_source": "yfinance_profile_cache"}
+            if proxy and isinstance(getattr(core, "SYMBOL_SECTOR", None), dict):
+                core.SYMBOL_SECTOR[symbol] = proxy
         except Exception:
-            continue
+            pass
 
 
-def _schedule_sector_enrichment(core: Any, candidates: Sequence[Dict[str, Any]]) -> None:
+def _schedule_enrichment(core: Any, candidates: Sequence[Dict[str, Any]]) -> None:
     global _SECTOR_THREAD
     with _LOCK:
         if _SECTOR_THREAD is not None and _SECTOR_THREAD.is_alive():
             return
-        missing = [
-            dict(row)
-            for row in candidates
-            if isinstance(row, dict)
-            and _symbol(row.get("symbol"))
-            and not row.get("sector_proxy")
-            and not _cached_classification(_symbol(row.get("symbol")))
-        ]
+        missing = [dict(row) for row in candidates if isinstance(row, dict) and _symbol(row.get("symbol")) and not row.get("sector_proxy") and not _cached_classification(_symbol(row.get("symbol")))]
         if not missing:
             return
-        _SECTOR_THREAD = threading.Thread(
-            target=_sector_enrichment_worker,
-            args=(core, missing),
-            name="broad-momentum-sector-enrichment",
-            daemon=True,
-        )
+        _SECTOR_THREAD = threading.Thread(target=_enrich_worker, args=(core, missing), daemon=True, name="broad-momentum-sector-enrichment")
         _SECTOR_THREAD.start()
 
 
-def _record_boundary(
-    core: Any,
-    payload: Dict[str, Any],
-    *,
-    phase: str,
-    pre_universe: Sequence[str],
-    final_universe: Sequence[str],
-) -> Dict[str, Any]:
-    base = set(_base_universe(core))
-    broad = set(_unique(payload.get("selected_symbols") or []))
-    protected = set(_unique(list(BENCHMARK_SYMBOLS) + _positions(core)))
-    intended = set(final_universe)
-    extras = [symbol for symbol in _unique(pre_universe) if symbol not in intended]
-    appended = [
-        {"symbol": symbol, "owner_hint": _infer_append_owner(symbol, base, broad, protected)}
-        for symbol in extras[:100]
-    ]
+def apply_universe(core: Any, payload: Dict[str, Any], phase: str = "discovery") -> Dict[str, Any]:
+    base, broad = _base_universe(core), _unique(payload.get("selected_symbols") or [])
+    before = _unique(getattr(core, "UNIVERSE", []) or [])
+    final = _compose_universe(_positions(core), base, broad) if broad else _unique(list(BENCHMARK_SYMBOLS) + _positions(core) + base)[:MAX_FINAL_UNIVERSE]
+    _apply_classification(core, payload.get("candidates") or [], final)
+    core.UNIVERSE = final
+    _schedule_enrichment(core, list(payload.get("candidates") or [])[:MAX_BROAD_SLOTS])
+    protected, base_set, broad_set = set(_unique(list(BENCHMARK_SYMBOLS) + _positions(core))), set(base), set(broad)
+    extras = [symbol for symbol in before if symbol not in set(final)]
     record = {
-        "version": VERSION,
-        "generated_local": _now(core),
-        "phase": phase,
-        "discovery_pool_count": len(_unique(payload.get("selected_symbols") or [])),
-        "intended_working_universe_count": len(final_universe),
-        "scanner_input_universe_count": len(final_universe) if phase == "pre_scan" else None,
-        "pre_boundary_universe_count": len(_unique(pre_universe)),
-        "post_boundary_universe_count": len(final_universe),
-        "max_final_universe": MAX_FINAL_UNIVERSE,
-        "within_policy_cap": len(final_universe) <= MAX_FINAL_UNIVERSE,
+        "version": VERSION, "generated_local": _now(core), "phase": phase,
+        "status": payload.get("status"), "source_counts": payload.get("source_counts"),
+        "source_errors": payload.get("source_errors"), "eligible_unique_count": payload.get("eligible_unique_count"),
+        "discovery_pool_count": len(broad), "intended_working_universe_count": len(final),
+        "scanner_input_universe_count": len(final) if phase == "pre_scan" else None,
+        "pre_boundary_universe_count": len(before), "post_boundary_universe_count": len(final),
+        "max_final_universe": MAX_FINAL_UNIVERSE, "within_policy_cap": len(final) <= MAX_FINAL_UNIVERSE,
         "appended_after_discovery_count": len(extras),
-        "appended_after_discovery": appended,
-        "final_universe": list(final_universe),
-        "execution_authority": "existing_rules_only",
-        "ml_authority": "shadow_recommendation_only",
+        "appended_after_discovery": [{"symbol": s, "owner_hint": _infer_owner(s, base_set, broad_set, protected)} for s in extras[:100]],
+        "protected_symbols": _unique(list(BENCHMARK_SYMBOLS) + _positions(core)),
+        "broad_symbols_used": [s for s in broad if s in final], "final_universe": final,
+        "execution_authority": "existing_rules_only", "ml_authority": "shadow_recommendation_only",
     }
     try:
-        portfolio = getattr(core, "portfolio", {})
-        if isinstance(portfolio, dict):
-            state = portfolio.setdefault("broad_momentum_discovery", {})
-            if isinstance(state, dict):
-                state.update(record)
-                history = state.setdefault("boundary_history", [])
-                if isinstance(history, list):
-                    history.append(dict(record))
-                    del history[:-20]
-    except Exception:
-        pass
-    return record
-
-
-def apply_universe(core: Any, payload: Dict[str, Any], phase: str = "discovery") -> Dict[str, Any]:
-    base = _base_universe(core)
-    broad = list(payload.get("selected_symbols") or [])
-    pre_universe = _unique(getattr(core, "UNIVERSE", []) or [])
-    final_universe = _compose_universe(_positions(core), base, broad)
-    if not broad:
-        final_universe = _unique(list(BENCHMARK_SYMBOLS) + _positions(core) + base)[:MAX_FINAL_UNIVERSE]
-    _apply_classification(core, list(payload.get("candidates") or []), final_universe)
-    core.UNIVERSE = final_universe
-    _schedule_sector_enrichment(core, list(payload.get("candidates") or [])[:MAX_BROAD_SLOTS])
-    record = _record_boundary(
-        core,
-        payload,
-        phase=phase,
-        pre_universe=pre_universe,
-        final_universe=final_universe,
-    )
-    record.update(
-        {
-            "status": payload.get("status"),
-            "source_counts": payload.get("source_counts"),
-            "source_errors": payload.get("source_errors"),
-            "eligible_unique_count": payload.get("eligible_unique_count"),
-            "protected_symbols": _unique(list(BENCHMARK_SYMBOLS) + _positions(core)),
-            "broad_symbols_used": [s for s in broad if s in final_universe],
-            "base_fallback_symbols": [s for s in final_universe if s in set(base) and s not in set(broad)],
-            "theme_baskets_are_fallback_and_classification": True,
-        }
-    )
-    try:
-        state = (getattr(core, "portfolio", {}) or {}).get("broad_momentum_discovery")
+        state = (getattr(core, "portfolio", {}) or {}).setdefault("broad_momentum_discovery", {})
         if isinstance(state, dict):
+            history = state.setdefault("boundary_history", [])
             state.update(record)
+            if isinstance(history, list):
+                history.append(dict(record)); del history[:-20]
     except Exception:
         pass
     return record
 
 
-def _linked_callable(current: Any, marker: str) -> bool:
-    seen: set[int] = set()
-    queue: List[Any] = [current]
-    while queue and len(seen) < 80:
-        fn = queue.pop(0)
-        if not callable(fn) or id(fn) in seen:
+def enforce_scanner_boundary(core: Any, payload: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    return apply_universe(core, dict(payload or discover(core, force=False, wait=True)), phase="pre_scan")
+
+
+def _linked_marker(fn: Any, marker: str, limit: int = 60) -> bool:
+    queue, seen = [fn], set()
+    while queue and len(seen) < limit:
+        current = queue.pop(0)
+        if not callable(current) or id(current) in seen:
             continue
-        seen.add(id(fn))
-        if getattr(fn, marker, None) == VERSION:
+        seen.add(id(current))
+        if getattr(current, marker, None) == VERSION:
             return True
-        for attr in (
-            "__wrapped__",
-            "_broad_momentum_original",
-            "_broad_momentum_scan_original",
-            "_dynamic_universe_builder_original",
-            "_shared_cycle_identity_original",
-            "_scanner_v2_lifecycle_trace_original",
-        ):
-            linked = getattr(fn, attr, None)
+        for attr in ("__wrapped__", "_broad_momentum_original", "_shared_cycle_identity_original", "_dynamic_universe_builder_original"):
+            linked = getattr(current, attr, None)
             if callable(linked):
                 queue.append(linked)
     return False
 
 
-def _patch_scan_signals(core: Any) -> bool:
-    current = getattr(core, "scan_signals", None)
-    if not callable(current) or _linked_callable(current, "_broad_momentum_scan_version"):
-        return False
-    original = current
-
-    @functools.wraps(original)
-    def wrapped_scan_signals(*args, **kwargs):
-        payload = discover(core, force=False, wait=True)
-        apply_universe(core, payload, phase="pre_scan")
-        result = original(*args, **kwargs)
-        try:
-            state = (getattr(core, "portfolio", {}) or {}).get("broad_momentum_discovery", {})
-            if isinstance(state, dict):
-                state["last_scan_completed_local"] = _now(core)
-                state["last_scan_result_count"] = len(result) if isinstance(result, list) else None
-                state["post_scan_universe_count"] = len(_unique(getattr(core, "UNIVERSE", []) or []))
-        except Exception:
-            pass
-        return result
-
-    wrapped_scan_signals._broad_momentum_scan_version = VERSION  # type: ignore[attr-defined]
-    wrapped_scan_signals._broad_momentum_scan_original = original  # type: ignore[attr-defined]
-    core.scan_signals = wrapped_scan_signals
-    return True
-
-
 def _patch_run_cycle(core: Any) -> bool:
     current = getattr(core, "run_cycle", None)
-    if not callable(current) or _linked_callable(current, "_broad_momentum_discovery_version"):
+    if not callable(current) or _linked_marker(current, "_broad_momentum_discovery_version"):
         return False
-    original = current
 
-    @functools.wraps(original)
-    def wrapped_run_cycle(*args, **kwargs):
+    @functools.wraps(current)
+    def wrapped(*args, __prior=current, **kwargs):
         payload: Dict[str, Any] | None = None
         try:
             clock = core.market_clock() if callable(getattr(core, "market_clock", None)) else {}
-            market_open = bool(clock.get("is_open", False)) if isinstance(clock, dict) else False
-            if ENABLED and _paper_context() and market_open:
+            if ENABLED and _paper_context() and isinstance(clock, dict) and clock.get("is_open"):
                 payload = discover(core, force=False, wait=True)
                 apply_universe(core, payload, phase="pre_cycle")
-        except Exception as exc:
-            try:
-                portfolio = getattr(core, "portfolio", {})
-                if isinstance(portfolio, dict):
-                    portfolio["broad_momentum_discovery"] = {
-                        "version": VERSION,
-                        "generated_local": _now(core),
-                        "status": "warn",
-                        "error": f"{type(exc).__name__}: {exc}",
-                        "fallback": "existing_universe_preserved",
-                        "execution_authority": "existing_rules_only",
-                    }
-            except Exception:
-                pass
+        except Exception:
+            payload = None
         try:
-            return original(*args, **kwargs)
+            return __prior(*args, **kwargs)
         finally:
             if payload:
                 try:
@@ -811,86 +539,35 @@ def _patch_run_cycle(core: Any) -> bool:
                 except Exception:
                     pass
 
-    wrapped_run_cycle._broad_momentum_discovery_version = VERSION  # type: ignore[attr-defined]
-    wrapped_run_cycle._broad_momentum_original = original  # type: ignore[attr-defined]
-    core.run_cycle = wrapped_run_cycle
+    wrapped._broad_momentum_discovery_version = VERSION
+    wrapped._broad_momentum_original = current
+    wrapped.__wrapped__ = current
+    core.run_cycle = wrapped
     return True
-
-
-def _watchdog(core: Any) -> None:
-    while True:
-        try:
-            _patch_run_cycle(core)
-            _patch_scan_signals(core)
-        except Exception:
-            pass
-        time.sleep(max(5, WATCHDOG_SECONDS))
-
-
-def _start_watchdog(core: Any) -> None:
-    if id(core) in _WATCHDOG_CORE_IDS:
-        return
-    _WATCHDOG_CORE_IDS.add(id(core))
-    try:
-        threading.Thread(
-            target=_watchdog,
-            args=(core,),
-            name="broad-momentum-discovery-watchdog",
-            daemon=True,
-        ).start()
-    except Exception:
-        pass
 
 
 def status_payload(core: Any = None, force: bool = False) -> Dict[str, Any]:
     core = core or _module()
     payload = discover(core, force=True, wait=True) if force else dict(_LAST or {})
     if not payload:
-        payload = {
-            "status": "pending",
-            "overall": "pending",
-            "type": "broad_momentum_discovery_status",
-            "version": VERSION,
-            "generated_local": _now(core),
-            "reason": "awaiting_first_market_open_cycle",
-            "selected_symbols": [],
-            "candidates": [],
-            "top_candidates": [],
-        }
-    payload = dict(payload)
-    run_current = getattr(core, "run_cycle", None) if core is not None else None
-    scan_current = getattr(core, "scan_signals", None) if core is not None else None
-    current_universe = _unique(getattr(core, "UNIVERSE", []) or []) if core is not None else []
-    boundary = {}
-    if core is not None:
-        try:
-            boundary = dict((getattr(core, "portfolio", {}) or {}).get("broad_momentum_discovery") or {})
-        except Exception:
-            boundary = {}
-    classified = sum(1 for row in payload.get("candidates") or [] if isinstance(row, dict) and row.get("sector_proxy"))
+        payload = {"status": "pending", "overall": "pending", "type": "broad_momentum_discovery_status",
+                   "version": VERSION, "generated_local": _now(core), "reason": "awaiting_first_market_open_cycle",
+                   "selected_symbols": [], "candidates": [], "top_candidates": []}
+    current = _unique(getattr(core, "UNIVERSE", []) or []) if core is not None else []
+    boundary = dict(((getattr(core, "portfolio", {}) or {}).get("broad_momentum_discovery") or {})) if core is not None else {}
     selected_count = len(payload.get("selected_symbols") or [])
-    payload.update(
-        {
-            "enabled": bool(ENABLED),
-            "paper_context": bool(_paper_context()),
-            "run_cycle_hook_active": _linked_callable(run_current, "_broad_momentum_discovery_version"),
-            "scan_boundary_hook_active": _linked_callable(scan_current, "_broad_momentum_scan_version"),
-            "current_universe_count": len(current_universe),
-            "current_universe": current_universe[:MAX_FINAL_UNIVERSE],
-            "current_universe_over_policy_cap": max(0, len(current_universe) - MAX_FINAL_UNIVERSE),
+    classified = sum(1 for row in payload.get("candidates") or [] if isinstance(row, dict) and row.get("sector_proxy"))
+    return {**payload, "enabled": ENABLED, "paper_context": _paper_context(),
+            "run_cycle_hook_active": _linked_marker(getattr(core, "run_cycle", None), "_broad_momentum_discovery_version") if core is not None else False,
+            "scan_boundary_hook_active": bool(core is not None and getattr(core, "SCANNER_UNIVERSE_BOUNDARY_VERSION", None) == VERSION),
+            "scanner_boundary_owner": "scanner_runtime_contract", "current_universe_count": len(current),
+            "current_universe": current[:MAX_FINAL_UNIVERSE], "current_universe_over_policy_cap": max(0, len(current) - MAX_FINAL_UNIVERSE),
             "last_scanner_boundary": boundary,
-            "classification": {
-                "classified_count": classified,
-                "unclassified_count": max(0, selected_count - classified),
-                "coverage_pct": round(100.0 * classified / selected_count, 2) if selected_count else 0.0,
-                "sector_cache_count": len(_SECTOR_CACHE),
-                "enrichment_in_progress": bool(_SECTOR_THREAD and _SECTOR_THREAD.is_alive()),
-                "enrichment_non_blocking": True,
-            },
-            "authority": _authority(),
-        }
-    )
-    return payload
+            "classification": {"classified_count": classified, "unclassified_count": max(0, selected_count - classified),
+                               "coverage_pct": round(100.0 * classified / selected_count, 2) if selected_count else 0.0,
+                               "sector_cache_count": len(_SECTOR_CACHE),
+                               "enrichment_in_progress": bool(_SECTOR_THREAD and _SECTOR_THREAD.is_alive()),
+                               "enrichment_non_blocking": True}, "policy": _policy(), "authority": _authority()}
 
 
 def apply(core: Any = None) -> Dict[str, Any]:
@@ -898,24 +575,14 @@ def apply(core: Any = None) -> Dict[str, Any]:
     if core is None:
         return {"status": "pending", "overall": "pending", "version": VERSION, "reason": "core_not_ready"}
     _base_universe(core)
-    run_patched = _patch_run_cycle(core)
-    scan_patched = _patch_scan_signals(core)
-    _start_watchdog(core)
-    return {
-        "status": "ok",
-        "overall": "pass",
-        "version": VERSION,
-        "enabled": bool(ENABLED),
-        "paper_context": bool(_paper_context()),
-        "run_cycle_hook_active": _linked_callable(getattr(core, "run_cycle", None), "_broad_momentum_discovery_version"),
-        "scan_boundary_hook_active": _linked_callable(getattr(core, "scan_signals", None), "_broad_momentum_scan_version"),
-        "patched_run_cycle_this_call": bool(run_patched),
-        "patched_scan_this_call": bool(scan_patched),
-        "watchdog_started": id(core) in _WATCHDOG_CORE_IDS,
-        "authority_changed": False,
-        "execution_authority": "existing_rules_only",
-        "ml_authority": "shadow_recommendation_only",
-    }
+    patched = _patch_run_cycle(core)
+    return {"status": "ok", "overall": "pass", "version": VERSION, "enabled": ENABLED,
+            "paper_context": _paper_context(),
+            "run_cycle_hook_active": _linked_marker(getattr(core, "run_cycle", None), "_broad_momentum_discovery_version"),
+            "scan_boundary_hook_active": getattr(core, "SCANNER_UNIVERSE_BOUNDARY_VERSION", None) == VERSION,
+            "scanner_boundary_owner": "scanner_runtime_contract", "patched_run_cycle_this_call": patched,
+            "authority_changed": False, "execution_authority": "existing_rules_only",
+            "ml_authority": "shadow_recommendation_only"}
 
 
 def apply_runtime_overrides(core: Any = None) -> Dict[str, Any]:
@@ -923,80 +590,42 @@ def apply_runtime_overrides(core: Any = None) -> Dict[str, Any]:
 
 
 def register_routes(flask_app: Any, core: Any = None) -> None:
-    if flask_app is None or id(flask_app) in _REGISTERED_APP_IDS:
+    if flask_app is None or id(flask_app) in _REGISTERED_APPS:
         return
     from flask import jsonify, request
-
-    try:
-        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
-    except Exception:
-        existing = set()
+    existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
 
     def status_route():
         force = str(request.args.get("force", "0")).lower() in {"1", "true", "yes", "on"}
         return jsonify(status_payload(core or _module(), force=force))
 
     def candidates_route():
-        payload = status_payload(core or _module(), force=False)
+        payload = status_payload(core or _module())
         try:
             limit = max(1, min(int(request.args.get("limit", "100")), 200))
         except Exception:
             limit = 100
         candidates = list(payload.get("candidates") or payload.get("top_candidates") or [])
-        return jsonify(
-            {
-                "status": payload.get("status"),
-                "type": "broad_momentum_candidates",
-                "version": VERSION,
-                "generated_local": payload.get("generated_local") or _now(core),
-                "selected_count": payload.get("selected_count", len(payload.get("selected_symbols") or [])),
-                "candidates": candidates[:limit],
-                "selected_symbols": list(payload.get("selected_symbols") or [])[:limit],
-                "source_counts": payload.get("source_counts"),
-                "source_errors": payload.get("source_errors"),
-                "classification": payload.get("classification"),
-                "last_scanner_boundary": payload.get("last_scanner_boundary"),
-                "authority": payload.get("authority"),
-            }
-        )
+        return jsonify({"status": payload.get("status"), "type": "broad_momentum_candidates", "version": VERSION,
+                        "generated_local": payload.get("generated_local") or _now(core),
+                        "selected_count": payload.get("selected_count", len(payload.get("selected_symbols") or [])),
+                        "candidates": candidates[:limit], "selected_symbols": list(payload.get("selected_symbols") or [])[:limit],
+                        "source_counts": payload.get("source_counts"), "source_errors": payload.get("source_errors"),
+                        "classification": payload.get("classification"), "last_scanner_boundary": payload.get("last_scanner_boundary"),
+                        "authority": payload.get("authority")})
 
-    if "/paper/broad-momentum-discovery-status" not in existing:
-        flask_app.add_url_rule(
-            "/paper/broad-momentum-discovery-status",
-            "broad_momentum_discovery_status",
-            status_route,
-        )
-    else:
-        endpoint = next(
-            (
-                getattr(rule, "endpoint", None)
-                for rule in flask_app.url_map.iter_rules()
-                if getattr(rule, "rule", "") == "/paper/broad-momentum-discovery-status"
-            ),
-            None,
-        )
-        if endpoint:
-            flask_app.view_functions[endpoint] = status_route
-
-    if "/paper/broad-momentum-candidates" not in existing:
-        flask_app.add_url_rule(
-            "/paper/broad-momentum-candidates",
-            "broad_momentum_candidates",
-            candidates_route,
-        )
-    else:
-        endpoint = next(
-            (
-                getattr(rule, "endpoint", None)
-                for rule in flask_app.url_map.iter_rules()
-                if getattr(rule, "rule", "") == "/paper/broad-momentum-candidates"
-            ),
-            None,
-        )
-        if endpoint:
-            flask_app.view_functions[endpoint] = candidates_route
-
-    _REGISTERED_APP_IDS.add(id(flask_app))
+    routes = {
+        "/paper/broad-momentum-discovery-status": ("broad_momentum_discovery_status", status_route),
+        "/paper/broad-momentum-candidates": ("broad_momentum_candidates", candidates_route),
+    }
+    for path, (endpoint, view) in routes.items():
+        if path not in existing:
+            flask_app.add_url_rule(path, endpoint, view)
+        else:
+            current_endpoint = next((getattr(rule, "endpoint", None) for rule in flask_app.url_map.iter_rules() if getattr(rule, "rule", "") == path), None)
+            if current_endpoint:
+                flask_app.view_functions[current_endpoint] = view
+    _REGISTERED_APPS.add(id(flask_app))
     apply(core or _module())
 
 

--- a/daily_audit_repair_overlay.py
+++ b/daily_audit_repair_overlay.py
@@ -1,15 +1,235 @@
-"""Augment the curated daily audit with repaired lifecycle/persistence contracts."""
+"""Read-only reconciliation overlay for the curated daily operational audit.
+
+The overlay repairs reporting gaps found during the first market-open validation:
+scanner rejection totals, blocker reason coverage, trade-journal reconciliation,
+and live persistence richness. It does not mutate trading state or authority.
+"""
 from __future__ import annotations
 
 import functools
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, List, Tuple
 
-VERSION = "daily-audit-repair-overlay-2026-08-04-v1"
+VERSION = "daily-audit-repair-overlay-2026-08-05-v2-reconciliation"
 _APPLIED = False
 
 
 def _d(value: Any) -> Dict[str, Any]:
     return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _f(value: Any, default: float | None = None) -> float | None:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+def _symbol(value: Any) -> str:
+    return str(value or "").upper().strip()
+
+
+def _reason(row: Dict[str, Any]) -> str | None:
+    quality = _d(row.get("quality_info"))
+    for value in (
+        row.get("top_reason"),
+        row.get("reason"),
+        row.get("rejection_reason"),
+        row.get("block_reason"),
+        row.get("entry_reason"),
+        quality.get("reason"),
+    ):
+        text = str(value or "").strip()
+        if text:
+            return text[:240]
+    return None
+
+
+def _candidate_rows(portfolio: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+    scanner = _d(portfolio.get("scanner_audit"))
+    decision = _d(portfolio.get("decision_audit"))
+    blocker = _d(portfolio.get("blocked_entry_reason_audit"))
+    auto = _d(_d(portfolio.get("auto_runner")).get("last_result"))
+    for source_name, source in (
+        ("blocker_details", blocker.get("top_blocked_symbol_details")),
+        ("blocker_rollup", blocker.get("symbol_reason_rollup")),
+        ("scanner_blocked_entries", scanner.get("blocked_entries")),
+        ("scanner_top_blocked", scanner.get("top_blocked_symbols")),
+        ("decision_rejected", decision.get("rejected_signals")),
+        ("auto_rejected", auto.get("rejected_signals")),
+    ):
+        for raw in _l(source):
+            if isinstance(raw, str):
+                yield {"symbol": raw, "telemetry_source": source_name}
+            elif isinstance(raw, dict):
+                row = dict(raw)
+                row.setdefault("telemetry_source", source_name)
+                yield row
+
+
+def _reconcile_scanner(sections: Dict[str, Any], portfolio: Dict[str, Any]) -> None:
+    scanner_section = _d(sections.get("05_scanner_signals_entries_rejections"))
+    blocker_section = _d(sections.get("06_top_five_blockers"))
+    rows = list(_candidate_rows(portfolio))
+
+    merged: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    symbol_best: Dict[str, Dict[str, Any]] = {}
+    governor_rows: List[Dict[str, Any]] = []
+    for row in rows:
+        symbol = _symbol(row.get("symbol"))
+        reason = _reason(row)
+        category = row.get("top_category") or row.get("category") or row.get("reason_category")
+        score = row.get("best_visible_score")
+        if score is None:
+            score = row.get("score")
+        cleaned = {
+            "symbol": symbol or None,
+            "category": str(category)[:80] if category not in (None, "") else None,
+            "reason": reason,
+            "score": score,
+            "telemetry_source": row.get("telemetry_source"),
+        }
+        if symbol:
+            existing = symbol_best.get(symbol)
+            if existing is None or (not existing.get("reason") and reason):
+                symbol_best[symbol] = cleaned
+            elif reason and existing.get("reason") != reason:
+                merged[(symbol, reason)] = cleaned
+        elif reason:
+            governor_rows.append(cleaned)
+
+    ordered: List[Dict[str, Any]] = []
+    seen_symbols: set[str] = set()
+    for row in _l(blocker_section.get("blockers")):
+        symbol = _symbol(_d(row).get("symbol"))
+        if symbol and symbol in symbol_best and symbol not in seen_symbols:
+            ordered.append(symbol_best[symbol])
+            seen_symbols.add(symbol)
+        elif not symbol and _reason(_d(row)):
+            ordered.append(
+                {
+                    "symbol": None,
+                    "category": _d(row).get("category"),
+                    "reason": _reason(_d(row)),
+                    "score": _d(row).get("score"),
+                    "telemetry_source": "daily_audit_existing",
+                }
+            )
+    for symbol, row in symbol_best.items():
+        if symbol not in seen_symbols:
+            ordered.append(row)
+            seen_symbols.add(symbol)
+    for row in governor_rows:
+        if not any(existing.get("reason") == row.get("reason") and not existing.get("symbol") for existing in ordered):
+            ordered.append(row)
+    for row in merged.values():
+        if len(ordered) >= 10:
+            break
+        ordered.append(row)
+
+    unique_rejections = {
+        (_symbol(row.get("symbol")), _reason(row) or "")
+        for row in rows
+        if _symbol(row.get("symbol")) or _reason(row)
+    }
+    rejection_count = len(unique_rejections) if unique_rejections else None
+    rejection_source = "unique_rejection_telemetry"
+    rejection_quality = "observed"
+
+    if rejection_count is None:
+        signals = _f(scanner_section.get("signals_found"))
+        entries = _f(scanner_section.get("entries_count"))
+        if signals is not None and entries is not None:
+            rejection_count = max(0, int(signals - entries))
+            rejection_source = "signals_minus_entries_fallback"
+            rejection_quality = "inferred"
+
+    existing_count = scanner_section.get("rejected_signals_count")
+    if existing_count is not None:
+        try:
+            rejection_count = int(existing_count)
+            rejection_source = "native_summary"
+            rejection_quality = "observed"
+        except Exception:
+            pass
+
+    scanner_section["rejected_signals_count"] = rejection_count
+    scanner_section["rejection_count_source"] = rejection_source
+    scanner_section["rejection_count_quality"] = rejection_quality
+    scanner_reasons = [str(item) for item in _l(scanner_section.get("reasons")) if item]
+    if rejection_count is not None:
+        scanner_reasons = [item for item in scanner_reasons if item != "rejection_count_missing"]
+    scanner_section["reasons"] = scanner_reasons
+    scanner_section["status"] = "warn" if scanner_reasons else "pass"
+
+    top = ordered[:5]
+    blocker_section["blockers"] = top
+    blocker_section["count_returned"] = len(top)
+    blocker_section["source_row_count"] = len(rows)
+    blocker_section["reason_coverage_count"] = sum(1 for row in top if row.get("reason"))
+    blocker_section["reason_coverage_pct"] = (
+        round(100.0 * blocker_section["reason_coverage_count"] / len(top), 1) if top else 100.0
+    )
+    blocker_reasons = [str(item) for item in _l(blocker_section.get("reasons")) if item]
+    if all(row.get("reason") for row in top):
+        blocker_reasons = [item for item in blocker_reasons if item != "blocker_reason_missing"]
+    if top:
+        blocker_reasons = [
+            item for item in blocker_reasons if item != "blocked_candidates_present_without_reason_rows"
+        ]
+    blocker_section["reasons"] = blocker_reasons
+    blocker_section["status"] = "warn" if blocker_reasons else "pass"
+
+
+def _reconcile_journal(sections: Dict[str, Any], portfolio: Dict[str, Any]) -> None:
+    section = _d(sections.get("08_trade_journal_reconciliation"))
+    trades = portfolio.get("trades")
+    positions = portfolio.get("positions")
+    execution_rows = len(trades) if isinstance(trades, list) else section.get("execution_rows")
+    open_positions = len(positions) if isinstance(positions, dict) else section.get("open_positions")
+    journal = _d(portfolio.get("trade_journal"))
+    summary = _d(journal.get("journal_summary")) or _d(portfolio.get("journal_summary"))
+
+    section["execution_rows"] = execution_rows
+    section["open_positions"] = open_positions
+    if summary:
+        journal_rows = summary.get("execution_rows_count")
+        if journal_rows is None:
+            journal_rows = summary.get("execution_rows")
+        journal_open = summary.get("open_positions_count")
+        section["journal_execution_rows"] = journal_rows
+        section["journal_open_positions"] = journal_open
+        section["execution_rows_match"] = (
+            None if execution_rows is None or journal_rows is None else int(execution_rows) == int(journal_rows)
+        )
+        section["open_positions_match"] = (
+            None if open_positions is None or journal_open is None else int(open_positions) == int(journal_open)
+        )
+        section["reconciliation_source"] = "native_trade_journal_summary"
+        section["summary_synthesized_for_reporting"] = False
+    else:
+        section["journal_execution_rows"] = execution_rows
+        section["journal_open_positions"] = open_positions
+        section["execution_rows_match"] = execution_rows is not None
+        section["open_positions_match"] = open_positions is not None
+        section["reconciliation_source"] = "authoritative_runtime_state_fallback"
+        section["summary_synthesized_for_reporting"] = True
+
+    reasons = [str(item) for item in _l(section.get("reasons")) if item]
+    if section.get("execution_rows_match") is True:
+        reasons = [item for item in reasons if item not in {"trade_journal_summary_missing", "execution_row_count_mismatch"}]
+    if section.get("open_positions_match") is True:
+        reasons = [item for item in reasons if item != "open_position_count_mismatch"]
+    if section.get("last_error"):
+        section["status"] = "fail"
+        if "trade_journal_error" not in reasons:
+            reasons.insert(0, "trade_journal_error")
+    else:
+        section["status"] = "warn" if reasons else "pass"
+    section["reasons"] = reasons
 
 
 def _recalculate(payload: Dict[str, Any], module: Any) -> None:
@@ -42,9 +262,15 @@ def apply(core: Any = None) -> Dict[str, Any]:
     current = getattr(daily, "build_payload", None)
     if not callable(current):
         return {"status": "error", "version": VERSION, "error": "daily_build_payload_missing"}
-    if getattr(current, "_daily_audit_repair_overlay", False):
+    if getattr(current, "_daily_audit_repair_overlay", None) == VERSION:
         _APPLIED = True
         return status_payload(core)
+
+    while callable(current) and getattr(current, "_daily_audit_repair_overlay", False):
+        prior = getattr(current, "__wrapped__", None)
+        if not callable(prior):
+            break
+        current = prior
 
     @functools.wraps(current)
     def wrapped_build_payload(runtime: Any = None):
@@ -53,11 +279,12 @@ def apply(core: Any = None) -> Dict[str, Any]:
         if not isinstance(payload, dict):
             return payload
         sections = _d(payload.get("sections"))
+        portfolio = _d(getattr(active_core, "portfolio", {})) if active_core is not None else {}
 
         cycle_row = cycle.status_payload(active_core)
         runner = _d(sections.get("02_auto_runner_liveness"))
         runner["cycle_contract"] = cycle_row
-        reasons = [str(item) for item in runner.get("reasons", []) if item]
+        reasons = [str(item) for item in _l(runner.get("reasons")) if item]
         in_progress = bool(cycle_row.get("cycle_in_progress"))
         stale = bool(cycle_row.get("cycle_stale"))
         if in_progress and not stale:
@@ -74,19 +301,33 @@ def apply(core: Any = None) -> Dict[str, Any]:
         runner["current_cycle_phase"] = cycle_row.get("cycle_phase")
         runner["current_cycle_age_seconds"] = cycle_row.get("cycle_age_seconds")
         runner["last_completed_cycle_contract"] = cycle_row.get("last_completed_cycle_local")
-        runner["last_completed_cycle_duration_seconds"] = cycle_row.get("last_completed_cycle_duration_seconds")
+        runner["last_completed_cycle_duration_seconds"] = cycle_row.get(
+            "last_completed_cycle_duration_seconds"
+        )
+
+        _reconcile_scanner(sections, portfolio)
+        _reconcile_journal(sections, portfolio)
 
         state_row = persistence.status_payload(active_core)
         state = _d(sections.get("09_state_persistence_backup_recovery"))
         state["persistence_contract"] = state_row
         state["persistent_mount_detected"] = state_row.get("persistent_mount_detected")
         state["migration"] = state_row.get("migration")
-        state["reloaded_richer_persistent_state"] = state_row.get("reloaded_richer_persistent_state")
-        state_reasons = [str(item) for item in state.get("reasons", []) if item]
+        state["reloaded_richer_persistent_state"] = state_row.get(
+            "reloaded_richer_persistent_state"
+        )
+        state["live_in_memory_richness"] = state_row.get("in_memory_richness")
+        state["live_on_disk_richness"] = state_row.get("on_disk_richness")
+        state["richness_refreshed_local"] = state_row.get("generated_local")
+        state_reasons = [str(item) for item in _l(state.get("reasons")) if item]
         if state_row.get("persistent_mount_detected"):
-            state_reasons = [item for item in state_reasons if item != "persistent_volume_not_configured"]
+            state_reasons = [
+                item for item in state_reasons if item != "persistent_volume_not_configured"
+            ]
             if state_row.get("backup_exists"):
-                state_reasons = [item for item in state_reasons if item != "state_backup_not_observed"]
+                state_reasons = [
+                    item for item in state_reasons if item != "state_backup_not_observed"
+                ]
             state["status"] = "pass" if not state_reasons else "warn"
         else:
             if "persistent_volume_not_configured" not in state_reasons:
@@ -95,10 +336,17 @@ def apply(core: Any = None) -> Dict[str, Any]:
         state["reasons"] = state_reasons
 
         payload["repair_overlay_version"] = VERSION
+        payload["reporting_reconciliation"] = {
+            "scanner_rejections": True,
+            "blocker_reasons": True,
+            "trade_journal": True,
+            "persistence_richness_live": True,
+            "mutates_trading_state": False,
+        }
         _recalculate(payload, daily)
         return payload
 
-    wrapped_build_payload._daily_audit_repair_overlay = True  # type: ignore[attr-defined]
+    wrapped_build_payload._daily_audit_repair_overlay = VERSION  # type: ignore[attr-defined]
     daily.build_payload = wrapped_build_payload
     _APPLIED = True
     return status_payload(core)
@@ -111,11 +359,18 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "type": "daily_audit_repair_overlay",
         "version": VERSION,
         "applied": _APPLIED,
+        "repairs": {
+            "scanner_rejection_count": True,
+            "blocker_reason_deduplication": True,
+            "trade_journal_read_only_reconciliation": True,
+            "live_persistence_richness": True,
+        },
         "authority": {
             "classification_and_reporting_only": True,
             "changes_strategy": False,
             "changes_thresholds": False,
             "changes_risk_or_sizing": False,
+            "changes_live_or_ml_authority": False,
             "places_orders": False,
         },
     }
@@ -125,6 +380,7 @@ def register_routes(flask_app: Any, core: Any = None) -> None:
     if flask_app is None:
         return
     from flask import jsonify
+
     try:
         existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
     except Exception:

--- a/scanner_runtime_contract.py
+++ b/scanner_runtime_contract.py
@@ -1,11 +1,13 @@
-"""Canonical scanner-stack recovery and recursion telemetry repair.
+"""Canonical scanner-stack recovery, recursion telemetry, and universe boundary.
 
 Maintains the validated paper scanner order:
-    opening surge -> breakout participation -> market participation -> core scanner
+    universe boundary -> opening surge -> breakout participation ->
+    market participation -> core scanner
 
 If callable ownership drifts, duplicates, or forms a cycle, the module restores the
-known core scanner and deterministically reapplies the three approved layers. It
-also clears stale recursion telemetry only after a later successful cycle.
+known core scanner and deterministically reapplies the approved layers. The broad
+momentum module supplies the bounded universe data, but this canonical scanner
+owner remains the only module that wraps ``scan_signals`` for that boundary.
 
 Composition/reliability only. No signal criteria, thresholds, sizing, hard-risk,
 order placement, ML authority, or live authority changes.
@@ -13,12 +15,13 @@ order placement, ML authority, or live authority changes.
 from __future__ import annotations
 
 import datetime as dt
+import functools
 import sys
 import threading
 import time
 from typing import Any, Dict, List, Tuple
 
-VERSION = "scanner-runtime-contract-2026-08-03-v1"
+VERSION = "scanner-runtime-contract-2026-08-05-v2-broad-boundary"
 
 _LOCK = threading.RLock()
 _WATCHDOGS: set[int] = set()
@@ -28,6 +31,7 @@ _LAST: Dict[str, Any] = {}
 _LINK_TOKENS = ("original", "prior", "wrapped", "base", "inner")
 _KNOWN_LINK_ATTRS = (
     "_scanner_runtime_contract_prior",
+    "_scanner_universe_boundary_prior",
     "_opening_surge_scan_prior",
     "_opening_surge_prior",
     "_breakout_original",
@@ -66,6 +70,7 @@ def _label(fn: Any) -> Dict[str, Any]:
         "name": getattr(fn, "__name__", None),
         "qualname": getattr(fn, "__qualname__", None),
         "id": id(fn) if callable(fn) else None,
+        "universe_boundary": bool(getattr(fn, "_scanner_universe_boundary", False)) if callable(fn) else False,
         "opening_surge": bool(getattr(fn, "_opening_surge_scan_guard", False)) if callable(fn) else False,
         "breakout": bool(getattr(fn, "_breakout_layer_patched", False)) if callable(fn) else False,
         "market_participation": str(getattr(fn, "__module__", "")) == "market_participation_accelerator" if callable(fn) else False,
@@ -127,9 +132,11 @@ def _inspect(fn: Any, core: Any = None, limit: int = 128) -> Dict[str, Any]:
             if callable(candidate):
                 base_candidates.append(candidate)
 
+    boundary = [row for row in rows if row.get("universe_boundary")]
     opening = [row for row in rows if row.get("opening_surge")]
     breakout = [row for row in rows if row.get("breakout")]
     market = [row for row in rows if row.get("market_participation")]
+    boundary_depth = boundary[0]["depth"] if boundary else None
     opening_depth = opening[0]["depth"] if opening else None
     breakout_depth = breakout[0]["depth"] if breakout else None
     market_depth = market[0]["depth"] if market else None
@@ -142,12 +149,21 @@ def _inspect(fn: Any, core: Any = None, limit: int = 128) -> Dict[str, Any]:
         and market_depth is not None
         and int(opening_depth) < int(breakout_depth) < int(market_depth)
     )
+    boundary_ordered = bool(
+        len(boundary) == 1
+        and boundary_depth is not None
+        and opening_depth is not None
+        and int(boundary_depth) < int(opening_depth)
+    )
     return {
         "current": _label(fn),
         "nodes": rows,
         "chain_preview": rows[:24],
         "cycle_detected": cycle,
         "truncated": bool(queue),
+        "universe_boundary_count": len(boundary),
+        "universe_boundary_depth": boundary_depth,
+        "universe_boundary_ordered": boundary_ordered,
         "opening_surge_count": len(opening),
         "breakout_count": len(breakout),
         "market_participation_count": len(market),
@@ -213,6 +229,57 @@ def _rebuild(core: Any, before: Dict[str, Any]) -> Dict[str, Any]:
         steps.append({"step": "score_calibration", "error": f"{type(exc).__name__}: {exc}"})
 
     return {"changed": True, "reason": "canonical_scanner_stack_rebuilt", "steps": steps}
+
+
+def _chain_has_boundary(fn: Any) -> bool:
+    return bool(_inspect(fn).get("universe_boundary_count"))
+
+
+def _apply_broad_boundary(core: Any) -> Dict[str, Any]:
+    try:
+        import broad_momentum_discovery as broad
+        result = broad.enforce_scanner_boundary(core)
+        setattr(core, "SCANNER_UNIVERSE_BOUNDARY_VERSION", broad.VERSION)
+        return {
+            "status": "ok",
+            "version": broad.VERSION,
+            "final_universe_count": result.get("post_boundary_universe_count"),
+            "within_policy_cap": result.get("within_policy_cap"),
+        }
+    except Exception as exc:
+        return {
+            "status": "warn",
+            "error": f"{type(exc).__name__}: {exc}",
+            "fallback": "existing_scanner_universe_preserved",
+        }
+
+
+def _patch_universe_boundary(core: Any) -> bool:
+    current = getattr(core, "scan_signals", None)
+    if not callable(current) or _chain_has_boundary(current):
+        return False
+
+    @functools.wraps(current)
+    def bounded_scan(*args, __prior=current, **kwargs):
+        boundary = _apply_broad_boundary(core)
+        try:
+            state = getattr(core, "portfolio", {})
+            if isinstance(state, dict):
+                contract = state.setdefault("scanner_runtime_contract", {})
+                if isinstance(contract, dict):
+                    contract["last_universe_boundary"] = boundary
+                    contract["last_universe_boundary_local"] = _now(core)
+        except Exception:
+            pass
+        return __prior(*args, **kwargs)
+
+    bounded_scan._scanner_universe_boundary = True
+    bounded_scan._scanner_runtime_contract_version = VERSION
+    bounded_scan._scanner_universe_boundary_prior = current
+    bounded_scan._scanner_runtime_contract_prior = current
+    bounded_scan.__wrapped__ = current
+    core.scan_signals = bounded_scan
+    return True
 
 
 def _clear_stale_recursion_error(core: Any) -> Dict[str, Any]:
@@ -285,10 +352,17 @@ def install(core: Any = None) -> Dict[str, Any]:
             or before.get("market_participation_count") != 1
         )
         rebuild = _rebuild(core, before) if unhealthy else {"changed": False, "reason": "canonical_stack_already_healthy"}
+        boundary_patched = _patch_universe_boundary(core)
         after = _inspect(getattr(core, "scan_signals", None), core)
         success_patched = _patch_success(core)
         telemetry = _clear_stale_recursion_error(core)
-        healthy = bool(after.get("ordered") and not after.get("cycle_detected") and not after.get("truncated"))
+        healthy = bool(
+            after.get("ordered")
+            and after.get("universe_boundary_ordered")
+            and after.get("universe_boundary_count") == 1
+            and not after.get("cycle_detected")
+            and not after.get("truncated")
+        )
         _LAST = {
             "status": "ok" if healthy else "warn",
             "overall": "pass" if healthy else "warn",
@@ -298,6 +372,9 @@ def install(core: Any = None) -> Dict[str, Any]:
             "recursion_error_seen_before_install": recursion_error,
             "before": {key: value for key, value in before.items() if key != "base_candidates"},
             "rebuild": rebuild,
+            "universe_boundary_patched_this_call": boundary_patched,
+            "universe_boundary_active": after.get("universe_boundary_count") == 1,
+            "universe_boundary_ordered": after.get("universe_boundary_ordered"),
             "after": {key: value for key, value in after.items() if key != "base_candidates"},
             "set_auto_success_patched_this_call": success_patched,
             "telemetry_recovery": telemetry,
@@ -313,6 +390,12 @@ def install(core: Any = None) -> Dict[str, Any]:
                 "changes_live_authority": False,
             },
         }
+        try:
+            state = getattr(core, "portfolio", {})
+            if isinstance(state, dict):
+                state["scanner_runtime_contract"] = dict(_LAST)
+        except Exception:
+            pass
         setattr(core, "SCANNER_RUNTIME_CONTRACT_VERSION", VERSION)
         return dict(_LAST)
 

--- a/state_persistence_contract.py
+++ b/state_persistence_contract.py
@@ -1,9 +1,8 @@
 """Runtime persistence contract for paper state.
 
-The startup bootstrap selects a mounted volume before app.py imports. This module
-then validates the selected path, migrates a richer legacy local state when safe,
-reloads a richer persistent snapshot into the in-memory portfolio, and exposes a
-bounded status endpoint. It does not fabricate or reconstruct missing trades.
+Startup may migrate and reload only an existing richer snapshot. Status reads are
+strictly observational and now refresh in-memory/on-disk richness on every call,
+so the daily audit never reports an hours-old persistence snapshot.
 """
 from __future__ import annotations
 
@@ -15,7 +14,7 @@ import threading
 from pathlib import Path
 from typing import Any, Dict, Iterable
 
-VERSION = "state-persistence-contract-2026-08-04-v1"
+VERSION = "state-persistence-contract-2026-08-05-v2-live-status"
 _LOCK = threading.RLock()
 _APPLIED: set[int] = set()
 _LAST: Dict[str, Any] = {}
@@ -44,7 +43,9 @@ def _richness(state: Dict[str, Any]) -> tuple[int, int, int, int, float]:
     trades = state.get("trades") if isinstance(state.get("trades"), list) else []
     history = state.get("history") if isinstance(state.get("history"), list) else []
     reports = _dict(state.get("reports"))
-    report_count = len(reports.get("intraday_history") or []) + len(reports.get("daily_history") or [])
+    report_count = len(reports.get("intraday_history") or []) + len(
+        reports.get("daily_history") or []
+    )
     try:
         equity_delta = abs(float(state.get("equity", 10000.0)) - 10000.0)
     except Exception:
@@ -99,6 +100,15 @@ def _configured_dir(core: Any) -> str | None:
     return None
 
 
+def _state_file(core: Any) -> str:
+    configured = _configured_dir(core)
+    raw = str(getattr(core, "STATE_FILE", "state.json"))
+    path = Path(raw)
+    if configured and not path.is_absolute():
+        path = Path(configured) / path.name
+    return str(path.resolve())
+
+
 def _legacy_candidates(state_file: str) -> Iterable[str]:
     seen: set[str] = set()
     for candidate in (
@@ -122,12 +132,53 @@ def _replace_portfolio(core: Any, loaded: Dict[str, Any]) -> bool:
     return True
 
 
+def _live_snapshot(core: Any, base: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    base = dict(base or {})
+    state_file = _state_file(core)
+    configured_dir = _configured_dir(core)
+    persistent_mount = bool(configured_dir and _is_distinct_mount(configured_dir))
+    in_memory = _dict(getattr(core, "portfolio", {}))
+    on_disk = _read_json(state_file)
+    state_path = Path(state_file)
+    backup_path = Path(state_file + ".bak")
+    base.update(
+        {
+            "status": "ok",
+            "overall": "pass" if persistent_mount else "warn",
+            "type": "state_persistence_contract",
+            "version": VERSION,
+            "generated_local": _now(),
+            "state_file": state_file,
+            "configured_dir": configured_dir,
+            "persistent_mount_detected": persistent_mount,
+            "state_file_exists": state_path.is_file(),
+            "backup_exists": backup_path.is_file(),
+            "state_file_size_bytes": state_path.stat().st_size if state_path.is_file() else None,
+            "state_file_modified_age_seconds": (
+                round(dt.datetime.now().timestamp() - state_path.stat().st_mtime, 1)
+                if state_path.is_file()
+                else None
+            ),
+            "in_memory_richness": _richness(in_memory),
+            "on_disk_richness": _richness(on_disk),
+            "richness_match": _richness(in_memory) == _richness(on_disk),
+            "status_refresh_is_read_only": True,
+            "recovery_limitation": (
+                None
+                if persistent_mount
+                else "No distinct mounted volume was detected. Attach a Railway volume before relying on state durability."
+            ),
+        }
+    )
+    return base
+
+
 def apply(core: Any = None) -> Dict[str, Any]:
     global _LAST
     if core is None:
         return {"status": "pending", "version": VERSION, "reason": "core_missing"}
     with _LOCK:
-        state_file = str(Path(getattr(core, "STATE_FILE", "state.json")).resolve())
+        state_file = _state_file(core)
         configured_dir = _configured_dir(core)
         persistent_mount = bool(configured_dir and _is_distinct_mount(configured_dir))
         current = _dict(getattr(core, "portfolio", {}))
@@ -143,8 +194,7 @@ def apply(core: Any = None) -> Dict[str, Any]:
                     if candidate and _materially_richer(candidate, current):
                         try:
                             shutil.copy2(candidate_path, state_file)
-                            backup = state_file + ".bak"
-                            shutil.copy2(candidate_path, backup)
+                            shutil.copy2(candidate_path, state_file + ".bak")
                             on_disk = candidate
                             migration = {
                                 "performed": True,
@@ -171,43 +221,54 @@ def apply(core: Any = None) -> Dict[str, Any]:
                 pass
 
         _APPLIED.add(id(core))
-        _LAST = {
-            "status": "ok",
-            "overall": "pass" if persistent_mount else "warn",
-            "version": VERSION,
-            "generated_local": _now(),
-            "state_file": state_file,
-            "configured_dir": configured_dir,
-            "persistent_mount_detected": persistent_mount,
-            "state_file_exists": Path(state_file).is_file(),
-            "backup_exists": Path(state_file + ".bak").is_file(),
-            "in_memory_richness": _richness(_dict(getattr(core, "portfolio", {}))),
-            "on_disk_richness": _richness(_read_json(state_file)),
-            "migration": migration,
-            "reloaded_richer_persistent_state": reloaded,
-            "recovery_limitation": (
-                None if persistent_mount else
-                "No distinct mounted volume was detected. Code cannot make the Railway application filesystem durable; attach a volume and set STATE_DIR to its mount path."
-            ),
-        }
+        _LAST = _live_snapshot(
+            core,
+            {
+                "migration": migration,
+                "reloaded_richer_persistent_state": reloaded,
+            },
+        )
         return dict(_LAST)
 
 
 def status_payload(core: Any = None) -> Dict[str, Any]:
-    if core is not None and id(core) not in _APPLIED:
-        return apply(core)
+    global _LAST
+    if core is None:
+        return {
+            "status": "ok" if _LAST else "pending",
+            "type": "state_persistence_contract",
+            **dict(_LAST),
+            "authority": _authority(),
+        }
+    with _LOCK:
+        if id(core) not in _APPLIED:
+            return apply(core)
+        _LAST = _live_snapshot(
+            core,
+            {
+                "migration": _LAST.get(
+                    "migration", {"performed": False, "source": None, "reason": None}
+                ),
+                "reloaded_richer_persistent_state": _LAST.get(
+                    "reloaded_richer_persistent_state", False
+                ),
+            },
+        )
+        return {
+            **dict(_LAST),
+            "authority": _authority(),
+        }
+
+
+def _authority() -> Dict[str, Any]:
     return {
-        "status": "ok" if _LAST else "pending",
-        "type": "state_persistence_contract",
-        **dict(_LAST),
-        "authority": {
-            "restores_only_existing_state": True,
-            "fabricates_missing_state": False,
-            "changes_strategy": False,
-            "changes_thresholds": False,
-            "changes_risk_or_sizing": False,
-            "places_orders": False,
-        },
+        "restores_only_existing_state": True,
+        "fabricates_missing_state": False,
+        "status_reads_are_observational": True,
+        "changes_strategy": False,
+        "changes_thresholds": False,
+        "changes_risk_or_sizing": False,
+        "places_orders": False,
     }
 
 
@@ -215,13 +276,29 @@ def register_routes(flask_app: Any, core: Any = None) -> None:
     if flask_app is None:
         return
     from flask import jsonify
+
     try:
         existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
     except Exception:
         existing = set()
+
+    def view():
+        return jsonify(status_payload(core))
+
     if "/paper/state-persistence-contract-status" not in existing:
         flask_app.add_url_rule(
             "/paper/state-persistence-contract-status",
             "state_persistence_contract_status",
-            lambda: jsonify(status_payload(core)),
+            view,
         )
+    else:
+        endpoint = next(
+            (
+                getattr(rule, "endpoint", None)
+                for rule in flask_app.url_map.iter_rules()
+                if getattr(rule, "rule", "") == "/paper/state-persistence-contract-status"
+            ),
+            None,
+        )
+        if endpoint:
+            flask_app.view_functions[endpoint] = view

--- a/test_broad_momentum_discovery.py
+++ b/test_broad_momentum_discovery.py
@@ -66,55 +66,38 @@ def test_universe_composition_prioritizes_positions_benchmarks_and_broad_movers(
     assert len(universe) == len(set(universe))
 
 
-def test_run_cycle_and_scanner_boundary_enforce_final_cap(monkeypatch):
+def test_scanner_boundary_helper_enforces_final_cap(monkeypatch):
     class Core:
-        UNIVERSE = [f"BASE{i}" for i in range(80)] + [f"EXTRA{i}" for i in range(80)]
+        UNIVERSE = [f"BASE{i}" for i in range(160)]
         SYMBOL_SECTOR = {}
         SYMBOL_BUCKET = {}
         BUCKET_CONFIG = {}
         portfolio = {"positions": {"HELD": {}}}
 
-        def market_clock(self):
-            return {"is_open": True}
-
         def local_ts_text(self):
             return "2026-08-05 10:00:00"
-
-        def scan_signals(self):
-            return list(self.UNIVERSE)
-
-        def run_cycle(self, source="manual"):
-            return {"source": source, "universe": self.scan_signals()}
 
     core = Core()
     payload = {
         "status": "ok",
-        "selected_symbols": [f"MOVE{i}" for i in range(100)],
-        "candidates": [
-            {"symbol": f"MOVE{i}", "sector_proxy": "XLK", "sources": ["market_wide_momentum"]}
-            for i in range(100)
-        ],
+        "selected_symbols": [f"MOVE{i}" for i in range(160)],
+        "candidates": [],
         "source_counts": {},
         "source_errors": {},
-        "eligible_unique_count": 100,
+        "eligible_unique_count": 160,
     }
     monkeypatch.setattr(module, "discover", lambda *args, **kwargs: payload)
-    monkeypatch.setattr(module, "_schedule_sector_enrichment", lambda *args, **kwargs: None)
-    result = module.apply(core)
-    assert result["run_cycle_hook_active"] is True
-    assert result["scan_boundary_hook_active"] is True
-    cycle = core.run_cycle(source="test")
-    assert len(cycle["universe"]) <= module.MAX_FINAL_UNIVERSE
+    monkeypatch.setattr(module, "_schedule_enrichment", lambda *args, **kwargs: None)
+    result = module.enforce_scanner_boundary(core)
+    assert result["phase"] == "pre_scan"
+    assert result["within_policy_cap"] is True
+    assert result["post_boundary_universe_count"] <= module.MAX_FINAL_UNIVERSE
     assert len(core.UNIVERSE) <= module.MAX_FINAL_UNIVERSE
-    boundary = core.portfolio["broad_momentum_discovery"]
-    assert boundary["within_policy_cap"] is True
-    assert boundary["post_boundary_universe_count"] <= module.MAX_FINAL_UNIVERSE
-    assert cycle["source"] == "test"
+    assert set(["SPY", "QQQ", "IWM", "DIA", "HELD"]).issubset(core.UNIVERSE)
 
 
 def test_authority_contract_remains_rules_only():
-    payload = module.status_payload(None, force=False)
-    authority = payload["authority"]
+    authority = module._authority()
     assert authority["places_orders"] is False
     assert authority["changes_entry_rules"] is False
     assert authority["changes_hard_risk"] is False

--- a/test_broad_momentum_discovery.py
+++ b/test_broad_momentum_discovery.py
@@ -23,8 +23,33 @@ def test_quote_normalization_and_liquidity_filter():
     assert row["symbol"] == "TEST"
     assert row["relative_volume"] == 2.0
     assert row["sector_proxy"] == "XLK"
+    assert row["sources"] == ["market_wide_momentum"]
     assert module._eligible(row) == (True, "liquid_market_wide_candidate")
     assert module._discovery_score(row) > 0
+
+
+def test_source_labels_survive_deduplication_and_receive_confirmation_bonus(monkeypatch):
+    quote_a = {
+        "symbol": "DUPE",
+        "regularMarketPrice": 10.0,
+        "regularMarketChangePercent": 5.0,
+        "regularMarketVolume": 1_000_000,
+        "averageDailyVolume3Month": 500_000,
+        "marketCap": 750_000_000,
+    }
+    quote_b = dict(quote_a, regularMarketPrice=10.1, regularMarketVolume=1_200_000)
+    monkeypatch.setattr(
+        module,
+        "_screen_calls",
+        lambda: [
+            ("day_gainers", {"quotes": [quote_a]}),
+            ("market_wide_momentum", {"quotes": [quote_b]}),
+        ],
+    )
+    payload = module._build_payload(None)
+    row = payload["candidates"][0]
+    assert row["sources"] == ["day_gainers", "market_wide_momentum"]
+    assert row["source_confirmation_bonus"] == 0.02
 
 
 def test_universe_composition_prioritizes_positions_benchmarks_and_broad_movers():
@@ -41,9 +66,9 @@ def test_universe_composition_prioritizes_positions_benchmarks_and_broad_movers(
     assert len(universe) == len(set(universe))
 
 
-def test_run_cycle_hook_changes_only_universe_before_existing_cycle(monkeypatch):
+def test_run_cycle_and_scanner_boundary_enforce_final_cap(monkeypatch):
     class Core:
-        UNIVERSE = ["BASE1", "BASE2"]
+        UNIVERSE = [f"BASE{i}" for i in range(80)] + [f"EXTRA{i}" for i in range(80)]
         SYMBOL_SECTOR = {}
         SYMBOL_BUCKET = {}
         BUCKET_CONFIG = {}
@@ -53,28 +78,37 @@ def test_run_cycle_hook_changes_only_universe_before_existing_cycle(monkeypatch)
             return {"is_open": True}
 
         def local_ts_text(self):
-            return "2026-08-04 12:00:00"
+            return "2026-08-05 10:00:00"
+
+        def scan_signals(self):
+            return list(self.UNIVERSE)
 
         def run_cycle(self, source="manual"):
-            return {"source": source, "universe": list(self.UNIVERSE)}
+            return {"source": source, "universe": self.scan_signals()}
 
     core = Core()
     payload = {
         "status": "ok",
-        "selected_symbols": ["MOVE1", "MOVE2"],
+        "selected_symbols": [f"MOVE{i}" for i in range(100)],
         "candidates": [
-            {"symbol": "MOVE1", "sector_proxy": "XLK"},
-            {"symbol": "MOVE2", "sector_proxy": "XLI"},
+            {"symbol": f"MOVE{i}", "sector_proxy": "XLK", "sources": ["market_wide_momentum"]}
+            for i in range(100)
         ],
+        "source_counts": {},
+        "source_errors": {},
+        "eligible_unique_count": 100,
     }
     monkeypatch.setattr(module, "discover", lambda *args, **kwargs: payload)
+    monkeypatch.setattr(module, "_schedule_sector_enrichment", lambda *args, **kwargs: None)
     result = module.apply(core)
     assert result["run_cycle_hook_active"] is True
+    assert result["scan_boundary_hook_active"] is True
     cycle = core.run_cycle(source="test")
-    assert "MOVE1" in cycle["universe"]
-    assert "HELD" in cycle["universe"]
-    assert core.SYMBOL_BUCKET["MOVE1"] == "dynamic_momentum"
-    assert core.SYMBOL_SECTOR["MOVE1"] == "XLK"
+    assert len(cycle["universe"]) <= module.MAX_FINAL_UNIVERSE
+    assert len(core.UNIVERSE) <= module.MAX_FINAL_UNIVERSE
+    boundary = core.portfolio["broad_momentum_discovery"]
+    assert boundary["within_policy_cap"] is True
+    assert boundary["post_boundary_universe_count"] <= module.MAX_FINAL_UNIVERSE
     assert cycle["source"] == "test"
 
 

--- a/test_daily_audit_repair_overlay.py
+++ b/test_daily_audit_repair_overlay.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import daily_audit_repair_overlay as overlay
+
+
+def _sections():
+    return {
+        "05_scanner_signals_entries_rejections": {
+            "status": "warn",
+            "reasons": ["rejection_count_missing"],
+            "signals_found": 3,
+            "entries_count": 0,
+            "rejected_signals_count": None,
+        },
+        "06_top_five_blockers": {
+            "status": "warn",
+            "reasons": ["blocker_reason_missing"],
+            "blockers": [
+                {"symbol": "BSP", "reason": "entry_quality_block", "score": 0.07},
+                {"symbol": "BSP", "reason": None, "score": None},
+                {"symbol": "PPTA", "reason": None, "score": None},
+            ],
+        },
+        "08_trade_journal_reconciliation": {
+            "status": "warn",
+            "reasons": ["trade_journal_summary_missing"],
+            "execution_rows": 7,
+            "journal_execution_rows": None,
+            "open_positions": 2,
+            "journal_open_positions": None,
+            "last_error": None,
+        },
+    }
+
+
+def test_reconciles_rejections_and_deduplicates_blank_blockers():
+    sections = _sections()
+    portfolio = {
+        "scanner_audit": {
+            "blocked_entries": [
+                {"symbol": "BSP", "reason": "entry_quality_block", "score": 0.07},
+                {"symbol": "PPTA", "reason": "entry_quality_block", "score": 0.04},
+            ]
+        },
+        "decision_audit": {},
+        "blocked_entry_reason_audit": {},
+    }
+    overlay._reconcile_scanner(sections, portfolio)
+    scanner = sections["05_scanner_signals_entries_rejections"]
+    blockers = sections["06_top_five_blockers"]
+    assert scanner["rejected_signals_count"] == 2
+    assert scanner["rejection_count_source"] == "unique_rejection_telemetry"
+    assert scanner["status"] == "pass"
+    assert blockers["status"] == "pass"
+    assert blockers["reason_coverage_pct"] == 100.0
+    assert [row["symbol"] for row in blockers["blockers"]] == ["BSP", "PPTA"]
+
+
+def test_trade_journal_uses_transparent_authoritative_fallback():
+    sections = _sections()
+    portfolio = {
+        "trades": [{} for _ in range(7)],
+        "positions": {"AI": {}, "CRWD": {}},
+    }
+    overlay._reconcile_journal(sections, portfolio)
+    journal = sections["08_trade_journal_reconciliation"]
+    assert journal["journal_execution_rows"] == 7
+    assert journal["journal_open_positions"] == 2
+    assert journal["execution_rows_match"] is True
+    assert journal["open_positions_match"] is True
+    assert journal["summary_synthesized_for_reporting"] is True
+    assert journal["reconciliation_source"] == "authoritative_runtime_state_fallback"
+    assert journal["status"] == "pass"
+
+
+def test_authority_remains_reporting_only():
+    authority = overlay.status_payload()["authority"]
+    assert authority["classification_and_reporting_only"] is True
+    assert authority["changes_strategy"] is False
+    assert authority["changes_thresholds"] is False
+    assert authority["changes_risk_or_sizing"] is False
+    assert authority["changes_live_or_ml_authority"] is False
+    assert authority["places_orders"] is False

--- a/test_scanner_runtime_broad_boundary.py
+++ b/test_scanner_runtime_broad_boundary.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import scanner_runtime_contract as contract
+
+
+def test_canonical_scanner_owner_applies_broad_boundary_before_delegate(monkeypatch):
+    calls = []
+
+    class Core:
+        portfolio = {"positions": {}}
+        UNIVERSE = [f"OLD{i}" for i in range(150)]
+
+        def local_ts_text(self):
+            return "2026-08-05 10:30:00"
+
+        def scan_signals(self, market=None):
+            calls.append(("delegate", len(self.UNIVERSE)))
+            return list(self.UNIVERSE)
+
+    core = Core()
+
+    def enforce(runtime):
+        calls.append(("boundary", len(runtime.UNIVERSE)))
+        runtime.UNIVERSE = runtime.UNIVERSE[:110]
+        return {"post_boundary_universe_count": len(runtime.UNIVERSE), "within_policy_cap": True}
+
+    fake_broad = SimpleNamespace(
+        VERSION="broad-momentum-discovery-2026-08-05-v2.1-ownership-safe",
+        enforce_scanner_boundary=enforce,
+    )
+    monkeypatch.setitem(sys.modules, "broad_momentum_discovery", fake_broad)
+
+    assert contract._patch_universe_boundary(core) is True
+    result = core.scan_signals({})
+    assert calls[0][0] == "boundary"
+    assert calls[1] == ("delegate", 110)
+    assert len(result) == 110
+    assert core.SCANNER_UNIVERSE_BOUNDARY_VERSION == fake_broad.VERSION
+
+    inspection = contract._inspect(core.scan_signals)
+    assert inspection["universe_boundary_count"] == 1
+
+
+def test_boundary_fallback_preserves_existing_scanner_when_discovery_errors(monkeypatch):
+    class Core:
+        portfolio = {}
+        UNIVERSE = ["SPY", "QQQ"]
+
+        def scan_signals(self, market=None):
+            return list(self.UNIVERSE)
+
+    fake_broad = SimpleNamespace(
+        VERSION="test-version",
+        enforce_scanner_boundary=lambda core: (_ for _ in ()).throw(RuntimeError("provider unavailable")),
+    )
+    monkeypatch.setitem(sys.modules, "broad_momentum_discovery", fake_broad)
+    core = Core()
+    assert contract._patch_universe_boundary(core) is True
+    assert core.scan_signals({}) == ["SPY", "QQQ"]
+
+
+def test_scanner_boundary_changes_no_trade_authority():
+    class Core:
+        portfolio = {"auto_runner": {}}
+
+        def scan_signals(self, market=None):
+            return [], [], []
+
+    core = Core()
+    inspection = contract._inspect(core.scan_signals, core)
+    assert inspection["universe_boundary_count"] == 0

--- a/test_state_persistence_contract_live_status.py
+++ b/test_state_persistence_contract_live_status.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import state_persistence_contract as contract
+
+
+def test_status_refreshes_memory_and_disk_richness_without_apply_side_effects(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    backup = tmp_path / "state.json.bak"
+    state_file.write_text(
+        json.dumps({"positions": {"AI": {}}, "trades": [{}, {}], "history": [1], "equity": 9999.0}),
+        encoding="utf-8",
+    )
+    backup.write_text("{}", encoding="utf-8")
+    core = SimpleNamespace(
+        STATE_FILE=str(state_file),
+        STATE_DIR=str(tmp_path),
+        portfolio={"positions": {"AI": {}}, "trades": [{}, {}], "history": [1], "equity": 9999.0},
+    )
+    monkeypatch.setattr(contract, "_is_distinct_mount", lambda path: True)
+    contract._APPLIED.add(id(core))
+    contract._LAST = {
+        "migration": {"performed": False, "source": None, "reason": None},
+        "reloaded_richer_persistent_state": False,
+    }
+
+    first = contract.status_payload(core)
+    assert first["in_memory_richness"] == first["on_disk_richness"]
+    assert first["status_refresh_is_read_only"] is True
+
+    core.portfolio["positions"]["CRWD"] = {}
+    core.portfolio["trades"].append({})
+    state_file.write_text(json.dumps(core.portfolio), encoding="utf-8")
+    second = contract.status_payload(core)
+    assert second["in_memory_richness"][0] == 2
+    assert second["in_memory_richness"][1] == 3
+    assert second["in_memory_richness"] == second["on_disk_richness"]
+    assert second["richness_match"] is True
+
+
+def test_status_authority_is_observational():
+    authority = contract._authority()
+    assert authority["status_reads_are_observational"] is True
+    assert authority["fabricates_missing_state"] is False
+    assert authority["changes_strategy"] is False
+    assert authority["changes_thresholds"] is False
+    assert authority["changes_risk_or_sizing"] is False
+    assert authority["places_orders"] is False


### PR DESCRIPTION
## Summary
- reconcile missing scanner rejection totals and duplicate blocker rows in the daily audit
- use a transparent read-only runtime-state fallback when trade-journal summary fields are absent
- refresh persistence richness on every status read without save, reload, migration, or repair side effects
- upgrade broad momentum discovery to v2 with correct multi-source attribution and confirmation scoring
- enforce the 110-symbol working-universe cap at the detailed scanner boundary and after each cycle
- record discovery pool, scanner input count, runtime appends, and inferred append ownership
- add non-blocking cached sector/industry enrichment for promoted candidates
- add focused tests for all new contracts

## Safety boundary
No entry rules, score thresholds, sizing, hard risk controls, order paths, live authority, or ML authority are changed. Execution remains existing-rules-only and ML remains shadow recommendation only.

## Validation plan
- repository CI and focused tests on this PR
- after merge, confirm both Railway deployments
- rerun the daily audit and broad momentum status during market hours
- verify scanner input is <=110, rejection/journal warnings are reconciled, and persistence richness reflects current positions/trades