### PR TITLE
Fix scanner-boundary marker inheritance

### DIFF
--- a/scanner_runtime_contract.py
+++ b/scanner_runtime_contract.py
@@ -15,13 +15,12 @@ order placement, ML authority, or live authority changes.
 from __future__ import annotations
 
 import datetime as dt
-import functools
 import sys
 import threading
 import time
 from typing import Any, Dict, List, Tuple
 
-VERSION = "scanner-runtime-contract-2026-08-05-v2-broad-boundary"
+VERSION = "scanner-runtime-contract-2026-08-05-v2.1-boundary-marker-safe"
 
 _LOCK = threading.RLock()
 _WATCHDOGS: set[int] = set()
@@ -259,7 +258,9 @@ def _patch_universe_boundary(core: Any) -> bool:
     if not callable(current) or _chain_has_boundary(current):
         return False
 
-    @functools.wraps(current)
+    # Do not use functools.wraps here. Copying the inner opening-surge wrapper's
+    # __dict__ would falsely mark this outer boundary as a second opening-surge
+    # layer and would duplicate its prior links in callable-chain telemetry.
     def bounded_scan(*args, __prior=current, **kwargs):
         boundary = _apply_broad_boundary(core)
         try:
@@ -273,11 +274,17 @@ def _patch_universe_boundary(core: Any) -> bool:
             pass
         return __prior(*args, **kwargs)
 
+    bounded_scan.__name__ = "bounded_scan"
+    bounded_scan.__qualname__ = "_patch_universe_boundary.<locals>.bounded_scan"
+    bounded_scan.__module__ = __name__
     bounded_scan._scanner_universe_boundary = True
     bounded_scan._scanner_runtime_contract_version = VERSION
     bounded_scan._scanner_universe_boundary_prior = current
-    bounded_scan._scanner_runtime_contract_prior = current
-    bounded_scan.__wrapped__ = current
+    try:
+        import broad_momentum_discovery as broad
+        setattr(core, "SCANNER_UNIVERSE_BOUNDARY_VERSION", broad.VERSION)
+    except Exception:
+        pass
     core.scan_signals = bounded_scan
     return True
 

--- a/test_scanner_runtime_broad_boundary.py
+++ b/test_scanner_runtime_broad_boundary.py
@@ -49,6 +49,9 @@ def test_canonical_scanner_owner_applies_broad_boundary_before_delegate(monkeypa
 
 
 def test_boundary_does_not_inherit_opening_surge_markers(monkeypatch):
+    def base_scan(market=None):
+        return ["SPY", "QQQ"]
+
     class Core:
         portfolio = {"positions": {}}
         UNIVERSE = [f"OLD{i}" for i in range(125)]
@@ -56,17 +59,12 @@ def test_boundary_does_not_inherit_opening_surge_markers(monkeypatch):
         def local_ts_text(self):
             return "2026-08-05 10:35:00"
 
+        def scan_signals(self, market=None):
+            return base_scan(market)
+
+    Core.scan_signals._opening_surge_scan_guard = True
+    Core.scan_signals._opening_surge_scan_prior = base_scan
     core = Core()
-
-    def base_scan(market=None):
-        return list(core.UNIVERSE)
-
-    def opening_scan(market=None):
-        return base_scan(market)
-
-    opening_scan._opening_surge_scan_guard = True
-    opening_scan._opening_surge_scan_prior = base_scan
-    core.scan_signals = opening_scan
 
     fake_broad = SimpleNamespace(
         VERSION="broad-momentum-discovery-2026-08-05-v2.1-ownership-safe",

--- a/test_scanner_runtime_broad_boundary.py
+++ b/test_scanner_runtime_broad_boundary.py
@@ -42,6 +42,50 @@ def test_canonical_scanner_owner_applies_broad_boundary_before_delegate(monkeypa
 
     inspection = contract._inspect(core.scan_signals)
     assert inspection["universe_boundary_count"] == 1
+    assert inspection["opening_surge_count"] == 0
+    assert inspection["cycle_detected"] is False
+    assert inspection["current"]["universe_boundary"] is True
+    assert inspection["current"]["opening_surge"] is False
+
+
+def test_boundary_does_not_inherit_opening_surge_markers(monkeypatch):
+    class Core:
+        portfolio = {"positions": {}}
+        UNIVERSE = [f"OLD{i}" for i in range(125)]
+
+        def local_ts_text(self):
+            return "2026-08-05 10:35:00"
+
+    core = Core()
+
+    def base_scan(market=None):
+        return list(core.UNIVERSE)
+
+    def opening_scan(market=None):
+        return base_scan(market)
+
+    opening_scan._opening_surge_scan_guard = True
+    opening_scan._opening_surge_scan_prior = base_scan
+    core.scan_signals = opening_scan
+
+    fake_broad = SimpleNamespace(
+        VERSION="broad-momentum-discovery-2026-08-05-v2.1-ownership-safe",
+        enforce_scanner_boundary=lambda runtime: {
+            "post_boundary_universe_count": len(runtime.UNIVERSE),
+            "within_policy_cap": True,
+        },
+    )
+    monkeypatch.setitem(sys.modules, "broad_momentum_discovery", fake_broad)
+
+    assert contract._patch_universe_boundary(core) is True
+    inspection = contract._inspect(core.scan_signals)
+    assert inspection["universe_boundary_count"] == 1
+    assert inspection["opening_surge_count"] == 1
+    assert inspection["universe_boundary_depth"] == 0
+    assert inspection["opening_surge_depth"] == 1
+    assert inspection["universe_boundary_ordered"] is True
+    assert inspection["cycle_detected"] is False
+    assert inspection["current"]["opening_surge"] is False
 
 
 def test_boundary_fallback_preserves_existing_scanner_when_discovery_errors(monkeypatch):


### PR DESCRIPTION
## Summary
- prevent the outer broad-universe boundary wrapper from inheriting opening-surge markers and prior-link attributes
- preserve canonical scanner ownership and callable-chain telemetry
- add regression coverage proving one boundary, one opening-surge layer, correct ordering, and no callable cycle

## Safety boundary
No strategy logic, entry thresholds, sizing, hard risk, order placement, live authority, or ML authority changes. This is scanner composition and observability only.

## Validation
- focused marker-isolation tests
- repository validation and startup smoke
- after merge, verify the live scanner contract reports one ordered boundary, one opening-surge layer, and no cycle