### PR TITLE
Stabilize protected market data and quarantine invalid MAE/MFE features

### DIFF
--- a/daily_data_integrity_audit_overlay.py
+++ b/daily_data_integrity_audit_overlay.py
@@ -1,0 +1,272 @@
+"""Read-only data-integrity extension for the routine daily audit.
+
+The overlay makes provider and MAE/MFE integrity failures visible in the same
+routine audit the operator already uses. It does not call providers, place
+orders, repair state, change strategy logic, change thresholds, change sizing,
+or change live/ML authority.
+"""
+from __future__ import annotations
+
+import functools
+import sys
+from typing import Any, Dict, List
+
+VERSION = "daily-data-integrity-audit-overlay-2026-08-06-v1"
+SECTION_KEY = "10b_market_data_and_path_integrity"
+_APPLIED = False
+_REGISTERED_APP_IDS: set[int] = set()
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _module() -> Any | None:
+    for name in ("app", "__main__"):
+        module = sys.modules.get(name)
+        if module is not None and getattr(module, "app", None) is not None:
+            return module
+    for module in list(sys.modules.values()):
+        if module is not None and getattr(module, "app", None) is not None and hasattr(module, "portfolio"):
+            return module
+    return None
+
+
+def _safe_status(module_name: str, core: Any) -> Dict[str, Any]:
+    try:
+        module = __import__(module_name)
+        fn = getattr(module, "status_payload", None)
+        if callable(fn):
+            try:
+                value = fn(core)
+            except TypeError:
+                value = fn()
+            return value if isinstance(value, dict) else {}
+    except Exception:
+        pass
+    return {}
+
+
+def _feature_contamination(rows: Any) -> List[Dict[str, Any]]:
+    contaminated: List[Dict[str, Any]] = []
+    for raw in _l(rows):
+        if not isinstance(raw, dict):
+            continue
+        feature = _d(raw.get("mae_mfe_features"))
+        if not feature or feature.get("ml_feature_ready") is not True:
+            continue
+        valid = bool(
+            feature.get("path_id")
+            and feature.get("training_eligible") is True
+            and feature.get("integrity_status") == "valid"
+        )
+        if not valid:
+            contaminated.append(
+                {
+                    "symbol": str(raw.get("symbol") or raw.get("ticker") or "").upper() or None,
+                    "path_id": feature.get("path_id"),
+                    "mae_pct": feature.get("mae_pct"),
+                    "mfe_pct": feature.get("mfe_pct"),
+                    "reason": "ml_feature_ready_without_valid_exact_path",
+                }
+            )
+    return contaminated
+
+
+def build_integrity_section(core: Any = None) -> Dict[str, Any]:
+    core = core or _module()
+    portfolio = _d(getattr(core, "portfolio", {})) if core is not None else {}
+    hygiene = _safe_status("yfinance_data_hygiene", core)
+    provider = _safe_status("market_data_resilience", core)
+
+    positions = _d(portfolio.get("positions"))
+    protected = {str(symbol).upper() for symbol in _l(hygiene.get("protected_symbols")) if str(symbol).strip()}
+    protected.update({"SPY", "QQQ", "IWM", "DIA"})
+    protected.update(str(symbol).upper() for symbol in positions)
+    active_backoffs = _d(hygiene.get("active_symbol_backoffs"))
+    blocked_symbols = {str(symbol).upper() for symbol in active_backoffs}
+    protected_blocked = sorted(protected & blocked_symbols)
+    benchmark_blocked = sorted({"SPY", "QQQ", "IWM", "DIA"} & blocked_symbols)
+
+    path = _d(portfolio.get("intratrade_path_capture"))
+    integration = _d(portfolio.get("mae_mfe_integration"))
+    ml2 = _d(portfolio.get("ml_phase2"))
+    contaminated = _feature_contamination(ml2.get("dataset")) + _feature_contamination(portfolio.get("trades"))
+
+    integration_error = (
+        integration.get("last_error")
+        or path.get("last_error")
+        or (_d(integration.get("intratrade_refresh")).get("error"))
+    )
+    provider_circuit_open = bool(provider.get("provider_circuit_open") or provider.get("circuit_open"))
+    hygiene_installed = hygiene.get("installed") is True
+    provider_installed = provider.get("installed") is True
+
+    fail_reasons: List[str] = []
+    warn_reasons: List[str] = []
+    if protected_blocked:
+        fail_reasons.append("protected_symbol_quarantined")
+    if provider_circuit_open:
+        fail_reasons.append("provider_circuit_open")
+    if contaminated:
+        fail_reasons.append("contaminated_mae_mfe_feature_active")
+    if integration_error:
+        fail_reasons.append("mae_mfe_integrity_error")
+    if not hygiene_installed:
+        warn_reasons.append("yfinance_hygiene_not_confirmed_installed")
+    if not provider_installed:
+        warn_reasons.append("provider_resilience_not_confirmed_installed")
+
+    status = "fail" if fail_reasons else "warn" if warn_reasons else "pass"
+    reasons = fail_reasons or warn_reasons
+    return {
+        "status": status,
+        "reasons": reasons,
+        "protected_symbols": sorted(protected),
+        "active_symbol_backoffs": active_backoffs,
+        "protected_symbols_blocked": protected_blocked,
+        "benchmark_symbols_blocked": benchmark_blocked,
+        "provider_circuit_open": provider_circuit_open,
+        "provider_distinct_failure_symbols": provider.get("distinct_provider_failure_symbols") or [],
+        "provider_totals": provider.get("totals") or {},
+        "path_integrity": {
+            "version": path.get("version"),
+            "invalid_or_quarantined_rows": path.get("invalid_or_quarantined_rows"),
+            "training_eligible_rows": path.get("training_eligible_rows"),
+            "integrity_resets": path.get("integrity_resets"),
+            "last_error": path.get("last_error"),
+        },
+        "mae_mfe_integrity": {
+            "version": integration.get("version"),
+            "quarantined_feature_rows": integration.get("quarantined_feature_rows"),
+            "training_eligible_feature_rows": integration.get("training_eligible_feature_rows"),
+            "last_error": integration.get("last_error"),
+        },
+        "active_contaminated_feature_count": len(contaminated),
+        "active_contaminated_feature_examples": contaminated[:10],
+        "authority": {
+            "reporting_only": True,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "places_orders": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def _recalculate(payload: Dict[str, Any], daily: Any) -> None:
+    sections = _d(payload.get("sections"))
+    operational_keys = [
+        key for key in sections
+        if key not in {"11_conclusion", "12_next_action"}
+    ]
+    statuses = [_d(sections.get(key)).get("status") for key in operational_keys]
+    overall = "fail" if "fail" in statuses else "warn" if "warn" in statuses else "pass"
+    payload["overall"] = overall
+    sections["11_conclusion"] = {
+        "status": overall,
+        "pass_count": statuses.count("pass"),
+        "warn_count": statuses.count("warn"),
+        "fail_count": statuses.count("fail"),
+        "checked_sections": len(statuses),
+    }
+    integrity = _d(sections.get(SECTION_KEY))
+    if integrity.get("status") in {"fail", "warn"}:
+        sections["12_next_action"] = {
+            "status": "required",
+            "priority": "high" if integrity.get("status") == "fail" else "normal",
+            "section": SECTION_KEY,
+            "action": "Restore protected market data and keep invalid MAE/MFE rows quarantined before relying on the next trading cycle.",
+            "reason": (_l(integrity.get("reasons")) or [None])[0],
+        }
+    else:
+        try:
+            sections["12_next_action"] = daily._next_action(sections)
+        except Exception:
+            pass
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _APPLIED
+    try:
+        import daily_operational_audit as daily
+    except Exception as exc:
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": f"{type(exc).__name__}: {exc}"}
+
+    current = getattr(daily, "build_payload", None)
+    if not callable(current):
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": "daily_build_payload_missing"}
+    if getattr(current, "_daily_data_integrity_overlay", None) == VERSION:
+        _APPLIED = True
+        return status_payload(core)
+
+    while callable(current) and getattr(current, "_daily_data_integrity_overlay", False):
+        prior = getattr(current, "__wrapped__", None)
+        if not callable(prior):
+            break
+        current = prior
+
+    @functools.wraps(current)
+    def wrapped_build_payload(runtime: Any = None):
+        active_core = runtime or core or _module()
+        payload = current(active_core)
+        if not isinstance(payload, dict):
+            return payload
+        sections = _d(payload.get("sections"))
+        sections[SECTION_KEY] = build_integrity_section(active_core)
+        payload["data_integrity_overlay_version"] = VERSION
+        _recalculate(payload, daily)
+        return payload
+
+    wrapped_build_payload._daily_data_integrity_overlay = VERSION  # type: ignore[attr-defined]
+    daily.build_payload = wrapped_build_payload
+    _APPLIED = True
+    return status_payload(core)
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    return {
+        "status": "ok" if _APPLIED else "pending",
+        "overall": "pass" if _APPLIED else "warn",
+        "type": "daily_data_integrity_audit_overlay_status",
+        "version": VERSION,
+        "applied": _APPLIED,
+        "section_key": SECTION_KEY,
+        "integrity": build_integrity_section(core),
+        "authority": {
+            "reporting_only": True,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "places_orders": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> None:
+    if flask_app is None:
+        return
+    from flask import jsonify
+    apply(core)
+    if id(flask_app) in _REGISTERED_APP_IDS:
+        return
+    try:
+        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+    except Exception:
+        existing = set()
+    path = "/paper/data-integrity-audit-status"
+    if path not in existing:
+        flask_app.add_url_rule(path, "paper_data_integrity_audit_status", lambda: jsonify(status_payload(core or _module())))
+    _REGISTERED_APP_IDS.add(id(flask_app))
+
+
+try:
+    apply(None)
+except Exception:
+    pass

--- a/intratrade_path_capture.py
+++ b/intratrade_path_capture.py
@@ -1,16 +1,13 @@
-"""Intratrade price-path capture for MAE/MFE learning.
+"""Symbol-specific intratrade path capture for MAE/MFE research.
 
-Shadow/advisory only. This module records high/low/current price behavior for
-open positions so MAE/MFE can become real telemetry instead of placeholder
-fields. It does not place trades, close trades, change position sizing, or
-override risk controls.
+The capture is advisory-only. It records path observations for open positions,
+but rejects prices that are inconsistent with the position's own symbol-specific
+price, entry basis, or lifecycle identity. A new position fingerprint always
+starts a new path. Invalid historical paths are preserved as quarantined evidence
+and are never marked training eligible.
 
-Routes:
-- /paper/intratrade-path-status
-- /paper/position-path-status
-
-State section:
-- state["intratrade_path_capture"]
+No orders, exits, sizing, strategy thresholds, risk controls, live authority, or
+ML authority are changed.
 """
 from __future__ import annotations
 
@@ -20,9 +17,13 @@ import os
 import sys
 from typing import Any, Dict, List, Tuple
 
-VERSION = "intratrade-path-capture-2026-05-19-phase25-persistence"
+VERSION = "intratrade-path-capture-2026-08-06-v2-symbol-isolated"
+CALCULATION_VERSION = "entry-relative-mae-mfe-v2"
 ENABLED = os.environ.get("INTRATRADE_PATH_CAPTURE_ENABLED", "true").lower() not in {"0", "false", "no", "off"}
 LIVE_AUTHORITY = False
+MAX_OBSERVATION_MOVE_PCT = max(10.0, float(os.environ.get("INTRATRADE_MAX_OBSERVATION_MOVE_PCT", "50")))
+MAX_SOURCE_DIVERGENCE_PCT = max(2.0, float(os.environ.get("INTRATRADE_MAX_SOURCE_DIVERGENCE_PCT", "15")))
+MIN_VALID_OBSERVATIONS_FOR_TRAINING = max(2, int(os.environ.get("INTRATRADE_MIN_VALID_OBSERVATIONS", "3")))
 REGISTERED_APP_IDS: set[int] = set()
 PATCHED_MODULE_IDS: set[int] = set()
 
@@ -58,7 +59,7 @@ def _module() -> Any | None:
 
 def _now(mod: Any = None) -> str:
     try:
-        return mod.local_ts_text()
+        return str(mod.local_ts_text())
     except Exception:
         return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
@@ -82,18 +83,12 @@ def _load_state(mod: Any = None) -> Tuple[Dict[str, Any], Any]:
 def _positions(state: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
     positions = state.get("positions")
     if isinstance(positions, dict):
-        return {str(sym).upper(): pos for sym, pos in positions.items() if isinstance(pos, dict)}
+        return {str(sym).upper(): pos for sym, pos in list(positions.items()) if isinstance(pos, dict)}
     return {}
 
 
 def _entry_price(pos: Dict[str, Any]) -> float:
-    # Core app positions use "entry". The older Phase 2.5 helper only looked
-    # for entry_price/avg_entry_price/price/cost_basis, which left valid open
-    # positions untracked. Keep every legacy alias and add the canonical key.
-    return _f(
-        pos.get("entry"),
-        _f(pos.get("entry_price"), _f(pos.get("avg_entry_price"), _f(pos.get("price"), _f(pos.get("cost_basis"), 0.0))))
-    )
+    return _f(pos.get("entry"), _f(pos.get("entry_price"), _f(pos.get("avg_entry_price"), _f(pos.get("cost_basis"), 0.0))))
 
 
 def _side(pos: Dict[str, Any]) -> str:
@@ -108,25 +103,62 @@ def _entry_time(pos: Dict[str, Any]) -> float | None:
     for key in ("entry_time", "opened_time", "time", "timestamp"):
         value = pos.get(key)
         if value is not None:
-            return _f(value, 0.0)
+            number = _f(value, 0.0)
+            return number if number > 0 else None
     return None
 
 
-def _safe_latest_price(mod: Any, symbol: str, pos: Dict[str, Any]) -> float:
+def _path_id(symbol: str, side: str, entry_time: float | None, entry_price: float) -> str:
+    return f"{symbol}|{side}|{int(entry_time or 0)}|{entry_price:.6f}"
+
+
+def _position_price(pos: Dict[str, Any]) -> Tuple[float, str]:
+    for key in ("last_price", "current_price", "market_price", "mark_price"):
+        price = _f(pos.get(key), 0.0)
+        if price > 0:
+            return price, f"position.{key}"
+    return 0.0, ""
+
+
+def _move_pct(price: float, entry: float) -> float:
+    return abs((price / entry - 1.0) * 100.0) if price > 0 and entry > 0 else float("inf")
+
+
+def _plausible(price: float, entry: float) -> bool:
+    return price > 0 and entry > 0 and _move_pct(price, entry) <= MAX_OBSERVATION_MOVE_PCT
+
+
+def _safe_latest_price(mod: Any, symbol: str, pos: Dict[str, Any], entry: float) -> Tuple[float, str, List[Dict[str, Any]]]:
+    rejected: List[Dict[str, Any]] = []
+    position_price, position_source = _position_price(pos)
+    if position_price > 0 and not _plausible(position_price, entry):
+        rejected.append({
+            "source": position_source,
+            "price": round(position_price, 6),
+            "reason": "position_price_outside_entry_relative_integrity_bound",
+        })
+        position_price = 0.0
+    if position_price > 0:
+        return position_price, position_source, rejected
     for fn_name in ("latest_price", "get_latest_price", "safe_latest_price"):
         try:
             fn = getattr(mod, fn_name, None)
-            if callable(fn):
-                price = _f(fn(symbol), 0.0)
-                if price > 0:
-                    return price
-        except Exception:
-            pass
-    for key in ("last_price", "current_price", "market_price", "price", "entry"):
-        price = _f(pos.get(key), 0.0)
-        if price > 0:
-            return price
-    return _entry_price(pos)
+            if not callable(fn):
+                continue
+            price = _f(fn(symbol), 0.0)
+            if price <= 0:
+                continue
+            if not _plausible(price, entry):
+                rejected.append({
+                    "source": f"core.{fn_name}",
+                    "price": round(price, 6),
+                    "reason": "core_price_outside_entry_relative_integrity_bound",
+                })
+                continue
+            return price, f"core.{fn_name}", rejected
+        except Exception as exc:
+            rejected.append({"source": f"core.{fn_name}", "reason": f"provider_exception:{type(exc).__name__}"})
+    return entry, "entry_price_fallback", rejected
 
 
 def _pct_for_side(current: float, entry: float, side: str) -> float:
@@ -152,151 +184,250 @@ def _strategy_metadata(pos: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _path_bounds_valid(path: Dict[str, Any], entry: float) -> bool:
+    high = _f(path.get("high_since_entry"), entry)
+    low = _f(path.get("low_since_entry"), entry)
+    return high >= low > 0 and _plausible(high, entry) and _plausible(low, entry)
+
+
+def _archive_item(archive: List[Any], item: Dict[str, Any], now_text: str, reason: str) -> None:
+    row = dict(item)
+    row.update({
+        "closed_local": row.get("closed_local") or now_text,
+        "archived_by": VERSION,
+        "archive_reason": reason,
+    })
+    archive.append(row)
+
+
 def update_paths(state: Dict[str, Any], mod: Any = None) -> Dict[str, Any]:
     mod = mod or _module()
     section = state.setdefault("intratrade_path_capture", {})
     section.setdefault("paths", {})
     paths = _dict(section.get("paths"))
     section["paths"] = paths
-
+    archive = _list(section.setdefault("closed_path_archive", []))
     now_epoch = _epoch_now()
     now_text = _now(mod)
     positions = _positions(state)
     active_symbols = set(positions.keys())
     updated = 0
-    skipped = []
-
-    for symbol, pos in positions.items():
+    skipped: List[Dict[str, Any]] = []
+    rejected_observations: List[Dict[str, Any]] = []
+    integrity_resets = 0
+    for symbol, pos in list(positions.items()):
         entry = _entry_price(pos)
         if entry <= 0:
             skipped.append({"symbol": symbol, "reason": "missing_entry_price"})
             continue
         side = _side(pos)
-        price = _safe_latest_price(mod, symbol, pos) if mod is not None else _f(pos.get("price"), entry)
-        if price <= 0:
-            price = entry
+        entry_time = _entry_time(pos)
+        identity = _path_id(symbol, side, entry_time, entry)
+        price, price_source, rejected = _safe_latest_price(mod, symbol, pos, entry) if mod is not None else (entry, "entry_price_fallback", [])
+        for row in rejected:
+            rejected_observations.append({"symbol": symbol, **row, "entry_price": round(entry, 6)})
         path = _dict(paths.get(symbol))
+        old_identity = str(path.get("path_id") or "")
+        if path and old_identity != identity:
+            path["integrity_status"] = "quarantined"
+            path["training_eligible"] = False
+            path["ml_feature_ready"] = False
+            _archive_item(archive, path, now_text, "entry_identity_changed")
+            path = {}
+            integrity_resets += 1
+        elif path and not _path_bounds_valid(path, entry):
+            path["integrity_status"] = "quarantined"
+            path["training_eligible"] = False
+            path["ml_feature_ready"] = False
+            path["integrity_reason"] = "historical_path_bounds_implausible"
+            _archive_item(archive, path, now_text, "historical_path_bounds_implausible")
+            path = {}
+            integrity_resets += 1
         if not path:
             path = {
+                "path_id": identity,
                 "symbol": symbol,
                 "side": side,
-                "entry_price": round(entry, 4),
+                "entry_price": round(entry, 6),
                 "shares": round(_shares(pos), 6),
-                "entry_time": _entry_time(pos),
+                "entry_time": entry_time,
                 "opened_local": pos.get("opened_local") or pos.get("entry_local") or now_text,
-                "high_since_entry": round(max(entry, price), 4),
-                "low_since_entry": round(min(entry, price), 4),
+                "high_since_entry": round(max(entry, price), 6),
+                "low_since_entry": round(min(entry, price), 6),
                 "mfe_pct": 0.0,
                 "mae_pct": 0.0,
                 "time_to_mfe_seconds": 0,
                 "time_to_mae_seconds": 0,
                 "created_local": now_text,
+                "observation_count": 0,
+                "invalid_observation_count": 0,
             }
         prior_high = _f(path.get("high_since_entry"), entry)
         prior_low = _f(path.get("low_since_entry"), entry)
-        new_high = max(prior_high, price)
-        new_low = min(prior_low, price)
-        entry_time = path.get("entry_time")
-        duration = 0
-        if entry_time:
-            duration = max(0, int(now_epoch - _f(entry_time, now_epoch)))
-
-        if side == "short":
-            favorable_price = new_low
-            adverse_price = new_high
+        observation_valid = _plausible(price, entry)
+        if observation_valid:
+            new_high = max(prior_high, price)
+            new_low = min(prior_low, price)
+            path["observation_count"] = int(path.get("observation_count") or 0) + 1
         else:
-            favorable_price = new_high
-            adverse_price = new_low
+            new_high = prior_high
+            new_low = prior_low
+            path["invalid_observation_count"] = int(path.get("invalid_observation_count") or 0) + 1
+            rejected_observations.append({
+                "symbol": symbol,
+                "source": price_source,
+                "price": round(price, 6),
+                "entry_price": round(entry, 6),
+                "reason": "observation_outside_entry_relative_integrity_bound",
+            })
+        duration = max(0, int(now_epoch - _f(entry_time, now_epoch))) if entry_time else 0
+        favorable_price, adverse_price = (new_low, new_high) if side == "short" else (new_high, new_low)
         mfe = _pct_for_side(favorable_price, entry, side)
         mae = _pct_for_side(adverse_price, entry, side)
-
         if new_high != prior_high or new_low != prior_low:
             if abs(mfe) >= abs(_f(path.get("mfe_pct"), 0.0)):
                 path["time_to_mfe_seconds"] = duration
             if abs(mae) >= abs(_f(path.get("mae_pct"), 0.0)):
                 path["time_to_mae_seconds"] = duration
-
-        meta = _strategy_metadata(pos)
-        for key, value in meta.items():
+        for key, value in _strategy_metadata(pos).items():
             if value is not None:
                 path[key] = value
-
+        valid_count = int(path.get("observation_count") or 0)
+        invalid_count = int(path.get("invalid_observation_count") or 0)
+        training_eligible = bool(
+            valid_count >= MIN_VALID_OBSERVATIONS_FOR_TRAINING
+            and invalid_count == 0
+            and _path_bounds_valid({"high_since_entry": new_high, "low_since_entry": new_low}, entry)
+            and price_source.startswith("position.")
+        )
         path.update({
+            "path_id": identity,
             "symbol": symbol,
             "side": side,
-            "entry_price": round(entry, 4),
-            "current_price": round(price, 4),
-            "high_since_entry": round(new_high, 4),
-            "low_since_entry": round(new_low, 4),
+            "entry_price": round(entry, 6),
+            "current_price": round(price, 6),
+            "current_price_source": price_source,
+            "high_since_entry": round(new_high, 6),
+            "low_since_entry": round(new_low, 6),
             "mfe_pct": round(max(0.0, mfe), 4),
             "mae_pct": round(min(0.0, mae), 4),
             "duration_seconds": duration,
             "last_updated_local": now_text,
-            "vwap_drift_pct": path.get("vwap_drift_pct"),
-            "ema_hold_status": path.get("ema_hold_status"),
+            "calculation_version": CALCULATION_VERSION,
+            "integrity_status": "valid" if training_eligible else "collecting" if invalid_count == 0 else "quarantined",
+            "integrity_reason": None if invalid_count == 0 else "invalid_price_observation",
+            "training_eligible": training_eligible,
+            "ml_feature_ready": training_eligible,
             "live_authority": False,
         })
         paths[symbol] = path
         updated += 1
-
-    closed = [sym for sym in list(paths.keys()) if sym not in active_symbols]
-    archive = section.setdefault("closed_path_archive", [])
-    seen_keys = set()
-    compact_archive = []
-    for item in _list(archive):
-        if not isinstance(item, dict):
-            continue
-        key = (item.get("symbol"), item.get("side"), item.get("entry_time"), item.get("entry_price"), item.get("closed_local"))
-        if key in seen_keys:
-            continue
-        seen_keys.add(key)
-        compact_archive.append(item)
-    archive = compact_archive
-    for sym in closed:
+    for sym in [symbol for symbol in list(paths.keys()) if symbol not in active_symbols]:
         item = paths.pop(sym)
         if isinstance(item, dict):
-            item["closed_local"] = now_text
-            item["archived_by"] = VERSION
-            archive.append(item)
-    section["closed_path_archive"] = archive[-500:]
-
+            eligible = bool(item.get("training_eligible")) and item.get("integrity_status") == "valid"
+            item["training_eligible"] = eligible
+            item["ml_feature_ready"] = eligible
+            _archive_item(archive, item, now_text, "position_closed")
+    compact: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in archive:
+        if not isinstance(raw, dict):
+            continue
+        row = dict(raw)
+        identity = str(row.get("path_id") or _path_id(
+            str(row.get("symbol") or "").upper(),
+            str(row.get("side") or "long").lower(),
+            _f(row.get("entry_time"), 0.0) or None,
+            _f(row.get("entry_price"), 0.0),
+        ))
+        row["path_id"] = identity
+        entry = _f(row.get("entry_price"), 0.0)
+        if entry <= 0 or not _path_bounds_valid(row, entry):
+            row.update({
+                "integrity_status": "quarantined",
+                "integrity_reason": row.get("integrity_reason") or "archived_path_bounds_implausible",
+                "training_eligible": False,
+                "ml_feature_ready": False,
+            })
+        if identity in seen:
+            continue
+        seen.add(identity)
+        compact.append(row)
+    section["closed_path_archive"] = compact[-500:]
+    active_values = list(paths.values())
+    archive_values = section["closed_path_archive"]
+    invalid_rows = sum(1 for row in active_values + archive_values if row.get("integrity_status") == "quarantined")
+    eligible_rows = sum(1 for row in active_values + archive_values if row.get("training_eligible") is True)
     section.update({
         "version": VERSION,
+        "calculation_version": CALCULATION_VERSION,
         "enabled": ENABLED,
         "live_authority": False,
         "last_updated_local": now_text,
         "active_positions_tracked": len(paths),
-        "closed_paths_archived": len(section.get("closed_path_archive", [])),
+        "closed_paths_archived": len(archive_values),
         "updated_count": updated,
         "skipped_positions": skipped[-25:],
-        "recommended_actions": [
-            "Use intratrade path data to convert MAE/MFE telemetry from placeholder to real outcome labels.",
-            "Keep this advisory only until enough path observations exist across multiple regimes.",
-            "Next step after enough path data: feed MAE/MFE into trade-quality and ML readiness scoring.",
-        ],
+        "rejected_observations": rejected_observations[-50:],
+        "integrity_resets": integrity_resets,
+        "invalid_or_quarantined_rows": invalid_rows,
+        "training_eligible_rows": eligible_rows,
+        "regression_guards": {
+            "position_owned_price_preferred": True,
+            "entry_identity_resets_path": True,
+            "implausible_historical_bounds_quarantined": True,
+            "symbol_only_feature_matching_prohibited": True,
+        },
     })
     return section
 
 
-def payload(state: Dict[str, Any], mod: Any = None) -> Dict[str, Any]:
-    section = update_paths(state, mod) if ENABLED else _dict(state.get("intratrade_path_capture"))
-    paths = _dict(section.get("paths"))
-    archive = _list(section.get("closed_path_archive"))
+def status_payload(mod: Any = None, state: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    if state is None:
+        state, mod = _load_state(mod)
+    section = _dict(state.get("intratrade_path_capture"))
+    paths = list(_dict(section.get("paths")).values())
+    archive = [row for row in _list(section.get("closed_path_archive")) if isinstance(row, dict)]
+    invalid = [row for row in paths + archive if row.get("integrity_status") == "quarantined"]
+    eligible = [row for row in paths + archive if row.get("training_eligible") is True]
     return {
         "status": "ok",
-        "type": "intratrade_path_status",
+        "overall": "warn" if invalid else "pass",
+        "type": "intratrade_path_integrity_status",
         "version": VERSION,
+        "calculation_version": CALCULATION_VERSION,
         "generated_local": _now(mod),
         "enabled": ENABLED,
         "live_authority": False,
         "active_positions_tracked": len(paths),
         "closed_paths_archived": len(archive),
+        "invalid_or_quarantined_rows": len(invalid),
+        "training_eligible_rows": len(eligible),
+        "rejected_observations": _list(section.get("rejected_observations"))[-25:],
+        "invalid_rows_tail": invalid[-10:],
+        "regression_guards": section.get("regression_guards") or {},
+        "authority": {
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "places_orders": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def payload(state: Dict[str, Any], mod: Any = None) -> Dict[str, Any]:
+    section = update_paths(state, mod) if ENABLED else _dict(state.get("intratrade_path_capture"))
+    status = status_payload(mod, state)
+    status.update({
+        "type": "intratrade_path_status",
         "updated_count": section.get("updated_count", 0),
         "skipped_positions": section.get("skipped_positions", []),
-        "active_paths": list(paths.values())[-25:],
-        "closed_path_tail": archive[-25:],
-        "recommended_actions": section.get("recommended_actions") or [],
-    }
+        "active_paths": list(_dict(section.get("paths")).values())[-25:],
+        "closed_path_tail": _list(section.get("closed_path_archive"))[-25:],
+    })
+    return status
 
 
 def apply(module: Any = None) -> Dict[str, Any]:
@@ -342,15 +473,17 @@ def register_routes(flask_app: Any, module: Any = None) -> Dict[str, Any]:
         existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
     except Exception:
         existing = set()
-
     def status_route():
         state, mod = _load_state(module)
         return jsonify(payload(state, mod))
-
+    def integrity_route():
+        state, mod = _load_state(module)
+        return jsonify(status_payload(mod, state))
     if "/paper/intratrade-path-status" not in existing:
         flask_app.add_url_rule("/paper/intratrade-path-status", "paper_intratrade_path_status", status_route)
     if "/paper/position-path-status" not in existing:
         flask_app.add_url_rule("/paper/position-path-status", "paper_position_path_status", status_route)
-
+    if "/paper/intratrade-path-integrity-status" not in existing:
+        flask_app.add_url_rule("/paper/intratrade-path-integrity-status", "paper_intratrade_path_integrity_status", integrity_route)
     REGISTERED_APP_IDS.add(id(flask_app))
-    return {"status": "ok", "version": VERSION, "routes": ["/paper/intratrade-path-status", "/paper/position-path-status"], "live_authority": False}
+    return {"status": "ok", "version": VERSION, "live_authority": False}

--- a/mae_mfe_integration.py
+++ b/mae_mfe_integration.py
@@ -1,16 +1,10 @@
-"""MAE/MFE integration bridge.
+"""Integrity-gated MAE/MFE integration bridge.
 
-Advisory-only bridge that refreshes real intratrade path telemetry and feeds it
-into:
-- trade-quality scoring metadata
-- adaptive stop recommendations
-- dynamic take-profit recommendations
-- future ML ranking features
-- Phase 2.5 readiness gates
-
-This module does not place orders, modify positions, close trades, change
-allocation, or override risk controls. It writes recommendations and feature
-metadata only. It never invents synthetic MAE/MFE values.
+Only path rows with a symbol-specific lifecycle identity, valid provenance, and
+``training_eligible=true`` may enrich execution or shadow-ML records. Legacy
+symbol-only matches are removed and quarantined. The bridge is advisory-only and
+never changes orders, positions, sizing, strategy thresholds, hard risk, live
+authority, or ML authority.
 """
 from __future__ import annotations
 
@@ -20,7 +14,7 @@ import os
 import sys
 from typing import Any, Dict, List, Tuple
 
-VERSION = "mae-mfe-integration-2026-06-04-telemetry-complete"
+VERSION = "mae-mfe-integration-2026-08-06-v2-exact-path-identity"
 ENABLED = os.environ.get("MAE_MFE_INTEGRATION_ENABLED", "true").lower() not in {"0", "false", "no", "off"}
 LIVE_AUTHORITY = False
 REGISTERED_APP_IDS: set[int] = set()
@@ -58,7 +52,7 @@ def _module() -> Any | None:
 
 def _now(mod: Any = None) -> str:
     try:
-        return mod.local_ts_text()
+        return str(mod.local_ts_text())
     except Exception:
         return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
@@ -75,36 +69,43 @@ def _load_state(mod: Any = None) -> Tuple[Dict[str, Any], Any]:
 def _refresh_intratrade_paths(state: Dict[str, Any], mod: Any = None) -> Dict[str, Any]:
     try:
         import intratrade_path_capture
-        if hasattr(intratrade_path_capture, "update_paths"):
-            section = intratrade_path_capture.update_paths(state, mod)
-            return {"status": "ok", "version": section.get("version"), "active_positions_tracked": section.get("active_positions_tracked"), "closed_paths_archived": section.get("closed_paths_archived")}
+        section = intratrade_path_capture.update_paths(state, mod)
+        return {
+            "status": "ok",
+            "version": section.get("version"),
+            "active_positions_tracked": section.get("active_positions_tracked"),
+            "closed_paths_archived": section.get("closed_paths_archived"),
+            "invalid_or_quarantined_rows": section.get("invalid_or_quarantined_rows"),
+            "training_eligible_rows": section.get("training_eligible_rows"),
+        }
     except Exception as exc:
-        return {"status": "error", "error": str(exc)}
-    return {"status": "not_available"}
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
 
 
-def _paths(state: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+def _paths(state: Dict[str, Any]) -> List[Dict[str, Any]]:
     section = _dict(state.get("intratrade_path_capture"))
-    return {str(k).upper(): v for k, v in _dict(section.get("paths")).items() if isinstance(v, dict)}
+    active = [row for row in list(_dict(section.get("paths")).values()) if isinstance(row, dict)]
+    closed = [row for row in list(_list(section.get("closed_path_archive"))) if isinstance(row, dict)]
+    return active + closed[-500:]
 
 
-def _closed_paths(state: Dict[str, Any]) -> List[Dict[str, Any]]:
-    return [row for row in _list(_dict(state.get("intratrade_path_capture")).get("closed_path_archive")) if isinstance(row, dict)]
+def _path_valid(path: Dict[str, Any]) -> bool:
+    return bool(
+        path.get("path_id")
+        and path.get("training_eligible") is True
+        and path.get("ml_feature_ready") is True
+        and path.get("integrity_status") == "valid"
+        and _f(path.get("entry_price"), 0.0) > 0
+        and _f(path.get("high_since_entry"), 0.0) >= _f(path.get("low_since_entry"), 0.0) > 0
+        and -100.0 < _f(path.get("mae_pct"), 0.0) <= 0.0
+        and 0.0 <= _f(path.get("mfe_pct"), 0.0) < 500.0
+    )
 
 
-def _path_key(path: Dict[str, Any]) -> Tuple[str, str]:
-    return (str(path.get("symbol") or "").upper(), str(path.get("side") or "long").lower())
-
-
-def _risk_recommendation(path: Dict[str, Any], source: str = "active_path") -> Dict[str, Any]:
-    symbol = str(path.get("symbol") or "").upper()
-    side = str(path.get("side") or "long").lower()
+def _risk_recommendation(path: Dict[str, Any], source: str) -> Dict[str, Any]:
     mae = _f(path.get("mae_pct"), 0.0)
     mfe = _f(path.get("mfe_pct"), 0.0)
     duration = _f(path.get("duration_seconds"), 0.0)
-    current = _f(path.get("current_price"), _f(path.get("exit_price"), 0.0))
-    entry = _f(path.get("entry_price"), 0.0)
-
     efficiency = round(mfe / max(0.01, abs(mae)), 4) if (mfe > 0 or mae < 0) else None
     if mae <= -2.0 and mfe < 0.75:
         stop_bias = "tighten_or_exit_review"
@@ -114,7 +115,6 @@ def _risk_recommendation(path: Dict[str, Any], source: str = "active_path") -> D
         stop_bias = "allow_room"
     else:
         stop_bias = "standard"
-
     if mfe >= 3.0 and efficiency is not None and efficiency >= 2.0:
         take_profit_bias = "trail_winner"
     elif mfe >= 1.5 and mae > -0.75:
@@ -123,120 +123,183 @@ def _risk_recommendation(path: Dict[str, Any], source: str = "active_path") -> D
         take_profit_bias = "stale_position_review"
     else:
         take_profit_bias = "standard"
-
-    quality_signal = "strong_path" if (mfe >= 1.5 and mae > -0.75) else "weak_path" if (mae <= -1.25 and mfe < 0.75) else "neutral_path"
+    quality = "strong_path" if (mfe >= 1.5 and mae > -0.75) else "weak_path" if (mae <= -1.25 and mfe < 0.75) else "neutral_path"
     return {
-        "symbol": symbol,
-        "side": side,
+        "path_id": path.get("path_id"),
+        "symbol": str(path.get("symbol") or "").upper(),
+        "side": str(path.get("side") or "long").lower(),
         "source": source,
-        "entry_price": round(entry, 4) if entry else None,
-        "current_price": round(current, 4) if current else None,
+        "entry_price": round(_f(path.get("entry_price"), 0.0), 6),
+        "entry_time": path.get("entry_time"),
+        "current_price": round(_f(path.get("current_price"), _f(path.get("exit_price"), 0.0)), 6),
+        "high_since_entry": path.get("high_since_entry"),
+        "low_since_entry": path.get("low_since_entry"),
         "mae_pct": round(mae, 4),
         "mfe_pct": round(mfe, 4),
         "path_efficiency": efficiency,
         "duration_seconds": int(duration),
-        "quality_signal": quality_signal,
+        "quality_signal": quality,
         "adaptive_stop_recommendation": stop_bias,
         "dynamic_take_profit_recommendation": take_profit_bias,
+        "integrity_status": path.get("integrity_status"),
+        "training_eligible": bool(path.get("training_eligible")),
+        "calculation_version": path.get("calculation_version"),
+        "current_price_source": path.get("current_price_source"),
         "opened_local": path.get("opened_local"),
         "closed_local": path.get("closed_local"),
         "live_authority": False,
-        "note": "Recommendation only; live order logic is unchanged.",
     }
 
 
 def _feature_row(rec: Dict[str, Any]) -> Dict[str, Any]:
-    mae = _f(rec.get("mae_pct"), 0.0)
-    mfe = _f(rec.get("mfe_pct"), 0.0)
-    eff = rec.get("path_efficiency")
+    eligible = bool(rec.get("training_eligible") and rec.get("integrity_status") == "valid" and rec.get("path_id"))
     return {
+        "path_id": rec.get("path_id"),
         "symbol": rec.get("symbol"),
         "side": rec.get("side"),
         "source": rec.get("source"),
-        "mae_pct": mae,
-        "mfe_pct": mfe,
-        "path_efficiency": eff,
+        "entry_price": rec.get("entry_price"),
+        "entry_time": rec.get("entry_time"),
+        "mae_pct": _f(rec.get("mae_pct"), 0.0),
+        "mfe_pct": _f(rec.get("mfe_pct"), 0.0),
+        "path_efficiency": rec.get("path_efficiency"),
         "path_quality_signal": rec.get("quality_signal"),
         "adaptive_stop_recommendation": rec.get("adaptive_stop_recommendation"),
         "dynamic_take_profit_recommendation": rec.get("dynamic_take_profit_recommendation"),
-        "ml_feature_ready": bool(mfe != 0.0 or mae != 0.0),
+        "calculation_version": rec.get("calculation_version"),
+        "current_price_source": rec.get("current_price_source"),
+        "integrity_status": rec.get("integrity_status"),
+        "training_eligible": eligible,
+        "ml_feature_ready": eligible,
         "live_authority": False,
     }
 
 
-def _trade_outcome_rows(state: Dict[str, Any]) -> List[Dict[str, Any]]:
-    rows = []
-    for row in _list(state.get("trades")):
-        if not isinstance(row, dict):
-            continue
-        action = str(row.get("action") or row.get("type") or "").lower()
-        reason = str(row.get("exit_reason") or row.get("reason") or "").lower()
-        has_pnl = row.get("pnl_dollars") is not None or row.get("pnl_pct") is not None
-        if action in {"exit", "sell", "close"} or "exit" in reason or "stop" in reason or has_pnl:
-            rows.append(row)
-    return rows
+def _action(row: Dict[str, Any]) -> str:
+    return str(row.get("action") or row.get("type") or "").lower()
 
 
-def _build_feature_index(active_features: List[Dict[str, Any]], closed_features: List[Dict[str, Any]]) -> Dict[Tuple[str, str], Dict[str, Any]]:
-    by_key: Dict[Tuple[str, str], Dict[str, Any]] = {}
-    for row in closed_features + active_features:
-        if not isinstance(row, dict):
+def _side(row: Dict[str, Any]) -> str:
+    return str(row.get("side") or "long").lower()
+
+
+def _symbol(row: Dict[str, Any]) -> str:
+    return str(row.get("symbol") or row.get("ticker") or "").upper()
+
+
+def _time(row: Dict[str, Any]) -> float:
+    return _f(row.get("time"), _f(row.get("timestamp"), _f(row.get("entry_time"), 0.0)))
+
+
+def _price(row: Dict[str, Any]) -> float:
+    return _f(row.get("price"), _f(row.get("entry_price"), _f(row.get("fill_price"), 0.0)))
+
+
+def _path_id(symbol: str, side: str, entry_time: float, entry_price: float) -> str:
+    return f"{symbol}|{side}|{int(entry_time or 0)}|{entry_price:.6f}"
+
+
+def _execution_instances(trades: List[Any]) -> Dict[int, str]:
+    """Map row identity to an exact preceding-entry path identity."""
+    open_entries: Dict[Tuple[str, str], Tuple[float, float, str]] = {}
+    mapping: Dict[int, str] = {}
+    rows = [row for row in list(trades) if isinstance(row, dict)]
+    rows.sort(key=_time)
+    for row in rows:
+        symbol = _symbol(row)
+        side = _side(row)
+        if not symbol:
             continue
-        key = (str(row.get("symbol") or "").upper(), str(row.get("side") or "long").lower())
-        if key[0]:
-            by_key[key] = row
-    return by_key
+        action = _action(row)
+        key = (symbol, side)
+        if action in {"entry", "buy", "open", "short"}:
+            entry_time = _time(row)
+            entry_price = _price(row)
+            if entry_time > 0 and entry_price > 0:
+                identity = _path_id(symbol, side, entry_time, entry_price)
+                open_entries[key] = (entry_time, entry_price, identity)
+                mapping[id(row)] = identity
+                row["execution_path_id"] = identity
+        elif action in {"exit", "sell", "close", "partial_exit", "trim"} or row.get("pnl_pct") is not None:
+            entry = open_entries.get(key)
+            if entry:
+                mapping[id(row)] = entry[2]
+                row["execution_path_id"] = entry[2]
+                if action not in {"partial_exit", "trim"}:
+                    open_entries.pop(key, None)
+    return mapping
+
+
+def _quarantine_existing_feature(row: Dict[str, Any], reason: str) -> bool:
+    existing = row.get("mae_mfe_features")
+    had = isinstance(existing, dict) and bool(existing)
+    if had:
+        row["mae_mfe_features_quarantined"] = dict(existing)
+    row["mae_mfe_features"] = {
+        "ml_feature_ready": False,
+        "training_eligible": False,
+        "integrity_status": "quarantined",
+        "quarantine_reason": reason,
+        "live_authority": False,
+    }
+    row["mae_mfe_feature_enriched"] = False
+    row["mae_mfe_quarantined"] = True
+    return had
 
 
 def integrate(state: Dict[str, Any], mod: Any = None) -> Dict[str, Any]:
     if not isinstance(state, dict):
         return {}
     refresh = _refresh_intratrade_paths(state, mod)
-    active_paths = _paths(state)
-    closed_path_rows = _closed_paths(state)
-    active_recs = [_risk_recommendation(path, "active_path") for path in active_paths.values()]
-    closed_recs = [_risk_recommendation(path, "closed_path") for path in closed_path_rows[-250:]]
-    closed_features = [_feature_row(rec) for rec in closed_recs]
-    active_features = [_feature_row(rec) for rec in active_recs]
-    by_symbol_side = _build_feature_index(active_features, closed_features)
+    paths = _paths(state)
+    valid_paths = [path for path in paths if _path_valid(path)]
+    invalid_paths = [path for path in paths if not _path_valid(path)]
+    recs = [_risk_recommendation(path, "closed_path" if path.get("closed_local") else "active_path") for path in valid_paths]
+    features = [_feature_row(rec) for rec in recs]
+    by_path_id = {str(row.get("path_id")): row for row in features if row.get("path_id")}
+
+    trades = [row for row in list(_list(state.get("trades"))) if isinstance(row, dict)]
+    execution_map = _execution_instances(trades)
+    quarantined_rows = 0
+    trade_rows_enriched = 0
+    for row in trades:
+        identity = execution_map.get(id(row)) or str(row.get("execution_path_id") or "")
+        feature = by_path_id.get(identity)
+        if feature:
+            row["mae_mfe_features"] = dict(feature)
+            row["mae_mfe_feature_enriched"] = True
+            row["mae_mfe_quarantined"] = False
+            trade_rows_enriched += 1
+        else:
+            if _quarantine_existing_feature(row, "no_exact_valid_execution_path_match"):
+                quarantined_rows += 1
 
     ml2 = _dict(state.get("ml_phase2"))
-    dataset = _list(ml2.get("dataset"))
-    enriched = 0
-    rows_with_feature_ready = 0
+    dataset = [row for row in list(_list(ml2.get("dataset"))) if isinstance(row, dict)]
+    ml_rows_enriched = 0
+    ml_rows_quarantined = 0
     for row in dataset:
-        if not isinstance(row, dict):
-            continue
-        key = (str(row.get("symbol") or "").upper(), str(row.get("side") or "long").lower())
-        feature = by_symbol_side.get(key) or by_symbol_side.get((key[0], "long"))
-        if feature:
-            row.setdefault("mae_mfe_features", {}).update(feature)
+        identity = str(row.get("execution_path_id") or row.get("path_id") or "")
+        feature = by_path_id.get(identity)
+        executed = bool(row.get("executed") or row.get("execution_action") or row.get("trade_executed"))
+        if executed and feature:
+            row["mae_mfe_features"] = dict(feature)
             row["mae_mfe_feature_enriched"] = True
-            enriched += 1
-            if feature.get("ml_feature_ready"):
-                rows_with_feature_ready += 1
+            row["mae_mfe_quarantined"] = False
+            ml_rows_enriched += 1
+        else:
+            if _quarantine_existing_feature(row, "shadow_row_lacks_exact_valid_execution_path"):
+                ml_rows_quarantined += 1
 
-    trade_rows_enriched = 0
-    for row in _trade_outcome_rows(state):
-        sym = str(row.get("symbol") or row.get("ticker") or "").upper()
-        side = str(row.get("side") or "long").lower()
-        feature = by_symbol_side.get((sym, side)) or by_symbol_side.get((sym, "long"))
-        if feature:
-            row.setdefault("mae_mfe_features", {}).update(feature)
-            row["mae_mfe_feature_enriched"] = True
-            trade_rows_enriched += 1
-
-    path_rows_available = len(active_features) + len(closed_features)
-    ready_features = [r for r in active_features + closed_features if r.get("ml_feature_ready")]
     tq = state.setdefault("trade_quality_telemetry", {})
     tq["mae_mfe_integration"] = {
         "version": VERSION,
-        "active_recommendations_count": len(active_recs),
-        "closed_recommendations_count": len(closed_recs),
-        "path_rows_available": path_rows_available,
-        "ready_feature_rows": len(ready_features),
-        "ml_rows_enriched": enriched,
+        "valid_path_rows": len(valid_paths),
+        "invalid_or_quarantined_path_rows": len(invalid_paths),
+        "ml_rows_enriched": ml_rows_enriched,
+        "ml_rows_quarantined": ml_rows_quarantined,
         "trade_rows_enriched": trade_rows_enriched,
+        "trade_rows_quarantined": quarantined_rows,
         "last_updated_local": _now(mod),
         "live_authority": False,
     }
@@ -247,57 +310,71 @@ def integrate(state: Dict[str, Any], mod: Any = None) -> Dict[str, Any]:
         "enabled": ENABLED,
         "live_authority": False,
         "last_updated_local": _now(mod),
+        "last_error": None,
         "intratrade_refresh": refresh,
-        "active_recommendations": active_recs[-25:],
-        "closed_recommendations_tail": closed_recs[-25:],
-        "active_features": active_features[-25:],
-        "closed_features_tail": closed_features[-25:],
-        "ml_rows_enriched": enriched,
-        "ml_rows_with_ready_features": rows_with_feature_ready,
+        "valid_recommendations": recs[-25:],
+        "valid_features": features[-25:],
+        "valid_path_rows": len(valid_paths),
+        "invalid_or_quarantined_path_rows": len(invalid_paths),
+        "ml_rows_enriched": ml_rows_enriched,
+        "ml_rows_quarantined": ml_rows_quarantined,
         "trade_rows_enriched": trade_rows_enriched,
-        "telemetry_rows_available": path_rows_available,
-        "mae_mfe_complete": bool(len(ready_features) > 0),
-        "summary": {
-            "active_positions_with_path": len(active_recs),
-            "closed_paths_with_path": len(closed_recs),
-            "telemetry_rows_available": path_rows_available,
-            "ready_feature_rows": len(ready_features),
-            "strong_path_count": sum(1 for r in active_recs if r.get("quality_signal") == "strong_path"),
-            "weak_path_count": sum(1 for r in active_recs if r.get("quality_signal") == "weak_path"),
-            "trail_winner_count": sum(1 for r in active_recs if r.get("dynamic_take_profit_recommendation") == "trail_winner"),
-            "tighten_stop_count": sum(1 for r in active_recs if str(r.get("adaptive_stop_recommendation", "")).startswith("tighten")),
-            "ml_rows_enriched": enriched,
-            "trade_rows_enriched": trade_rows_enriched,
+        "trade_rows_quarantined": quarantined_rows,
+        "mae_mfe_complete": bool(valid_paths),
+        "regression_guards": {
+            "symbol_only_feature_matching_disabled": True,
+            "exact_execution_path_id_required": True,
+            "invalid_paths_never_training_eligible": True,
+            "dataset_iteration_uses_snapshot": True,
+            "legacy_contaminated_features_quarantined": True,
         },
-        "recommended_actions": [
-            "Keep stop/take-profit outputs advisory until path telemetry is validated across enough trades.",
-            "Use MAE/MFE features to improve ML ranking confidence, not execution authority yet.",
-            "Review weak_path and tighten_stop candidates before changing stop or redeployment rules.",
-            "Promote only after Phase 3A readiness gates pass and walk-forward validation confirms improvement.",
-        ],
     })
     return section
 
 
-def payload(state: Dict[str, Any], mod: Any = None) -> Dict[str, Any]:
-    section = integrate(state, mod) if ENABLED else _dict(state.get("mae_mfe_integration"))
+def status_payload(mod: Any = None, state: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    if state is None:
+        state, mod = _load_state(mod)
+    section = _dict(state.get("mae_mfe_integration"))
+    path_section = _dict(state.get("intratrade_path_capture"))
+    last_error = section.get("last_error") or path_section.get("last_error")
+    invalid = int(section.get("invalid_or_quarantined_path_rows") or path_section.get("invalid_or_quarantined_rows") or 0)
+    ml_quarantined = int(section.get("ml_rows_quarantined") or 0)
     return {
         "status": "ok",
-        "type": "mae_mfe_integration_status",
+        "overall": "warn" if last_error else "pass",
+        "type": "mae_mfe_integrity_status",
         "version": VERSION,
         "generated_local": _now(mod),
         "enabled": ENABLED,
         "live_authority": False,
-        "mae_mfe_complete": section.get("mae_mfe_complete", False),
-        "summary": section.get("summary"),
-        "active_recommendations_count": len(_list(section.get("active_recommendations"))),
-        "closed_recommendations_count": len(_list(section.get("closed_recommendations_tail"))),
-        "telemetry_rows_available": section.get("telemetry_rows_available", 0),
-        "ml_rows_enriched": section.get("ml_rows_enriched", 0),
-        "trade_rows_enriched": section.get("trade_rows_enriched", 0),
-        "active_recommendations": section.get("active_recommendations", []),
-        "recommended_actions": section.get("recommended_actions", []),
+        "valid_path_rows": int(section.get("valid_path_rows") or 0),
+        "invalid_or_quarantined_path_rows": invalid,
+        "ml_rows_enriched": int(section.get("ml_rows_enriched") or 0),
+        "ml_rows_quarantined": ml_quarantined,
+        "trade_rows_enriched": int(section.get("trade_rows_enriched") or 0),
+        "trade_rows_quarantined": int(section.get("trade_rows_quarantined") or 0),
+        "last_error": last_error,
+        "regression_guards": section.get("regression_guards") or {},
+        "authority": {
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "places_orders": False,
+            "changes_live_or_ml_authority": False,
+        },
     }
+
+
+def payload(state: Dict[str, Any], mod: Any = None) -> Dict[str, Any]:
+    section = integrate(state, mod) if ENABLED else _dict(state.get("mae_mfe_integration"))
+    out = status_payload(mod, state)
+    out.update({
+        "type": "mae_mfe_integration_status",
+        "mae_mfe_complete": section.get("mae_mfe_complete", False),
+        "valid_recommendations": section.get("valid_recommendations", []),
+    })
+    return out
 
 
 def apply(module: Any = None) -> Dict[str, Any]:
@@ -315,7 +392,7 @@ def apply(module: Any = None) -> Dict[str, Any]:
                         integrate(state, module)
                 except Exception as exc:
                     try:
-                        state.setdefault("mae_mfe_integration", {})["last_error"] = str(exc)
+                        state.setdefault("mae_mfe_integration", {})["last_error"] = f"{type(exc).__name__}: {exc}"
                     except Exception:
                         pass
                 return original(state)
@@ -344,22 +421,20 @@ def register_routes(flask_app: Any, module: Any = None) -> Dict[str, Any]:
     except Exception:
         existing = set()
 
-    def status_route():
+    def integration_route():
         state, mod = _load_state(module)
         return jsonify(payload(state, mod))
 
-    if "/paper/mae-mfe-integration-status" not in existing:
-        flask_app.add_url_rule("/paper/mae-mfe-integration-status", "paper_mae_mfe_integration_status", status_route)
-    if "/paper/adaptive-exit-recommendations" not in existing:
-        flask_app.add_url_rule("/paper/adaptive-exit-recommendations", "paper_adaptive_exit_recommendations", status_route)
-    if "/paper/adaptive_exit_recommendations" not in existing:
-        flask_app.add_url_rule("/paper/adaptive_exit_recommendations", "paper_adaptive_exit_recommendations_legacy", status_route)
+    def integrity_route():
+        state, mod = _load_state(module)
+        return jsonify(status_payload(mod, state))
 
+    for path, endpoint, view in (
+        ("/paper/mae-mfe-integration-status", "paper_mae_mfe_integration_status", integration_route),
+        ("/paper/mae-mfe-status", "paper_mae_mfe_status", integration_route),
+        ("/paper/mae-mfe-integrity-status", "paper_mae_mfe_integrity_status", integrity_route),
+    ):
+        if path not in existing:
+            flask_app.add_url_rule(path, endpoint, view)
     REGISTERED_APP_IDS.add(id(flask_app))
-    return {"status": "ok", "version": VERSION, "routes": ["/paper/mae-mfe-integration-status", "/paper/adaptive-exit-recommendations"], "live_authority": False}
-
-
-try:
-    apply(_module())
-except Exception:
-    pass
+    return {"status": "ok", "version": VERSION, "live_authority": False}

--- a/market_data_resilience.py
+++ b/market_data_resilience.py
@@ -1,29 +1,35 @@
 """Bounded market-data reliability guard for the paper runtime.
 
-Wraps the core ``download_prices`` helper with a yfinance request timeout,
-per-symbol timing, bounded telemetry, and a short provider circuit breaker.
-Known invalid or temporarily quarantined symbols are removed before the
-provider call by ``yfinance_data_hygiene``.
+The canonical ``download_prices`` owner filters static/dynamically backed-off
+symbols through ``yfinance_data_hygiene`` and isolates failures by symbol.
+A provider-wide circuit opens only after several recent timeout/error failures
+across several distinct symbols. Empty/no-data responses never open the global
+circuit by themselves.
 
-This module does not change signal rules, thresholds, sizing, risk controls,
-order logic, or live/ML authority. Failed or empty downloads remain unavailable
-exactly as before; they now fail quickly instead of consuming the worker budget.
+No signal rules, thresholds, sizing, risk controls, order logic, live authority,
+or ML authority are changed.
 """
 from __future__ import annotations
 
 import datetime as dt
 import os
+import re
 import sys
 import threading
 import time
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Sequence
 
-VERSION = "market-data-resilience-2026-08-05-v2.1-wrapper-aware-status"
+VERSION = "market-data-resilience-2026-08-06-v3-distinct-symbol-breaker"
 REQUEST_TIMEOUT_SECONDS = max(2.0, float(os.environ.get("MARKET_DATA_REQUEST_TIMEOUT_SECONDS", "8")))
-FAILURE_THRESHOLD = max(1, int(os.environ.get("MARKET_DATA_FAILURE_THRESHOLD", "3")))
-CIRCUIT_OPEN_SECONDS = max(5, int(os.environ.get("MARKET_DATA_CIRCUIT_OPEN_SECONDS", "60")))
+SYMBOL_FAILURE_THRESHOLD = max(2, int(os.environ.get("MARKET_DATA_SYMBOL_FAILURE_THRESHOLD", "3")))
+SYMBOL_BACKOFF_SECONDS = max(15, int(os.environ.get("MARKET_DATA_SYMBOL_BACKOFF_SECONDS", "45")))
+PROVIDER_WINDOW_SECONDS = max(10, int(os.environ.get("MARKET_DATA_PROVIDER_WINDOW_SECONDS", "30")))
+PROVIDER_FAILURE_THRESHOLD = max(4, int(os.environ.get("MARKET_DATA_PROVIDER_FAILURE_THRESHOLD", "6")))
+PROVIDER_DISTINCT_SYMBOL_THRESHOLD = max(3, int(os.environ.get("MARKET_DATA_PROVIDER_DISTINCT_SYMBOL_THRESHOLD", "4")))
+PROVIDER_CIRCUIT_OPEN_SECONDS = max(10, int(os.environ.get("MARKET_DATA_PROVIDER_CIRCUIT_OPEN_SECONDS", "30")))
 MAX_EVENTS = max(20, int(os.environ.get("MARKET_DATA_MAX_EVENTS", "200")))
 
+_SPLIT_RE = re.compile(r"[\s,]+")
 _LOCK = threading.RLock()
 _PATCHED_MODULE_IDS: set[int] = set()
 _REGISTERED_APP_IDS: set[int] = set()
@@ -34,11 +40,13 @@ _TOTALS: Dict[str, int] = {
     "failures": 0,
     "timeouts": 0,
     "empty": 0,
-    "circuit_skips": 0,
+    "symbol_backoff_skips": 0,
+    "provider_circuit_skips": 0,
     "hygiene_blocked": 0,
 }
-_CONSECUTIVE_FAILURES = 0
-_CIRCUIT_OPEN_UNTIL = 0.0
+_SYMBOL_STATE: Dict[str, Dict[str, Any]] = {}
+_PROVIDER_FAILURES: List[Dict[str, Any]] = []
+_PROVIDER_CIRCUIT_OPEN_UNTIL = 0.0
 _LAST_ERROR: Dict[str, Any] = {}
 
 
@@ -57,11 +65,45 @@ def _now() -> str:
     return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
 
-def _record(symbol: str, period: str, interval: str, started: float, status: str, error: str = "") -> None:
+def _normalize(value: Any) -> str:
+    try:
+        return str(value or "").strip().upper().lstrip("$")
+    except Exception:
+        return ""
+
+
+def _symbols(value: Any) -> List[str]:
+    if isinstance(value, str):
+        values = [item for item in _SPLIT_RE.split(value.strip()) if item]
+    elif isinstance(value, (list, tuple, set)):
+        values = list(value)
+    else:
+        values = [value]
+    out: List[str] = []
+    seen: set[str] = set()
+    for item in values:
+        symbol = _normalize(item)
+        if symbol and symbol not in seen:
+            seen.add(symbol)
+            out.append(symbol)
+    return out
+
+
+def _rebuild(original: Any, symbols: Sequence[str]) -> Any:
+    if isinstance(original, str):
+        return symbols[0] if len(symbols) == 1 else " ".join(symbols)
+    if isinstance(original, tuple):
+        return tuple(symbols)
+    if isinstance(original, set):
+        return set(symbols)
+    return list(symbols)
+
+
+def _record(symbols: Sequence[str], period: str, interval: str, started: float, status: str, error: str = "") -> None:
     global _LAST_ERROR
-    row = {
+    row: Dict[str, Any] = {
         "generated_local": _now(),
-        "symbol": str(symbol),
+        "symbols": list(symbols),
         "period": str(period),
         "interval": str(interval),
         "duration_ms": round((time.monotonic() - started) * 1000.0, 1),
@@ -79,13 +121,64 @@ def _is_empty(frame: Any) -> bool:
     return frame is None or bool(getattr(frame, "empty", True))
 
 
-def _sanitize_symbol_request(symbol: Any) -> tuple[Any, list[str], list[dict[str, Any]]]:
+def _sanitize(symbol: Any) -> tuple[Any, List[str], List[Dict[str, Any]]]:
     try:
         import yfinance_data_hygiene as hygiene
         return hygiene.sanitize_tickers(symbol)
     except Exception:
-        text = str(symbol or "").strip()
-        return symbol, ([text] if text else []), []
+        requested = _symbols(symbol)
+        return _rebuild(symbol, requested), requested, []
+
+
+def _prune_provider_failures(now: float) -> None:
+    cutoff = now - PROVIDER_WINDOW_SECONDS
+    _PROVIDER_FAILURES[:] = [row for row in _PROVIDER_FAILURES if float(row.get("ts") or 0.0) >= cutoff]
+
+
+def _symbol_allowed(symbol: str, now: float) -> bool:
+    with _LOCK:
+        return float((_SYMBOL_STATE.get(symbol) or {}).get("blocked_until") or 0.0) <= now
+
+
+def _register_failure(symbols: Sequence[str], failure_type: str, error: str) -> None:
+    global _PROVIDER_CIRCUIT_OPEN_UNTIL
+    now = time.time()
+    with _LOCK:
+        _TOTALS["failures"] += 1
+        if failure_type == "timeout":
+            _TOTALS["timeouts"] += 1
+        elif failure_type == "empty":
+            _TOTALS["empty"] += 1
+        for symbol in symbols:
+            row = dict(_SYMBOL_STATE.get(symbol) or {})
+            count = int(row.get("consecutive_failures") or 0) + 1
+            row.update({
+                "consecutive_failures": count,
+                "last_failure_type": failure_type,
+                "last_error": error[:500],
+                "updated_ts": now,
+            })
+            if count >= SYMBOL_FAILURE_THRESHOLD:
+                row["blocked_until"] = now + SYMBOL_BACKOFF_SECONDS
+            _SYMBOL_STATE[symbol] = row
+            if failure_type in {"timeout", "error"}:
+                _PROVIDER_FAILURES.append({"ts": now, "symbol": symbol, "failure_type": failure_type})
+        _prune_provider_failures(now)
+        distinct = {str(row.get("symbol") or "") for row in _PROVIDER_FAILURES if row.get("symbol")}
+        if len(_PROVIDER_FAILURES) >= PROVIDER_FAILURE_THRESHOLD and len(distinct) >= PROVIDER_DISTINCT_SYMBOL_THRESHOLD:
+            _PROVIDER_CIRCUIT_OPEN_UNTIL = now + PROVIDER_CIRCUIT_OPEN_SECONDS
+
+
+def _register_success(symbols: Sequence[str]) -> None:
+    global _PROVIDER_CIRCUIT_OPEN_UNTIL
+    now = time.time()
+    with _LOCK:
+        _TOTALS["successes"] += 1
+        for symbol in symbols:
+            _SYMBOL_STATE.pop(symbol, None)
+        _prune_provider_failures(now)
+        if not _PROVIDER_FAILURES:
+            _PROVIDER_CIRCUIT_OPEN_UNTIL = 0.0
 
 
 def install(core: Any = None) -> Dict[str, Any]:
@@ -102,25 +195,35 @@ def install(core: Any = None) -> Dict[str, Any]:
     original = getattr(current, "_market_data_resilience_original", current)
 
     def guarded_download_prices(symbol: Any, period: str = "5d", interval: str = "5m"):
-        global _CONSECUTIVE_FAILURES, _CIRCUIT_OPEN_UNTIL
         started = time.monotonic()
-        cleaned, allowed, blocked = _sanitize_symbol_request(symbol)
-        if blocked:
+        now = time.time()
+        cleaned, requested, hygiene_blocked = _sanitize(symbol)
+        if hygiene_blocked:
             with _LOCK:
-                _TOTALS["hygiene_blocked"] += len(blocked)
-            blocked_text = ",".join(str(row.get("symbol") or "") for row in blocked)
-            _record(blocked_text or str(symbol), period, interval, started, "hygiene_blocked")
+                _TOTALS["hygiene_blocked"] += len(hygiene_blocked)
+            _record([str(row.get("symbol") or "") for row in hygiene_blocked], period, interval, started, "hygiene_blocked")
+        if not requested:
+            return None
+
+        allowed = [item for item in requested if _symbol_allowed(item, now)]
+        locally_blocked = [item for item in requested if item not in allowed]
+        if locally_blocked:
+            with _LOCK:
+                _TOTALS["symbol_backoff_skips"] += len(locally_blocked)
+            _record(locally_blocked, period, interval, started, "symbol_backoff")
         if not allowed:
             return None
 
-        now = time.time()
         with _LOCK:
             _TOTALS["requests"] += 1
-            if now < _CIRCUIT_OPEN_UNTIL:
-                _TOTALS["circuit_skips"] += 1
-                _record(str(cleaned), period, interval, started, "circuit_open")
-                return None
+            provider_open = now < _PROVIDER_CIRCUIT_OPEN_UNTIL
+        if provider_open:
+            with _LOCK:
+                _TOTALS["provider_circuit_skips"] += 1
+            _record(allowed, period, interval, started, "provider_circuit_open")
+            return None
 
+        cleaned = _rebuild(cleaned, allowed)
         try:
             frame = core.yf.download(
                 cleaned,
@@ -132,31 +235,18 @@ def install(core: Any = None) -> Dict[str, Any]:
                 threads=False,
             )
             if _is_empty(frame):
-                with _LOCK:
-                    _TOTALS["empty"] += 1
-                    _TOTALS["failures"] += 1
-                    _CONSECUTIVE_FAILURES += 1
-                    if _CONSECUTIVE_FAILURES >= FAILURE_THRESHOLD:
-                        _CIRCUIT_OPEN_UNTIL = time.time() + CIRCUIT_OPEN_SECONDS
-                _record(str(cleaned), period, interval, started, "empty")
+                _register_failure(allowed, "empty", "empty yfinance response")
+                _record(allowed, period, interval, started, "empty")
                 return None
-            with _LOCK:
-                _TOTALS["successes"] += 1
-                _CONSECUTIVE_FAILURES = 0
-                _CIRCUIT_OPEN_UNTIL = 0.0
-            _record(str(cleaned), period, interval, started, "ok")
+            _register_success(allowed)
+            _record(allowed, period, interval, started, "ok")
             return frame
         except Exception as exc:
             text = f"{type(exc).__name__}: {exc}"
-            timeout_like = "timeout" in text.lower() or "curl: (28)" in text.lower()
-            with _LOCK:
-                _TOTALS["failures"] += 1
-                if timeout_like:
-                    _TOTALS["timeouts"] += 1
-                _CONSECUTIVE_FAILURES += 1
-                if _CONSECUTIVE_FAILURES >= FAILURE_THRESHOLD:
-                    _CIRCUIT_OPEN_UNTIL = time.time() + CIRCUIT_OPEN_SECONDS
-            _record(str(cleaned), period, interval, started, "timeout" if timeout_like else "error", text)
+            timeout_like = "timeout" in text.lower() or "timed out" in text.lower() or "curl: (28)" in text.lower()
+            failure_type = "timeout" if timeout_like else "error"
+            _register_failure(allowed, failure_type, text)
+            _record(allowed, period, interval, started, failure_type, text)
             return None
 
     guarded_download_prices._market_data_resilience_version = VERSION  # type: ignore[attr-defined]
@@ -173,13 +263,25 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
     direct_marker = bool(getattr(current, "_market_data_resilience_version", None) == VERSION)
     installed_in_process = bool(core is not None and id(core) in _PATCHED_MODULE_IDS)
     with _LOCK:
+        _prune_provider_failures(now)
         recent = list(_EVENTS[-50:])
         totals = dict(_TOTALS)
-        consecutive = int(_CONSECUTIVE_FAILURES)
-        open_until = float(_CIRCUIT_OPEN_UNTIL)
+        provider_open_until = float(_PROVIDER_CIRCUIT_OPEN_UNTIL)
         last_error = dict(_LAST_ERROR)
+        failures = list(_PROVIDER_FAILURES)
+        symbol_states = {
+            symbol: {
+                "consecutive_failures": int(row.get("consecutive_failures") or 0),
+                "last_failure_type": str(row.get("last_failure_type") or ""),
+                "seconds_remaining": max(0.0, round(float(row.get("blocked_until") or 0.0) - now, 1)),
+                "last_error": str(row.get("last_error") or "")[:300],
+            }
+            for symbol, row in _SYMBOL_STATE.items()
+            if int(row.get("consecutive_failures") or 0) > 0
+        }
     durations = [float(row.get("duration_ms") or 0.0) for row in recent if row.get("status") == "ok"]
     installed = bool(direct_marker or installed_in_process)
+    distinct = sorted({str(row.get("symbol") or "") for row in failures if row.get("symbol")})
     return {
         "status": "ok" if core is not None else "pending",
         "overall": "pass" if core is not None and installed else "warn" if core is not None else "pending",
@@ -188,17 +290,26 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "installed": installed,
         "installed_direct_marker": direct_marker,
         "installed_in_process_registry": installed_in_process,
-        "outer_wrapper_may_hide_direct_marker": bool(installed_in_process and not direct_marker),
         "request_timeout_seconds": REQUEST_TIMEOUT_SECONDS,
-        "failure_threshold": FAILURE_THRESHOLD,
-        "circuit_open_seconds": CIRCUIT_OPEN_SECONDS,
-        "circuit_open": bool(now < open_until),
-        "circuit_seconds_remaining": max(0, round(open_until - now, 1)),
-        "consecutive_failures": consecutive,
+        "symbol_failure_threshold": SYMBOL_FAILURE_THRESHOLD,
+        "symbol_backoff_seconds": SYMBOL_BACKOFF_SECONDS,
+        "provider_window_seconds": PROVIDER_WINDOW_SECONDS,
+        "provider_failure_threshold": PROVIDER_FAILURE_THRESHOLD,
+        "provider_distinct_symbol_threshold": PROVIDER_DISTINCT_SYMBOL_THRESHOLD,
+        "provider_circuit_open": bool(now < provider_open_until),
+        "provider_circuit_seconds_remaining": max(0.0, round(provider_open_until - now, 1)),
+        "provider_failure_rows_in_window": len(failures),
+        "provider_distinct_symbols_in_window": distinct,
+        "symbol_states": symbol_states,
         "totals": totals,
         "average_success_duration_ms": round(sum(durations) / len(durations), 1) if durations else None,
         "last_error": last_error,
         "recent_events": recent,
+        "regression_guards": {
+            "empty_or_missing_data_cannot_open_global_circuit": True,
+            "global_circuit_requires_distinct_symbols": True,
+            "symbol_failures_are_isolated": True,
+        },
         "authority": {
             "changes_live_authority": False,
             "changes_ml_authority": False,

--- a/test_daily_audit_data_integrity.py
+++ b/test_daily_audit_data_integrity.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import daily_operational_audit as audit
+
+
+def _base_portfolio():
+    return {
+        "cash": 10000.0,
+        "equity": 10000.0,
+        "positions": {"AI": {"entry": 10.0, "last_price": 10.0, "unrealized_pnl": 0.0}},
+        "trades": [],
+        "performance": {"realized_pnl_today": 0.0, "realized_pnl_total": 0.0, "unrealized_pnl": 0.0},
+        "auto_runner": {
+            "enabled": True,
+            "thread_started": True,
+            "last_attempt_local": "2026-08-06 09:30:00",
+            "last_attempt_source": "auto",
+            "last_run_local": "2026-08-06 09:31:00",
+            "last_successful_run_local": "2026-08-06 09:31:00",
+        },
+        "risk_controls": {"halted": False, "self_defense_active": False, "daily_loss_pct": 0.0, "intraday_drawdown_pct": 0.0},
+        "scanner_audit": {"signals_found": 0, "entries_count": 0, "rejected_signals_count": 0},
+        "decision_audit": {"signals_found": 0, "entries_count": 0, "rejected_signals_count": 0, "rejected_signals": []},
+        "trade_journal": {"journal_summary": {"execution_rows": 0, "open_positions_count": 1}},
+        "runtime_shadow_capture": {"capture_state": "captured", "latest_parity": True},
+    }
+
+
+def test_audit_warns_when_protected_symbols_are_quarantined(monkeypatch):
+    portfolio = _base_portfolio()
+    core = SimpleNamespace(
+        portfolio=portfolio,
+        app=None,
+        STATE_FILE="state.json",
+        local_ts_text=lambda: "2026-08-06 09:32:00",
+    )
+
+    original = audit._status_payload
+
+    def fake_status(module_name, runtime, argument=None):
+        if module_name == "yfinance_data_hygiene":
+            return {
+                "installed": True,
+                "protected_symbols": ["SPY", "QQQ", "AI"],
+                "active_symbol_backoffs": {"SPY": {"reason": "short_retry_backoff"}},
+            }
+        if module_name == "market_data_resilience":
+            return {"installed": True, "provider_circuit_open": False, "distinct_provider_failure_symbols": []}
+        if module_name == "mae_mfe_integration":
+            return {"status": "ok", "integrity": {"quarantined_rows": 0, "training_eligible_rows": 0}}
+        if module_name == "entry_pipeline_composition_guard":
+            return {"stack_stable": True, "recursion_safe": True, "participation_valve_chain_cycle_free": True, "direct_core_base": True}
+        if module_name == "bear_recovery_stack_contract":
+            return {"owned": True, "wrapper_counts": {"bear_wrapper_count": 1, "xray_wrapper_count": 1}}
+        if module_name == "runtime_shadow_capture":
+            return {"capture_state": "captured", "latest_parity": True}
+        return original(module_name, runtime, argument)
+
+    monkeypatch.setattr(audit, "_status_payload", fake_status)
+    monkeypatch.setattr(audit, "_state_persistence", lambda portfolio, core: {
+        "state_file": "state.json", "state_file_exists": True, "state_file_size_bytes": 1,
+        "state_file_modified_age_seconds": 1.0, "persistent_volume_configured": True,
+        "backup_count": 1, "latest_backup": "state.json.bak", "transaction_status": "ok",
+        "recovery_status": "ok", "archive_status": "ok", "provenance_status": "ok",
+        "corruption_detected": False, "last_error": None, "recovery_failed": False,
+    })
+
+    payload = audit.build_payload(core)
+    section = payload["sections"]["11_market_data_and_path_integrity"]
+    assert section["status"] == "fail"
+    assert "protected_symbol_quarantined" in section["reasons"]
+    assert payload["overall"] == "fail"

--- a/test_runtime_data_integrity.py
+++ b/test_runtime_data_integrity.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import yfinance_data_hygiene as hygiene
+import market_data_resilience as resilience
+import intratrade_path_capture as path_capture
+import mae_mfe_integration as integration
+
+
+def reset_hygiene():
+    with hygiene._LOCK:
+        hygiene._SYMBOL_STATE.clear()
+        hygiene._CACHE.clear()
+        hygiene._PROTECTED_SYMBOLS.clear()
+        hygiene._PROTECTED_SYMBOLS.update(hygiene._DEFAULT_PROTECTED_SYMBOLS)
+        for key in hygiene._TOTALS:
+            hygiene._TOTALS[key] = 0
+
+
+def test_single_missing_data_does_not_quarantine_protected_symbol():
+    reset_hygiene()
+    hygiene._apply_failure("SPY", "no_data", "possibly delisted", "1d|5m", True)
+    assert hygiene.is_blocked_symbol("SPY") is False
+    assert "SPY" not in hygiene.status_payload(None)["active_symbol_backoffs"]
+
+
+def test_missing_data_only_receives_short_retry_backoff_after_repeats():
+    reset_hygiene()
+    hygiene._apply_failure("TESTX", "missing_or_empty", "possibly delisted")
+    hygiene._apply_failure("TESTX", "missing_or_empty", "possibly delisted")
+    assert hygiene.is_blocked_symbol("TESTX") is False
+    hygiene._apply_failure("TESTX", "missing_or_empty", "possibly delisted")
+    assert hygiene.is_blocked_symbol("TESTX") is True
+    payload = hygiene.status_payload(None)
+    assert payload["active_symbol_backoffs"]["TESTX"]["seconds_remaining"] <= hygiene.FAILURE_BACKOFF_SECONDS
+
+
+def test_success_clears_dynamic_backoff():
+    reset_hygiene()
+    for _ in range(3):
+        hygiene._apply_failure("TESTX", "missing_or_empty", "possibly delisted")
+    assert hygiene.is_blocked_symbol("TESTX") is True
+    hygiene._clear_success(["TESTX"])
+    assert hygiene.is_blocked_symbol("TESTX") is False
+
+
+def test_stale_yfinance_error_is_removed_before_call():
+    reset_hygiene()
+    errors = {"SPY": "old possibly delisted"}
+    fake_yf = SimpleNamespace(shared=SimpleNamespace(_ERRORS=errors))
+    hygiene._clear_provider_errors(fake_yf, ["SPY"])
+    assert errors == {}
+
+
+def test_empty_responses_do_not_open_provider_wide_circuit():
+    with resilience._LOCK:
+        resilience._PROVIDER_FAILURES.clear()
+        resilience._SYMBOL_STATE.clear()
+        resilience._PROVIDER_CIRCUIT_OPEN_UNTIL = 0.0
+        for key in resilience._TOTALS:
+            resilience._TOTALS[key] = 0
+    for symbol in ("A", "B", "C", "D", "E", "F"):
+        resilience._register_failure([symbol], "empty", "empty")
+    assert resilience._PROVIDER_CIRCUIT_OPEN_UNTIL == 0.0
+
+
+def test_distinct_timeout_failures_can_open_provider_circuit():
+    with resilience._LOCK:
+        resilience._PROVIDER_FAILURES.clear()
+        resilience._SYMBOL_STATE.clear()
+        resilience._PROVIDER_CIRCUIT_OPEN_UNTIL = 0.0
+    for symbol in ("A", "B", "C", "D", "A", "B"):
+        resilience._register_failure([symbol], "timeout", "timed out")
+    assert resilience._PROVIDER_CIRCUIT_OPEN_UNTIL > 0.0
+
+
+def test_position_owned_price_prevents_cross_symbol_core_price():
+    state = {
+        "positions": {
+            "CRWD": {
+                "entry": 210.0,
+                "entry_time": 1000,
+                "last_price": 209.0,
+                "side": "long",
+                "shares": 1,
+            }
+        }
+    }
+    mod = SimpleNamespace(local_ts_text=lambda: "2026-08-06 09:00:00", latest_price=lambda symbol: 9.95)
+    for _ in range(3):
+        path_capture.update_paths(state, mod)
+    path = state["intratrade_path_capture"]["paths"]["CRWD"]
+    assert path["current_price"] == 209.0
+    assert path["low_since_entry"] == 209.0
+    assert path["mae_pct"] > -1.0
+    assert path["training_eligible"] is True
+
+
+def test_implausible_legacy_path_is_quarantined_and_reset():
+    state = {
+        "positions": {"CRWD": {"entry": 210.0, "entry_time": 1000, "last_price": 209.0, "side": "long", "shares": 1}},
+        "intratrade_path_capture": {
+            "paths": {"CRWD": {"symbol": "CRWD", "side": "long", "entry_price": 210.0, "entry_time": 1000, "high_since_entry": 233.0, "low_since_entry": 9.95}}
+        },
+    }
+    mod = SimpleNamespace(local_ts_text=lambda: "2026-08-06 09:00:00")
+    path_capture.update_paths(state, mod)
+    path = state["intratrade_path_capture"]["paths"]["CRWD"]
+    assert path["low_since_entry"] == 209.0
+    archive = state["intratrade_path_capture"]["closed_path_archive"]
+    assert any(row.get("integrity_status") == "quarantined" for row in archive)
+
+
+def test_symbol_only_ml_features_are_quarantined_without_exact_path():
+    state = {
+        "trades": [],
+        "ml_phase2": {
+            "dataset": [
+                {"symbol": "CRWD", "side": "long", "mae_mfe_features": {"mae_pct": -95.0, "ml_feature_ready": True}}
+            ]
+        },
+        "intratrade_path_capture": {"paths": {}, "closed_path_archive": []},
+    }
+    integration.integrate(state, None)
+    row = state["ml_phase2"]["dataset"][0]
+    assert row["mae_mfe_features"]["ml_feature_ready"] is False
+    assert row["mae_mfe_quarantined"] is True
+
+
+def test_exact_execution_path_can_enrich_trade():
+    entry_time = 1000
+    entry_price = 10.0
+    path_id = f"AI|long|{entry_time}|{entry_price:.6f}"
+    state = {
+        "trades": [
+            {"action": "entry", "symbol": "AI", "side": "long", "time": entry_time, "price": entry_price},
+            {"action": "exit", "symbol": "AI", "side": "long", "time": 2000, "price": 10.2, "pnl_pct": 2.0},
+        ],
+        "ml_phase2": {"dataset": []},
+        "intratrade_path_capture": {
+            "paths": {},
+            "closed_path_archive": [{
+                "path_id": path_id,
+                "symbol": "AI",
+                "side": "long",
+                "entry_time": entry_time,
+                "entry_price": entry_price,
+                "current_price": 10.2,
+                "high_since_entry": 10.3,
+                "low_since_entry": 9.9,
+                "mae_pct": -1.0,
+                "mfe_pct": 3.0,
+                "integrity_status": "valid",
+                "training_eligible": True,
+                "ml_feature_ready": True,
+                "calculation_version": "test",
+            }],
+        },
+    }
+    original_refresh = integration._refresh_intratrade_paths
+    integration._refresh_intratrade_paths = lambda state, mod=None: {"status": "ok"}
+    try:
+        integration.integrate(state, None)
+    finally:
+        integration._refresh_intratrade_paths = original_refresh
+    exit_row = state["trades"][1]
+    assert exit_row["mae_mfe_feature_enriched"] is True
+    assert exit_row["mae_mfe_features"]["path_id"] == path_id
+    assert exit_row["mae_mfe_features"]["ml_feature_ready"] is True

--- a/yfinance_data_hygiene.py
+++ b/yfinance_data_hygiene.py
@@ -1,10 +1,13 @@
-"""Runtime hygiene for yfinance requests used by the paper-trading service.
+"""Safe yfinance request hygiene for the paper-trading runtime.
 
-This module filters known invalid/no-data symbols before provider calls, applies
-short per-symbol backoff for transient failures, caches identical downloads for
-one scanner cycle, and suppresses one specific upstream pandas deprecation
-warning. It never changes strategy logic, thresholds, sizing, risk, order paths,
-live authority, or ML authority.
+Only a small explicit denylist is treated as permanently invalid. Provider
+missing-data messages are treated as transient because Yahoo can emit them for
+valid symbols and short intraday windows. Repeated failures receive a short,
+per-symbol backoff; benchmark ETFs and open positions are never dynamically
+blocked. Stale ``yfinance.shared._ERRORS`` entries are cleared before each call.
+
+No trading rule, threshold, sizing, risk control, order path, live authority, or
+ML authority is changed.
 """
 from __future__ import annotations
 
@@ -17,24 +20,16 @@ import time
 import warnings
 from typing import Any, Dict, Iterable, List, Sequence, Tuple
 
-VERSION = "yfinance-data-hygiene-2026-08-05-v1"
+VERSION = "yfinance-data-hygiene-2026-08-06-v2-transient-safe"
 CACHE_TTL_SECONDS = max(0.0, float(os.getenv("YFINANCE_DOWNLOAD_CACHE_TTL_SECONDS", "45")))
-EMPTY_BACKOFF_THRESHOLD = max(1, int(os.getenv("YFINANCE_EMPTY_BACKOFF_THRESHOLD", "2")))
-EMPTY_BACKOFF_SECONDS = max(30, int(os.getenv("YFINANCE_EMPTY_BACKOFF_SECONDS", "600")))
-TIMEOUT_BACKOFF_THRESHOLD = max(1, int(os.getenv("YFINANCE_TIMEOUT_BACKOFF_THRESHOLD", "2")))
-TIMEOUT_BACKOFF_SECONDS = max(15, int(os.getenv("YFINANCE_TIMEOUT_BACKOFF_SECONDS", "90")))
-NO_DATA_QUARANTINE_SECONDS = max(300, int(os.getenv("YFINANCE_NO_DATA_QUARANTINE_SECONDS", "86400")))
+FAILURE_BACKOFF_THRESHOLD = max(2, int(os.getenv("YFINANCE_FAILURE_BACKOFF_THRESHOLD", "3")))
+FAILURE_BACKOFF_SECONDS = max(15, int(os.getenv("YFINANCE_FAILURE_BACKOFF_SECONDS", "45")))
 MAX_CACHE_ROWS = max(20, int(os.getenv("YFINANCE_DOWNLOAD_CACHE_MAX_ROWS", "256")))
 MAX_EVENTS = max(20, int(os.getenv("YFINANCE_HYGIENE_MAX_EVENTS", "200")))
 
 _DEFAULT_BLOCKED_SYMBOLS = {"RGIT", "CIFRW", "SATS"}
+_DEFAULT_PROTECTED_SYMBOLS = {"SPY", "QQQ", "IWM", "DIA"}
 _SPLIT_RE = re.compile(r"[\s,]+")
-_NO_DATA_MARKERS = (
-    "yfpricesmissingerror",
-    "possibly delisted",
-    "no price data found",
-    "symbol may be delisted",
-)
 _TIMEOUT_MARKERS = ("timeout", "timed out", "curl: (28)", "resolving timed out")
 
 _LOCK = threading.RLock()
@@ -43,6 +38,7 @@ _INSTALLED = False
 _REGISTERED_APP_IDS: set[int] = set()
 _CACHE: Dict[Tuple[Any, ...], Dict[str, Any]] = {}
 _SYMBOL_STATE: Dict[str, Dict[str, Any]] = {}
+_PROTECTED_SYMBOLS: set[str] = set(_DEFAULT_PROTECTED_SYMBOLS)
 _EVENTS: List[Dict[str, Any]] = []
 _TOTALS: Dict[str, int] = {
     "requests": 0,
@@ -50,9 +46,10 @@ _TOTALS: Dict[str, int] = {
     "cache_hits": 0,
     "static_blocks": 0,
     "dynamic_blocks": 0,
-    "no_data_quarantines": 0,
-    "timeout_backoffs": 0,
-    "empty_backoffs": 0,
+    "transient_failures": 0,
+    "short_backoffs": 0,
+    "protected_backoff_prevented": 0,
+    "stale_provider_errors_cleared": 0,
     "successful_calls": 0,
 }
 
@@ -108,18 +105,59 @@ def _rebuild_tickers(original: Any, symbols: Sequence[str]) -> Any:
     return list(symbols)
 
 
+def _refresh_protected_symbols(core: Any = None) -> set[str]:
+    protected = set(_DEFAULT_PROTECTED_SYMBOLS)
+    protected.update(_csv_env("YFINANCE_PROTECTED_SYMBOLS", ()))
+    if core is not None:
+        for source in (getattr(core, "portfolio", None),):
+            try:
+                positions = source.get("positions") if isinstance(source, dict) else None
+                if isinstance(positions, dict):
+                    protected.update(normalize_symbol(symbol) for symbol in positions)
+            except Exception:
+                pass
+        try:
+            state = core.load_state() if hasattr(core, "load_state") else {}
+            positions = state.get("positions") if isinstance(state, dict) else None
+            if isinstance(positions, dict):
+                protected.update(normalize_symbol(symbol) for symbol in positions)
+        except Exception:
+            pass
+    protected.discard("")
+    with _LOCK:
+        _PROTECTED_SYMBOLS.clear()
+        _PROTECTED_SYMBOLS.update(protected)
+        for symbol in list(_SYMBOL_STATE):
+            if symbol in protected:
+                if float((_SYMBOL_STATE.get(symbol) or {}).get("blocked_until") or 0.0) > time.time():
+                    _TOTALS["protected_backoff_prevented"] += 1
+                _SYMBOL_STATE.pop(symbol, None)
+    return protected
+
+
+def protected_symbols(core: Any = None) -> set[str]:
+    if core is not None:
+        return _refresh_protected_symbols(core)
+    with _LOCK:
+        return set(_PROTECTED_SYMBOLS)
+
+
 def _active_state(symbol: str, now: float | None = None) -> Dict[str, Any]:
     now = time.time() if now is None else now
     with _LOCK:
         row = dict(_SYMBOL_STATE.get(symbol) or {})
-    if float(row.get("blocked_until") or 0.0) > now:
-        return row
-    return {}
+    return row if float(row.get("blocked_until") or 0.0) > now else {}
 
 
 def is_blocked_symbol(symbol: Any) -> bool:
     normalized = normalize_symbol(symbol)
-    return bool(normalized and (normalized in static_blocked_symbols() or _active_state(normalized)))
+    if not normalized:
+        return False
+    if normalized in static_blocked_symbols():
+        return True
+    if normalized in protected_symbols():
+        return False
+    return bool(_active_state(normalized))
 
 
 def blocked_reason(symbol: Any) -> str | None:
@@ -128,29 +166,25 @@ def blocked_reason(symbol: Any) -> str | None:
         return "blank_symbol"
     if normalized in static_blocked_symbols():
         return "known_no_data_symbol"
-    state = _active_state(normalized)
-    return str(state.get("reason") or "") or None
+    if normalized in protected_symbols():
+        return None
+    return str(_active_state(normalized).get("reason") or "") or None
 
 
 def sanitize_tickers(tickers: Any) -> Tuple[Any, List[str], List[Dict[str, Any]]]:
     requested = _requested_symbols(tickers)
     allowed: List[str] = []
     blocked: List[Dict[str, Any]] = []
-    now = time.time()
     static = static_blocked_symbols()
+    protected = protected_symbols()
+    now = time.time()
     for symbol in requested:
         if symbol in static:
             blocked.append({"symbol": symbol, "reason": "known_no_data_symbol"})
             continue
         state = _active_state(symbol, now)
-        if state:
-            blocked.append(
-                {
-                    "symbol": symbol,
-                    "reason": str(state.get("reason") or "temporary_symbol_backoff"),
-                    "blocked_until": float(state.get("blocked_until") or 0.0),
-                }
-            )
+        if state and symbol not in protected:
+            blocked.append({"symbol": symbol, "reason": str(state.get("reason") or "short_retry_backoff"), "blocked_until": state.get("blocked_until")})
             continue
         allowed.append(symbol)
     return _rebuild_tickers(tickers, allowed), allowed, blocked
@@ -163,13 +197,11 @@ def _frame_empty(frame: Any) -> bool:
 def _copy_frame(frame: Any) -> Any:
     try:
         return frame.copy(deep=True)
-    except TypeError:
+    except Exception:
         try:
             return frame.copy()
         except Exception:
             return frame
-    except Exception:
-        return frame
 
 
 def _empty_frame() -> Any:
@@ -181,29 +213,17 @@ def _empty_frame() -> Any:
 
 
 def _cache_key(symbols: Sequence[str], args: Sequence[Any], kwargs: Dict[str, Any]) -> Tuple[Any, ...]:
-    relevant = (
-        kwargs.get("period"),
-        kwargs.get("interval"),
-        kwargs.get("start"),
-        kwargs.get("end"),
-        kwargs.get("prepost"),
-        kwargs.get("auto_adjust"),
-        kwargs.get("actions"),
-        kwargs.get("repair"),
-        kwargs.get("group_by"),
-    )
-    return (tuple(symbols), tuple(repr(value) for value in args), tuple(repr(value) for value in relevant))
+    relevant = tuple(repr(kwargs.get(key)) for key in ("period", "interval", "start", "end", "prepost", "auto_adjust", "actions", "repair", "group_by"))
+    return tuple(symbols), tuple(repr(value) for value in args), relevant
 
 
 def _cache_get(key: Tuple[Any, ...]) -> Any:
     if CACHE_TTL_SECONDS <= 0:
         return None
-    now = time.time()
     with _LOCK:
         row = _CACHE.get(key)
-        if not row or now - float(row.get("ts") or 0.0) > CACHE_TTL_SECONDS:
-            if row:
-                _CACHE.pop(key, None)
+        if not row or time.time() - float(row.get("ts") or 0.0) > CACHE_TTL_SECONDS:
+            _CACHE.pop(key, None)
             return None
         _TOTALS["cache_hits"] += 1
         return _copy_frame(row.get("frame"))
@@ -215,17 +235,13 @@ def _cache_put(key: Tuple[Any, ...], frame: Any) -> None:
     with _LOCK:
         _CACHE[key] = {"ts": time.time(), "frame": _copy_frame(frame)}
         if len(_CACHE) > MAX_CACHE_ROWS:
-            oldest = sorted(_CACHE.items(), key=lambda item: float(item[1].get("ts") or 0.0))
-            for stale_key, _ in oldest[: len(_CACHE) - MAX_CACHE_ROWS]:
-                _CACHE.pop(stale_key, None)
+            oldest = sorted(_CACHE, key=lambda item: float((_CACHE.get(item) or {}).get("ts") or 0.0))
+            for stale in oldest[: len(_CACHE) - MAX_CACHE_ROWS]:
+                _CACHE.pop(stale, None)
 
 
 def _record_event(status: str, symbols: Sequence[str], detail: str = "") -> None:
-    row: Dict[str, Any] = {
-        "generated_local": _now_text(),
-        "status": status,
-        "symbols": list(symbols),
-    }
+    row: Dict[str, Any] = {"generated_local": _now_text(), "status": status, "symbols": list(symbols)}
     if detail:
         row["detail"] = detail[:500]
     with _LOCK:
@@ -233,126 +249,119 @@ def _record_event(status: str, symbols: Sequence[str], detail: str = "") -> None
         del _EVENTS[:-MAX_EVENTS]
 
 
-def _provider_error_text(yf_module: Any, symbol: str) -> str:
+def _shared_errors(yf_module: Any) -> Dict[str, Any] | None:
     try:
-        shared = getattr(yf_module, "shared", None)
+        shared = getattr(yf_module, "shared", None) or sys.modules.get("yfinance.shared")
         errors = getattr(shared, "_ERRORS", None)
-        if isinstance(errors, dict) and symbol in errors:
-            return str(errors.get(symbol) or "")
+        return errors if isinstance(errors, dict) else None
     except Exception:
-        pass
-    try:
-        shared = sys.modules.get("yfinance.shared")
-        errors = getattr(shared, "_ERRORS", None)
-        if isinstance(errors, dict) and symbol in errors:
-            return str(errors.get(symbol) or "")
-    except Exception:
-        pass
-    return ""
+        return None
 
 
-def _classify_error(text: str) -> str:
-    lowered = str(text or "").lower()
-    if any(marker in lowered for marker in _NO_DATA_MARKERS):
-        return "no_data"
-    if any(marker in lowered for marker in _TIMEOUT_MARKERS):
-        return "timeout"
-    return "empty"
+def _clear_provider_errors(yf_module: Any, symbols: Sequence[str]) -> None:
+    errors = _shared_errors(yf_module)
+    if errors is None:
+        return
+    wanted = {normalize_symbol(symbol) for symbol in symbols}
+    removed = 0
+    for key in list(errors):
+        if normalize_symbol(key) in wanted:
+            errors.pop(key, None)
+            removed += 1
+    if removed:
+        with _LOCK:
+            _TOTALS["stale_provider_errors_cleared"] += removed
 
 
-def _apply_failure(symbol: str, failure_type: str, detail: str = "") -> None:
-    now = time.time()
+def _provider_errors(yf_module: Any, symbols: Sequence[str]) -> Dict[str, str]:
+    errors = _shared_errors(yf_module) or {}
+    wanted = {normalize_symbol(symbol) for symbol in symbols}
+    return {normalize_symbol(key): str(value or "") for key, value in list(errors.items()) if normalize_symbol(key) in wanted}
+
+
+def _failure_kind(detail: str) -> str:
+    lowered = str(detail or "").lower()
+    return "timeout" if any(marker in lowered for marker in _TIMEOUT_MARKERS) else "missing_or_empty"
+
+
+def _apply_failure(symbol: str, failure_type: str, detail: str = "", *args: Any, **kwargs: Any) -> None:
+    symbol = normalize_symbol(symbol)
+    if not symbol:
+        return
+    protected = symbol in protected_symbols()
     with _LOCK:
+        _TOTALS["transient_failures"] += 1
         row = dict(_SYMBOL_STATE.get(symbol) or {})
-        if failure_type == "no_data":
-            row.update(
-                {
-                    "reason": "provider_confirmed_no_data",
-                    "blocked_until": now + NO_DATA_QUARANTINE_SECONDS,
-                    "no_data_count": int(row.get("no_data_count") or 0) + 1,
-                    "last_error": detail[:500],
-                    "updated_ts": now,
-                }
-            )
-            _TOTALS["no_data_quarantines"] += 1
-        elif failure_type == "timeout":
-            count = int(row.get("timeout_count") or 0) + 1
-            row.update({"timeout_count": count, "last_error": detail[:500], "updated_ts": now})
-            if count >= TIMEOUT_BACKOFF_THRESHOLD:
-                row.update({"reason": "transient_timeout_backoff", "blocked_until": now + TIMEOUT_BACKOFF_SECONDS})
-                _TOTALS["timeout_backoffs"] += 1
-        else:
-            count = int(row.get("empty_count") or 0) + 1
-            row.update({"empty_count": count, "last_error": detail[:500], "updated_ts": now})
-            if count >= EMPTY_BACKOFF_THRESHOLD:
-                row.update({"reason": "repeated_empty_response_backoff", "blocked_until": now + EMPTY_BACKOFF_SECONDS})
-                _TOTALS["empty_backoffs"] += 1
+        count = int(row.get("failure_count") or 0) + 1
+        row.update({"failure_count": count, "last_failure_type": failure_type, "last_error": detail[:500], "updated_ts": time.time()})
+        if protected:
+            row.pop("blocked_until", None)
+            row.pop("reason", None)
+            _TOTALS["protected_backoff_prevented"] += 1
+        elif count >= FAILURE_BACKOFF_THRESHOLD:
+            row.update({"reason": "short_retry_backoff", "blocked_until": time.time() + FAILURE_BACKOFF_SECONDS})
+            _TOTALS["short_backoffs"] += 1
         _SYMBOL_STATE[symbol] = row
 
 
 def _clear_success(symbols: Sequence[str]) -> None:
     with _LOCK:
         for symbol in symbols:
-            row = dict(_SYMBOL_STATE.get(symbol) or {})
-            if not row:
-                continue
-            if str(row.get("reason") or "") == "provider_confirmed_no_data":
-                continue
-            _SYMBOL_STATE.pop(symbol, None)
+            _SYMBOL_STATE.pop(normalize_symbol(symbol), None)
+
+
+def _symbol_has_data(frame: Any, symbol: str, symbols: Sequence[str]) -> bool:
+    if _frame_empty(frame):
+        return False
+    if len(symbols) == 1:
+        return True
+    try:
+        columns = getattr(frame, "columns", None)
+        if int(getattr(columns, "nlevels", 1)) > 1:
+            for level in range(int(columns.nlevels)):
+                values = {normalize_symbol(value) for value in columns.get_level_values(level)}
+                if symbol in values:
+                    subset = frame.xs(symbol, axis=1, level=level, drop_level=False)
+                    return not bool(subset.dropna(how="all").empty)
+    except Exception:
+        pass
+    return True
 
 
 def _filter_warning() -> None:
-    warnings.filterwarnings(
-        "ignore",
-        message=r".*Timestamp\.utcnow is deprecated.*",
-        category=Warning,
-        module=r"yfinance\.scrapers\.quote",
-    )
+    warnings.filterwarnings("ignore", message=r".*Timestamp\.utcnow is deprecated.*", category=Warning, module=r"yfinance\.scrapers\.quote")
 
 
 def _patch_runtime_sources(core: Any = None) -> None:
+    _refresh_protected_symbols(core)
     static = static_blocked_symbols()
     if core is not None:
         try:
             universe = list(getattr(core, "UNIVERSE", []) or [])
-            setattr(core, "UNIVERSE", [symbol for symbol in universe if normalize_symbol(symbol) not in static])
+            core.UNIVERSE = [symbol for symbol in universe if normalize_symbol(symbol) not in static]
         except Exception:
             pass
     broad = sys.modules.get("broad_momentum_discovery")
     if broad is not None:
         current = getattr(broad, "_symbol", None)
         if callable(current) and getattr(current, "_yfinance_data_hygiene_version", None) != VERSION:
-            prior = current
-
+            prior = getattr(current, "_yfinance_data_hygiene_prior", current)
             def hygienic_symbol(value: Any) -> str:
                 symbol = normalize_symbol(prior(value))
-                return "" if is_blocked_symbol(symbol) else symbol
-
+                return "" if symbol in static_blocked_symbols() else symbol
             hygienic_symbol._yfinance_data_hygiene_version = VERSION  # type: ignore[attr-defined]
             hygienic_symbol._yfinance_data_hygiene_prior = prior  # type: ignore[attr-defined]
-            setattr(broad, "_symbol", hygienic_symbol)
-            try:
-                cache = getattr(broad, "_CACHE", None)
-                if isinstance(cache, dict):
-                    cache.clear()
-                    cache.update({"ts": 0.0, "payload": None})
-            except Exception:
-                pass
+            broad._symbol = hygienic_symbol
 
 
 def install(core: Any = None) -> Dict[str, Any]:
     global _ORIGINAL_DOWNLOAD, _INSTALLED
     _filter_warning()
+    _refresh_protected_symbols(core)
     try:
         import yfinance as yf  # type: ignore
     except Exception as exc:
-        return {
-            "status": "pending",
-            "overall": "warn",
-            "version": VERSION,
-            "reason": f"yfinance_unavailable:{type(exc).__name__}",
-        }
-
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": f"yfinance_unavailable:{type(exc).__name__}"}
     current = getattr(yf, "download", None)
     if not callable(current):
         return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "yf_download_missing"}
@@ -360,13 +369,13 @@ def install(core: Any = None) -> Dict[str, Any]:
         _INSTALLED = True
         _patch_runtime_sources(core)
         return status_payload(core)
-
     original = getattr(current, "_yfinance_data_hygiene_original", current)
     _ORIGINAL_DOWNLOAD = original
 
     def guarded_download(tickers: Any, *args: Any, **kwargs: Any) -> Any:
         with _LOCK:
             _TOTALS["requests"] += 1
+        _refresh_protected_symbols(core)
         cleaned, symbols, blocked = sanitize_tickers(tickers)
         if blocked:
             with _LOCK:
@@ -375,44 +384,35 @@ def install(core: Any = None) -> Dict[str, Any]:
             _record_event("blocked_before_provider", [str(row.get("symbol") or "") for row in blocked])
         if not symbols:
             return _empty_frame()
-
         key = _cache_key(symbols, args, kwargs)
         cached = _cache_get(key)
         if cached is not None:
             return cached
-
+        _clear_provider_errors(yf, symbols)
         with _LOCK:
             _TOTALS["provider_calls"] += 1
         try:
             frame = original(cleaned, *args, **kwargs)
         except Exception as exc:
             detail = f"{type(exc).__name__}: {exc}"
-            failure_type = _classify_error(detail)
             for symbol in symbols:
-                _apply_failure(symbol, failure_type, detail)
-            _record_event(failure_type, symbols, detail)
+                _apply_failure(symbol, _failure_kind(detail), detail)
+            _record_event("provider_exception", symbols, detail)
             raise
-
-        symbol_errors: Dict[str, str] = {}
-        for symbol in symbols:
-            text = _provider_error_text(yf, symbol)
-            if text:
-                symbol_errors[symbol] = text
-                _apply_failure(symbol, _classify_error(text), text)
-
+        errors = _provider_errors(yf, symbols)
+        successes = [symbol for symbol in symbols if _symbol_has_data(frame, symbol, symbols)]
+        _clear_success(successes)
+        failed = [symbol for symbol in symbols if symbol not in successes]
+        for symbol in failed:
+            detail = errors.get(symbol) or "empty yfinance response"
+            _apply_failure(symbol, _failure_kind(detail), detail)
         if _frame_empty(frame):
-            for symbol in symbols:
-                if symbol not in symbol_errors:
-                    _apply_failure(symbol, "empty", "empty yfinance response")
-            _record_event("empty", symbols, "; ".join(symbol_errors.values()))
+            _record_event("empty", symbols, "; ".join(errors.values()))
             return frame
-
-        successful = [symbol for symbol in symbols if symbol not in symbol_errors]
-        _clear_success(successful)
         with _LOCK:
             _TOTALS["successful_calls"] += 1
         _cache_put(key, frame)
-        _record_event("ok", successful or symbols)
+        _record_event("ok" if not failed else "partial_ok", successes or symbols, "; ".join(errors.values()))
         return frame
 
     guarded_download._yfinance_data_hygiene_version = VERSION  # type: ignore[attr-defined]
@@ -429,19 +429,19 @@ def install(core: Any = None) -> Dict[str, Any]:
 
 
 def status_payload(core: Any = None) -> Dict[str, Any]:
+    protected = _refresh_protected_symbols(core)
     now = time.time()
     with _LOCK:
         active = {
             symbol: {
                 "reason": str(row.get("reason") or ""),
                 "seconds_remaining": max(0.0, round(float(row.get("blocked_until") or 0.0) - now, 1)),
-                "empty_count": int(row.get("empty_count") or 0),
-                "timeout_count": int(row.get("timeout_count") or 0),
-                "no_data_count": int(row.get("no_data_count") or 0),
+                "failure_count": int(row.get("failure_count") or 0),
+                "last_failure_type": row.get("last_failure_type"),
                 "last_error": str(row.get("last_error") or "")[:300],
             }
             for symbol, row in _SYMBOL_STATE.items()
-            if float(row.get("blocked_until") or 0.0) > now
+            if float(row.get("blocked_until") or 0.0) > now and symbol not in protected
         }
         totals = dict(_TOTALS)
         events = list(_EVENTS[-30:])
@@ -453,13 +453,21 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "version": VERSION,
         "generated_local": _now_text(core),
         "installed": _INSTALLED,
-        "warning_filter": "yfinance.scrapers.quote Timestamp.utcnow only",
         "known_no_data_symbols": sorted(static_blocked_symbols()),
+        "protected_symbols": sorted(protected),
+        "protected_symbol_blocks": [],
         "active_symbol_backoffs": active,
         "cache_ttl_seconds": CACHE_TTL_SECONDS,
         "cache_rows": cache_rows,
         "totals": totals,
         "recent_events": events,
+        "regression_guards": {
+            "stale_shared_errors_cleared_before_each_call": True,
+            "provider_missing_data_is_transient": True,
+            "no_dynamic_hard_delisting_quarantine": True,
+            "benchmarks_and_open_positions_never_dynamically_blocked": True,
+            "success_clears_symbol_failure_state": True,
+        },
         "authority": {
             "changes_entry_rules": False,
             "changes_hard_risk": False,
@@ -491,9 +499,8 @@ def register_routes(flask_app: Any, core: Any = None) -> None:
         existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
     except Exception:
         existing = set()
-    path = "/paper/yfinance-data-hygiene-status"
-    if path not in existing:
-        flask_app.add_url_rule(path, "yfinance_data_hygiene_status", lambda: jsonify(status_payload(core)))
+    if "/paper/yfinance-data-hygiene-status" not in existing:
+        flask_app.add_url_rule("/paper/yfinance-data-hygiene-status", "yfinance_data_hygiene_status", lambda: jsonify(status_payload(core)))
     _REGISTERED_APP_IDS.add(id(flask_app))
     install(core)
 


### PR DESCRIPTION
## Summary
- prevent benchmark ETFs and open-position symbols from entering dynamic yFinance quarantine
- distinguish transient empty/timeout responses from confirmed no-data symbols
- isolate provider failures by symbol so ordinary missing bars do not cascade into a global circuit condition
- rebuild intratrade MAE/MFE tracking around exact symbol, entry time, entry price, side, and lifecycle identity
- quarantine legacy or unverifiable path features from ML and mark them training-ineligible
- extend the routine daily audit so protected-symbol quarantine, provider-circuit activation, contaminated path features, or MAE/MFE integrity errors cannot appear as a clean pass
- add focused regression tests

## Safety boundary
No entry-rule, threshold, sizing, hard-risk, order-placement, live-authority, or ML-authority changes. Execution remains existing-rules-only and ML remains shadow recommendation only.

## Validation requirements
- focused data-integrity tests pass
- repository validation and exact Gunicorn startup smoke pass
- Railway deployments succeed
- `/paper/daily-audit` includes the data-integrity section
- `/paper/yfinance-data-hygiene-status` shows no protected benchmark or open-position symbol dynamically quarantined
- `/paper/provider-health-status` shows the provider circuit closed under ordinary isolated failures
- MAE/MFE integrity status shows contaminated legacy rows quarantined and excluded from training