### PR TITLE
Compact daily audit and finalize integrity reporting

### DIFF
--- a/.github/workflows/daily-operational-audit.yml
+++ b/.github/workflows/daily-operational-audit.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - "daily_operational_audit.py"
       - "daily_audit_repair_overlay.py"
+      - "daily_data_integrity_audit_overlay.py"
+      - "data_integrity_startup_bridge.py"
       - "cycle_completion_contract.py"
       - "provider_timeout_contract.py"
       - "state_persistence_contract.py"
@@ -13,6 +15,7 @@ on:
       - "bootstrap/sitecustomize.py"
       - "test_daily_operational_audit.py"
       - "test_runtime_repair_contracts.py"
+      - "test_daily_data_integrity_overlay_v2.py"
       - "usercustomize.py"
       - ".github/workflows/daily-operational-audit.yml"
   workflow_dispatch:
@@ -39,7 +42,8 @@ jobs:
         run: |
           python -m unittest -v \
             test_daily_operational_audit.py \
-            test_runtime_repair_contracts.py
+            test_runtime_repair_contracts.py \
+            test_daily_data_integrity_overlay_v2.py
 
       - name: Wait for the repaired Railway runtime
         id: deployment_ready
@@ -83,7 +87,7 @@ jobs:
             "cycle_completion_contract_live.json:/paper/cycle-completion-contract-status" \
             "state_persistence_contract_live.json:/paper/state-persistence-contract-status" \
             "provider_timeout_contract_live.json:/paper/provider-timeout-contract-status" \
-            "daily_operational_audit_live.json:/paper/daily-audit"; do
+            "daily_operational_audit_live.json:/paper/daily-audit?full=1"; do
             file=${spec%%:*}
             path=${spec#*:}
             curl --silent --show-error --fail \
@@ -107,13 +111,15 @@ jobs:
           sections = daily.get("sections")
           contract = daily.get("performance_contract", {})
           authority = daily.get("authority", {})
+          conclusion = (sections or {}).get("11_conclusion", {})
 
           assert bootstrap.get("status") == "ready", bootstrap
           assert bootstrap.get("delegate_ready") is True, bootstrap
           assert daily.get("status") == "ok", daily
           assert daily.get("type") == "daily_operational_audit", daily
-          assert isinstance(sections, dict) and len(sections) == 12, sections
+          assert isinstance(sections, dict) and len(sections) == 13, sections
           assert daily.get("repair_overlay_version"), daily
+          assert daily.get("data_integrity_overlay_version"), daily
           assert contract.get("route_fanout_count") == 0, contract
           assert contract.get("external_provider_calls") == 0, contract
           assert contract.get("trading_actions") == 0, contract
@@ -121,7 +127,9 @@ jobs:
           assert contract.get("bounded_output") is True, contract
           assert authority.get("reporting_only") is True, authority
           assert float(daily.get("duration_seconds", 999.0)) <= 5.0, daily.get("duration_seconds")
-          assert sections.get("11_conclusion", {}).get("status") in {"pass", "warn", "fail"}
+          assert conclusion.get("status") in {"pass", "warn", "fail"}, conclusion
+          assert conclusion.get("checked_sections") == 11, conclusion
+          assert sections.get("10b_market_data_and_path_integrity", {}).get("status") in {"pass", "warn", "fail"}
           assert sections.get("12_next_action", {}).get("status") in {"none", "required"}
 
           assert cycle.get("status") == "ok" and cycle.get("installed") is True, cycle
@@ -135,6 +143,7 @@ jobs:
               "overall": daily.get("overall"),
               "duration_seconds": daily.get("duration_seconds"),
               "section_count": len(sections),
+              "checked_sections": conclusion.get("checked_sections"),
               "cycle_health": cycle.get("cycle_health"),
               "cycle_phase": cycle.get("cycle_phase"),
               "cycle_in_progress": cycle.get("cycle_in_progress"),

--- a/daily_data_integrity_audit_overlay.py
+++ b/daily_data_integrity_audit_overlay.py
@@ -1,9 +1,11 @@
-"""Read-only data-integrity extension for the routine daily audit.
+"""Read-only data-integrity finalizer for the routine daily audit.
 
 The overlay makes provider and MAE/MFE integrity failures visible in the same
-routine audit the operator already uses. It does not call providers, place
-orders, repair state, change strategy logic, change thresholds, change sizing,
-or change live/ML authority.
+routine audit the operator already uses. It also provides a compact default
+response while preserving the complete audit behind ``?full=1``.
+
+It does not call providers, place orders, repair state, change strategy logic,
+change thresholds, change sizing, or change live/ML authority.
 """
 from __future__ import annotations
 
@@ -11,7 +13,7 @@ import functools
 import sys
 from typing import Any, Dict, List
 
-VERSION = "daily-data-integrity-audit-overlay-2026-08-06-v1"
+VERSION = "daily-data-integrity-audit-overlay-2026-08-06-v2-compact-finalizer"
 SECTION_KEY = "10b_market_data_and_path_integrity"
 _APPLIED = False
 _REGISTERED_APP_IDS: set[int] = set()
@@ -23,6 +25,22 @@ def _d(value: Any) -> Dict[str, Any]:
 
 def _l(value: Any) -> List[Any]:
     return value if isinstance(value, list) else []
+
+
+def _int(value: Any, default: int = 0) -> int:
+    try:
+        if value is None or isinstance(value, bool):
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _first(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
 
 
 def _module() -> Any | None:
@@ -77,6 +95,72 @@ def _feature_contamination(rows: Any) -> List[Dict[str, Any]]:
     return contaminated
 
 
+def _integrity_counts(
+    path: Dict[str, Any],
+    path_status: Dict[str, Any],
+    integration: Dict[str, Any],
+    integration_status: Dict[str, Any],
+) -> Dict[str, int]:
+    valid_path_rows = _int(
+        _first(
+            integration_status.get("valid_path_rows"),
+            integration.get("valid_path_rows"),
+            path_status.get("valid_path_rows"),
+        )
+    )
+    invalid_path_rows = _int(
+        _first(
+            integration_status.get("invalid_or_quarantined_path_rows"),
+            integration.get("invalid_or_quarantined_path_rows"),
+            path_status.get("invalid_or_quarantined_rows"),
+            path.get("invalid_or_quarantined_rows"),
+        )
+    )
+    training_eligible_path_rows = _int(
+        _first(
+            path_status.get("training_eligible_rows"),
+            path.get("training_eligible_rows"),
+            valid_path_rows,
+        )
+    )
+    ml_rows_enriched = _int(
+        _first(integration_status.get("ml_rows_enriched"), integration.get("ml_rows_enriched"))
+    )
+    ml_rows_quarantined = _int(
+        _first(integration_status.get("ml_rows_quarantined"), integration.get("ml_rows_quarantined"))
+    )
+    trade_rows_enriched = _int(
+        _first(integration_status.get("trade_rows_enriched"), integration.get("trade_rows_enriched"))
+    )
+    trade_rows_quarantined = _int(
+        _first(
+            integration_status.get("trade_rows_quarantined"),
+            integration.get("trade_rows_quarantined"),
+        )
+    )
+    recomputed_rows = _int(
+        _first(
+            integration_status.get("recomputed_rows"),
+            integration.get("recomputed_rows"),
+            path_status.get("recomputed_rows"),
+            path.get("recomputed_rows"),
+            0,
+        )
+    )
+    return {
+        "valid_path_rows": valid_path_rows,
+        "invalid_or_quarantined_path_rows": invalid_path_rows,
+        "training_eligible_path_rows": training_eligible_path_rows,
+        "training_eligible_feature_rows": valid_path_rows,
+        "ml_rows_enriched": ml_rows_enriched,
+        "ml_rows_quarantined": ml_rows_quarantined,
+        "trade_rows_enriched": trade_rows_enriched,
+        "trade_rows_quarantined": trade_rows_quarantined,
+        "quarantined_feature_rows": ml_rows_quarantined + trade_rows_quarantined,
+        "recomputed_rows": recomputed_rows,
+    }
+
+
 def build_integrity_section(core: Any = None) -> Dict[str, Any]:
     core = core or _module()
     portfolio = _d(getattr(core, "portfolio", {})) if core is not None else {}
@@ -93,12 +177,18 @@ def build_integrity_section(core: Any = None) -> Dict[str, Any]:
     benchmark_blocked = sorted({"SPY", "QQQ", "IWM", "DIA"} & blocked_symbols)
 
     path = _d(portfolio.get("intratrade_path_capture"))
+    path_status = _safe_status("intratrade_path_capture", core)
     integration = _d(portfolio.get("mae_mfe_integration"))
+    integration_status = _safe_status("mae_mfe_integration", core)
+    counts = _integrity_counts(path, path_status, integration, integration_status)
+
     ml2 = _d(portfolio.get("ml_phase2"))
     contaminated = _feature_contamination(ml2.get("dataset")) + _feature_contamination(portfolio.get("trades"))
 
     integration_error = (
-        integration.get("last_error")
+        integration_status.get("last_error")
+        or integration.get("last_error")
+        or path_status.get("last_error")
         or path.get("last_error")
         or (_d(integration.get("intratrade_refresh")).get("error"))
     )
@@ -134,20 +224,34 @@ def build_integrity_section(core: Any = None) -> Dict[str, Any]:
         "provider_distinct_failure_symbols": provider.get("distinct_provider_failure_symbols") or [],
         "provider_totals": provider.get("totals") or {},
         "path_integrity": {
-            "version": path.get("version"),
-            "invalid_or_quarantined_rows": path.get("invalid_or_quarantined_rows"),
-            "training_eligible_rows": path.get("training_eligible_rows"),
-            "integrity_resets": path.get("integrity_resets"),
-            "last_error": path.get("last_error"),
+            "version": _first(path_status.get("version"), path.get("version")),
+            "valid_rows": counts["valid_path_rows"],
+            "invalid_or_quarantined_rows": counts["invalid_or_quarantined_path_rows"],
+            "training_eligible_rows": counts["training_eligible_path_rows"],
+            "recomputed_rows": counts["recomputed_rows"],
+            "integrity_resets": _int(_first(path_status.get("integrity_resets"), path.get("integrity_resets"))),
+            "last_error": _first(path_status.get("last_error"), path.get("last_error")),
         },
         "mae_mfe_integrity": {
-            "version": integration.get("version"),
-            "quarantined_feature_rows": integration.get("quarantined_feature_rows"),
-            "training_eligible_feature_rows": integration.get("training_eligible_feature_rows"),
-            "last_error": integration.get("last_error"),
+            "version": _first(integration_status.get("version"), integration.get("version")),
+            "valid_path_rows": counts["valid_path_rows"],
+            "invalid_or_quarantined_path_rows": counts["invalid_or_quarantined_path_rows"],
+            "training_eligible_feature_rows": counts["training_eligible_feature_rows"],
+            "quarantined_feature_rows": counts["quarantined_feature_rows"],
+            "ml_rows_enriched": counts["ml_rows_enriched"],
+            "ml_rows_quarantined": counts["ml_rows_quarantined"],
+            "trade_rows_enriched": counts["trade_rows_enriched"],
+            "trade_rows_quarantined": counts["trade_rows_quarantined"],
+            "recomputed_rows": counts["recomputed_rows"],
+            "last_error": integration_error,
         },
         "active_contaminated_feature_count": len(contaminated),
         "active_contaminated_feature_examples": contaminated[:10],
+        "forward_validation": {
+            "valid_exact_lifecycle_rows_observed": counts["valid_path_rows"],
+            "complete": counts["valid_path_rows"] > 0,
+            "historical_backfill_established": counts["recomputed_rows"] > 0,
+        },
         "authority": {
             "reporting_only": True,
             "changes_strategy": False,
@@ -162,7 +266,8 @@ def build_integrity_section(core: Any = None) -> Dict[str, Any]:
 def _recalculate(payload: Dict[str, Any], daily: Any) -> None:
     sections = _d(payload.get("sections"))
     operational_keys = [
-        key for key in sections
+        key
+        for key in sections
         if key not in {"11_conclusion", "12_next_action"}
     ]
     statuses = [_d(sections.get(key)).get("status") for key in operational_keys]
@@ -191,6 +296,124 @@ def _recalculate(payload: Dict[str, Any], daily: Any) -> None:
             pass
 
 
+def _finalize_payload(payload: Dict[str, Any], daily: Any, core: Any = None) -> Dict[str, Any]:
+    if not isinstance(payload, dict):
+        return payload
+    sections = _d(payload.setdefault("sections", {}))
+    sections[SECTION_KEY] = build_integrity_section(core)
+    payload["data_integrity_overlay_version"] = VERSION
+    _recalculate(payload, daily)
+
+    risk = _d(sections.get("04_risk_controls_and_drawdown"))
+    if "realized_loss_pct" in risk:
+        risk["net_daily_loss_pct"] = risk.get("realized_loss_pct")
+        risk["realized_loss_pct_source_key"] = "risk_controls.daily_loss_pct"
+        risk["metric_label_note"] = (
+            "realized_loss_pct is retained for compatibility; net_daily_loss_pct "
+            "is the canonical operator label for this runtime daily-loss metric."
+        )
+
+    links = _d(payload.get("links"))
+    routine = links.get("routine_daily_audit")
+    if routine:
+        links["full_daily_audit"] = f"{str(routine).split('?')[0]}?full=1"
+    return payload
+
+
+def _compact_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    sections = _d(payload.get("sections"))
+    account = _d(sections.get("01_account_and_open_position_performance"))
+    runner = _d(sections.get("02_auto_runner_liveness"))
+    errors = _d(sections.get("03_active_errors_and_recursion"))
+    risk = _d(sections.get("04_risk_controls_and_drawdown"))
+    scanner = _d(sections.get("05_scanner_signals_entries_rejections"))
+    blockers = _d(sections.get("06_top_five_blockers"))
+    journal = _d(sections.get("08_trade_journal_reconciliation"))
+    persistence = _d(sections.get("09_state_persistence_backup_recovery"))
+    integrity = _d(sections.get(SECTION_KEY))
+    conclusion = _d(sections.get("11_conclusion"))
+    next_action = _d(sections.get("12_next_action"))
+
+    return {
+        "status": payload.get("status"),
+        "overall": payload.get("overall"),
+        "type": "daily_operational_audit_compact",
+        "version": payload.get("version"),
+        "data_integrity_overlay_version": VERSION,
+        "generated_local": payload.get("generated_local"),
+        "duration_seconds": payload.get("duration_seconds"),
+        "section_summary": {
+            "checked": conclusion.get("checked_sections"),
+            "pass": conclusion.get("pass_count"),
+            "warn": conclusion.get("warn_count"),
+            "fail": conclusion.get("fail_count"),
+        },
+        "account": {
+            "cash": account.get("cash"),
+            "equity": account.get("equity"),
+            "open_positions_count": account.get("open_positions_count"),
+            "positions": account.get("positions") or [],
+            "realized_today": account.get("realized_today"),
+            "realized_total": account.get("realized_total"),
+            "unrealized_pnl": account.get("unrealized_pnl"),
+            "wins_total": account.get("wins_total"),
+            "losses_total": account.get("losses_total"),
+        },
+        "runner": {
+            "status": runner.get("status"),
+            "enabled": runner.get("enabled"),
+            "liveness_state": runner.get("liveness_state"),
+            "last_completed_cycle": runner.get("last_completed_cycle"),
+            "last_completed_cycle_duration_seconds": runner.get("last_completed_cycle_duration_seconds"),
+            "last_skip_reason": runner.get("last_skip_reason"),
+        },
+        "errors": {
+            "status": errors.get("status"),
+            "active_error": errors.get("active_error"),
+            "last_error": errors.get("last_error"),
+            "recursion_error_active": errors.get("recursion_error_active"),
+        },
+        "risk": {
+            "status": risk.get("status"),
+            "halted": risk.get("halted"),
+            "halt_reason": risk.get("halt_reason"),
+            "self_defense_active": risk.get("self_defense_active"),
+            "net_daily_loss_pct": _first(risk.get("net_daily_loss_pct"), risk.get("realized_loss_pct")),
+            "intraday_drawdown_pct": risk.get("intraday_drawdown_pct"),
+            "absolute_daily_loss_ceiling_pct": risk.get("absolute_daily_loss_ceiling_pct"),
+            "hard_intraday_drawdown_halt_pct": risk.get("hard_intraday_drawdown_halt_pct"),
+        },
+        "scanner": {
+            "status": scanner.get("status"),
+            "signals_found": scanner.get("signals_found"),
+            "entries_count": scanner.get("entries_count"),
+            "rejected_signals_count": scanner.get("rejected_signals_count"),
+            "top_blockers": _l(blockers.get("blockers"))[:5],
+        },
+        "reconciliation": {
+            "journal_status": journal.get("status"),
+            "execution_rows_match": journal.get("execution_rows_match"),
+            "open_positions_match": journal.get("open_positions_match"),
+            "persistence_status": persistence.get("status"),
+            "state_file_exists": persistence.get("state_file_exists"),
+            "backup_count": persistence.get("backup_count"),
+        },
+        "data_integrity": {
+            "status": integrity.get("status"),
+            "reasons": integrity.get("reasons") or [],
+            "provider_circuit_open": integrity.get("provider_circuit_open"),
+            "protected_symbols_blocked": integrity.get("protected_symbols_blocked") or [],
+            "active_contaminated_feature_count": integrity.get("active_contaminated_feature_count"),
+            "path_integrity": integrity.get("path_integrity") or {},
+            "mae_mfe_integrity": integrity.get("mae_mfe_integrity") or {},
+            "forward_validation": integrity.get("forward_validation") or {},
+        },
+        "next_action": next_action,
+        "links": payload.get("links") or {},
+        "authority": payload.get("authority") or {},
+    }
+
+
 def apply(core: Any = None) -> Dict[str, Any]:
     global _APPLIED
     try:
@@ -215,13 +438,7 @@ def apply(core: Any = None) -> Dict[str, Any]:
     def wrapped_build_payload(runtime: Any = None):
         active_core = runtime or core or _module()
         payload = current(active_core)
-        if not isinstance(payload, dict):
-            return payload
-        sections = _d(payload.get("sections"))
-        sections[SECTION_KEY] = build_integrity_section(active_core)
-        payload["data_integrity_overlay_version"] = VERSION
-        _recalculate(payload, daily)
-        return payload
+        return _finalize_payload(payload, daily, active_core)
 
     wrapped_build_payload._daily_data_integrity_overlay = VERSION  # type: ignore[attr-defined]
     daily.build_payload = wrapped_build_payload
@@ -237,6 +454,8 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "version": VERSION,
         "applied": _APPLIED,
         "section_key": SECTION_KEY,
+        "daily_audit_default_mode": "compact",
+        "daily_audit_full_query": "?full=1",
         "integrity": build_integrity_section(core),
         "authority": {
             "reporting_only": True,
@@ -249,21 +468,57 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
     }
 
 
-def register_routes(flask_app: Any, core: Any = None) -> None:
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
     if flask_app is None:
-        return
-    from flask import jsonify
+        return {"status": "error", "version": VERSION, "error": "flask_app_missing"}
+
+    from flask import jsonify, request
+    import daily_operational_audit as daily
+
     apply(core)
-    if id(flask_app) in _REGISTERED_APP_IDS:
-        return
+    active_core = core or _module()
+
+    def daily_audit_view():
+        payload = daily.build_payload(active_core or _module())
+        payload = _finalize_payload(payload, daily, active_core or _module())
+        full = str(request.args.get("full", "")).strip().lower() in {"1", "true", "yes", "on"}
+        return jsonify(payload if full else _compact_payload(payload))
+
+    daily_audit_view._daily_operational_audit_version = VERSION  # type: ignore[attr-defined]
     try:
-        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+        rules = list(flask_app.url_map.iter_rules())
+        existing = {getattr(rule, "rule", "") for rule in rules}
     except Exception:
+        rules = []
         existing = set()
-    path = "/paper/data-integrity-audit-status"
-    if path not in existing:
-        flask_app.add_url_rule(path, "paper_data_integrity_audit_status", lambda: jsonify(status_payload(core or _module())))
+
+    daily_path = getattr(daily, "ROUTE", "/paper/daily-audit")
+    if daily_path not in existing:
+        flask_app.add_url_rule(daily_path, "paper_daily_audit", daily_audit_view)
+    else:
+        endpoint = next(
+            (getattr(rule, "endpoint", None) for rule in rules if getattr(rule, "rule", "") == daily_path),
+            None,
+        )
+        if endpoint:
+            flask_app.view_functions[endpoint] = daily_audit_view
+
+    status_path = "/paper/data-integrity-audit-status"
+    if status_path not in existing:
+        flask_app.add_url_rule(
+            status_path,
+            "paper_data_integrity_audit_status",
+            lambda: jsonify(status_payload(active_core or _module())),
+        )
+
     _REGISTERED_APP_IDS.add(id(flask_app))
+    return {
+        "status": "ok",
+        "version": VERSION,
+        "daily_route_finalizer_installed": True,
+        "daily_audit_default_mode": "compact",
+        "daily_audit_full_query": "?full=1",
+    }
 
 
 try:

--- a/test_daily_data_integrity_overlay_v2.py
+++ b/test_daily_data_integrity_overlay_v2.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import daily_data_integrity_audit_overlay as overlay
+
+
+class _Daily:
+    @staticmethod
+    def _next_action(sections):
+        return {
+            "status": "none",
+            "priority": None,
+            "section": None,
+            "action": "none",
+            "reason": None,
+        }
+
+
+def _base_payload():
+    sections = {
+        f"{index:02d}_section": {"status": "pass", "reasons": []}
+        for index in range(1, 11)
+    }
+    sections["04_risk_controls_and_drawdown"] = {
+        "status": "pass",
+        "reasons": [],
+        "realized_loss_pct": 0.12,
+        "intraday_drawdown_pct": 0.12,
+    }
+    sections["11_conclusion"] = {
+        "status": "pass",
+        "pass_count": 10,
+        "warn_count": 0,
+        "fail_count": 0,
+        "checked_sections": 10,
+    }
+    sections["12_next_action"] = {"status": "none", "action": "none"}
+    return {
+        "status": "ok",
+        "overall": "pass",
+        "version": "test",
+        "generated_local": "2026-08-06 13:46:56 CDT",
+        "duration_seconds": 0.2,
+        "sections": sections,
+        "links": {"routine_daily_audit": "https://example.test/paper/daily-audit"},
+        "authority": {"reporting_only": True},
+    }
+
+
+def test_finalizer_counts_integrity_section_after_outer_wrappers(monkeypatch):
+    monkeypatch.setattr(
+        overlay,
+        "build_integrity_section",
+        lambda core=None: {
+            "status": "pass",
+            "reasons": [],
+            "provider_circuit_open": False,
+            "protected_symbols_blocked": [],
+            "active_contaminated_feature_count": 0,
+            "path_integrity": {
+                "valid_rows": 0,
+                "invalid_or_quarantined_rows": 4,
+                "training_eligible_rows": 0,
+                "recomputed_rows": 0,
+            },
+            "mae_mfe_integrity": {
+                "valid_path_rows": 0,
+                "invalid_or_quarantined_path_rows": 4,
+                "training_eligible_feature_rows": 0,
+                "quarantined_feature_rows": 4,
+                "recomputed_rows": 0,
+            },
+            "forward_validation": {
+                "valid_exact_lifecycle_rows_observed": 0,
+                "complete": False,
+                "historical_backfill_established": False,
+            },
+        },
+    )
+
+    payload = overlay._finalize_payload(_base_payload(), _Daily(), SimpleNamespace())
+    conclusion = payload["sections"]["11_conclusion"]
+
+    assert conclusion == {
+        "status": "pass",
+        "pass_count": 11,
+        "warn_count": 0,
+        "fail_count": 0,
+        "checked_sections": 11,
+    }
+    risk = payload["sections"]["04_risk_controls_and_drawdown"]
+    assert risk["net_daily_loss_pct"] == 0.12
+    assert risk["realized_loss_pct_source_key"] == "risk_controls.daily_loss_pct"
+    assert payload["links"]["full_daily_audit"].endswith("/paper/daily-audit?full=1")
+
+
+def test_compact_payload_keeps_operator_fields_without_full_sections(monkeypatch):
+    monkeypatch.setattr(
+        overlay,
+        "build_integrity_section",
+        lambda core=None: {
+            "status": "pass",
+            "reasons": [],
+            "provider_circuit_open": False,
+            "protected_symbols_blocked": [],
+            "active_contaminated_feature_count": 0,
+            "path_integrity": {
+                "valid_rows": 0,
+                "invalid_or_quarantined_rows": 4,
+                "training_eligible_rows": 0,
+                "recomputed_rows": 0,
+            },
+            "mae_mfe_integrity": {
+                "valid_path_rows": 0,
+                "invalid_or_quarantined_path_rows": 4,
+                "training_eligible_feature_rows": 0,
+                "quarantined_feature_rows": 4,
+                "recomputed_rows": 0,
+            },
+            "forward_validation": {
+                "valid_exact_lifecycle_rows_observed": 0,
+                "complete": False,
+                "historical_backfill_established": False,
+            },
+        },
+    )
+
+    payload = overlay._finalize_payload(_base_payload(), _Daily(), SimpleNamespace())
+    compact = overlay._compact_payload(payload)
+
+    assert compact["type"] == "daily_operational_audit_compact"
+    assert compact["section_summary"]["checked"] == 11
+    assert compact["section_summary"]["pass"] == 11
+    assert compact["risk"]["net_daily_loss_pct"] == 0.12
+    assert compact["data_integrity"]["path_integrity"]["invalid_or_quarantined_rows"] == 4
+    assert "sections" not in compact
+
+
+def test_integrity_counts_are_explicit_integers():
+    counts = overlay._integrity_counts(
+        {"invalid_or_quarantined_rows": 4, "training_eligible_rows": 0},
+        {},
+        {
+            "valid_path_rows": 0,
+            "ml_rows_quarantined": 3,
+            "trade_rows_quarantined": 1,
+        },
+        {},
+    )
+
+    assert counts["valid_path_rows"] == 0
+    assert counts["invalid_or_quarantined_path_rows"] == 4
+    assert counts["training_eligible_feature_rows"] == 0
+    assert counts["quarantined_feature_rows"] == 4
+    assert counts["recomputed_rows"] == 0
+    assert all(isinstance(value, int) for value in counts.values())

--- a/test_daily_data_integrity_overlay_v2.py
+++ b/test_daily_data_integrity_overlay_v2.py
@@ -19,14 +19,21 @@ class _Daily:
 
 def _base_payload():
     sections = {
-        f"{index:02d}_section": {"status": "pass", "reasons": []}
-        for index in range(1, 11)
-    }
-    sections["04_risk_controls_and_drawdown"] = {
-        "status": "pass",
-        "reasons": [],
-        "realized_loss_pct": 0.12,
-        "intraday_drawdown_pct": 0.12,
+        "01_account_and_open_position_performance": {"status": "pass", "reasons": []},
+        "02_auto_runner_liveness": {"status": "pass", "reasons": []},
+        "03_active_errors_and_recursion": {"status": "pass", "reasons": []},
+        "04_risk_controls_and_drawdown": {
+            "status": "pass",
+            "reasons": [],
+            "realized_loss_pct": 0.12,
+            "intraday_drawdown_pct": 0.12,
+        },
+        "05_scanner_signals_entries_rejections": {"status": "pass", "reasons": []},
+        "06_top_five_blockers": {"status": "pass", "reasons": [], "blockers": []},
+        "07_entry_pipeline_ownership_and_stability": {"status": "pass", "reasons": []},
+        "08_trade_journal_reconciliation": {"status": "pass", "reasons": []},
+        "09_state_persistence_backup_recovery": {"status": "pass", "reasons": []},
+        "10_runtime_shadow_cycles_and_parity": {"status": "pass", "reasons": []},
     }
     sections["11_conclusion"] = {
         "status": "pass",

--- a/test_daily_data_integrity_overlay_v2.py
+++ b/test_daily_data_integrity_overlay_v2.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import daily_data_integrity_audit_overlay as overlay
 
@@ -55,110 +57,89 @@ def _base_payload():
     }
 
 
-def test_finalizer_counts_integrity_section_after_outer_wrappers(monkeypatch):
-    monkeypatch.setattr(
-        overlay,
-        "build_integrity_section",
-        lambda core=None: {
-            "status": "pass",
-            "reasons": [],
-            "provider_circuit_open": False,
-            "protected_symbols_blocked": [],
-            "active_contaminated_feature_count": 0,
-            "path_integrity": {
-                "valid_rows": 0,
-                "invalid_or_quarantined_rows": 4,
-                "training_eligible_rows": 0,
-                "recomputed_rows": 0,
-            },
-            "mae_mfe_integrity": {
-                "valid_path_rows": 0,
-                "invalid_or_quarantined_path_rows": 4,
-                "training_eligible_feature_rows": 0,
-                "quarantined_feature_rows": 4,
-                "recomputed_rows": 0,
-            },
-            "forward_validation": {
-                "valid_exact_lifecycle_rows_observed": 0,
-                "complete": False,
-                "historical_backfill_established": False,
-            },
-        },
-    )
-
-    payload = overlay._finalize_payload(_base_payload(), _Daily(), SimpleNamespace())
-    conclusion = payload["sections"]["11_conclusion"]
-
-    assert conclusion == {
+def _integrity_section():
+    return {
         "status": "pass",
-        "pass_count": 11,
-        "warn_count": 0,
-        "fail_count": 0,
-        "checked_sections": 11,
-    }
-    risk = payload["sections"]["04_risk_controls_and_drawdown"]
-    assert risk["net_daily_loss_pct"] == 0.12
-    assert risk["realized_loss_pct_source_key"] == "risk_controls.daily_loss_pct"
-    assert payload["links"]["full_daily_audit"].endswith("/paper/daily-audit?full=1")
-
-
-def test_compact_payload_keeps_operator_fields_without_full_sections(monkeypatch):
-    monkeypatch.setattr(
-        overlay,
-        "build_integrity_section",
-        lambda core=None: {
-            "status": "pass",
-            "reasons": [],
-            "provider_circuit_open": False,
-            "protected_symbols_blocked": [],
-            "active_contaminated_feature_count": 0,
-            "path_integrity": {
-                "valid_rows": 0,
-                "invalid_or_quarantined_rows": 4,
-                "training_eligible_rows": 0,
-                "recomputed_rows": 0,
-            },
-            "mae_mfe_integrity": {
-                "valid_path_rows": 0,
-                "invalid_or_quarantined_path_rows": 4,
-                "training_eligible_feature_rows": 0,
-                "quarantined_feature_rows": 4,
-                "recomputed_rows": 0,
-            },
-            "forward_validation": {
-                "valid_exact_lifecycle_rows_observed": 0,
-                "complete": False,
-                "historical_backfill_established": False,
-            },
+        "reasons": [],
+        "provider_circuit_open": False,
+        "protected_symbols_blocked": [],
+        "active_contaminated_feature_count": 0,
+        "path_integrity": {
+            "valid_rows": 0,
+            "invalid_or_quarantined_rows": 4,
+            "training_eligible_rows": 0,
+            "recomputed_rows": 0,
         },
-    )
-
-    payload = overlay._finalize_payload(_base_payload(), _Daily(), SimpleNamespace())
-    compact = overlay._compact_payload(payload)
-
-    assert compact["type"] == "daily_operational_audit_compact"
-    assert compact["section_summary"]["checked"] == 11
-    assert compact["section_summary"]["pass"] == 11
-    assert compact["risk"]["net_daily_loss_pct"] == 0.12
-    assert compact["data_integrity"]["path_integrity"]["invalid_or_quarantined_rows"] == 4
-    assert "sections" not in compact
-
-
-def test_integrity_counts_are_explicit_integers():
-    counts = overlay._integrity_counts(
-        {"invalid_or_quarantined_rows": 4, "training_eligible_rows": 0},
-        {},
-        {
+        "mae_mfe_integrity": {
             "valid_path_rows": 0,
-            "ml_rows_quarantined": 3,
-            "trade_rows_quarantined": 1,
+            "invalid_or_quarantined_path_rows": 4,
+            "training_eligible_feature_rows": 0,
+            "quarantined_feature_rows": 4,
+            "recomputed_rows": 0,
         },
-        {},
-    )
+        "forward_validation": {
+            "valid_exact_lifecycle_rows_observed": 0,
+            "complete": False,
+            "historical_backfill_established": False,
+        },
+    }
 
-    assert counts["valid_path_rows"] == 0
-    assert counts["invalid_or_quarantined_path_rows"] == 4
-    assert counts["training_eligible_feature_rows"] == 0
-    assert counts["quarantined_feature_rows"] == 4
-    assert counts["recomputed_rows"] == 0
-    assert all(isinstance(value, int) for value in counts.values())
+
+class DailyDataIntegrityOverlayV2Tests(unittest.TestCase):
+    def test_finalizer_counts_integrity_section_after_outer_wrappers(self):
+        with patch.object(overlay, "build_integrity_section", return_value=_integrity_section()):
+            payload = overlay._finalize_payload(_base_payload(), _Daily(), SimpleNamespace())
+
+        conclusion = payload["sections"]["11_conclusion"]
+        self.assertEqual(
+            conclusion,
+            {
+                "status": "pass",
+                "pass_count": 11,
+                "warn_count": 0,
+                "fail_count": 0,
+                "checked_sections": 11,
+            },
+        )
+        risk = payload["sections"]["04_risk_controls_and_drawdown"]
+        self.assertEqual(risk["net_daily_loss_pct"], 0.12)
+        self.assertEqual(risk["realized_loss_pct_source_key"], "risk_controls.daily_loss_pct")
+        self.assertTrue(payload["links"]["full_daily_audit"].endswith("/paper/daily-audit?full=1"))
+
+    def test_compact_payload_keeps_operator_fields_without_full_sections(self):
+        with patch.object(overlay, "build_integrity_section", return_value=_integrity_section()):
+            payload = overlay._finalize_payload(_base_payload(), _Daily(), SimpleNamespace())
+
+        compact = overlay._compact_payload(payload)
+        self.assertEqual(compact["type"], "daily_operational_audit_compact")
+        self.assertEqual(compact["section_summary"]["checked"], 11)
+        self.assertEqual(compact["section_summary"]["pass"], 11)
+        self.assertEqual(compact["risk"]["net_daily_loss_pct"], 0.12)
+        self.assertEqual(
+            compact["data_integrity"]["path_integrity"]["invalid_or_quarantined_rows"],
+            4,
+        )
+        self.assertNotIn("sections", compact)
+
+    def test_integrity_counts_are_explicit_integers(self):
+        counts = overlay._integrity_counts(
+            {"invalid_or_quarantined_rows": 4, "training_eligible_rows": 0},
+            {},
+            {
+                "valid_path_rows": 0,
+                "ml_rows_quarantined": 3,
+                "trade_rows_quarantined": 1,
+            },
+            {},
+        )
+
+        self.assertEqual(counts["valid_path_rows"], 0)
+        self.assertEqual(counts["invalid_or_quarantined_path_rows"], 4)
+        self.assertEqual(counts["training_eligible_feature_rows"], 0)
+        self.assertEqual(counts["quarantined_feature_rows"], 4)
+        self.assertEqual(counts["recomputed_rows"], 0)
+        self.assertTrue(all(isinstance(value, int) for value in counts.values()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make `/paper/daily-audit` compact by default while preserving the complete payload at `?full=1`
- re-finalize the audit after all wrapper layers so the new `10b` integrity section is included in conclusion totals
- expose explicit integer counts for valid, invalid/quarantined, training-eligible, enriched, quarantined, and recomputed MAE/MFE rows
- add forward-validation status without treating containment as completed evidence
- retain the legacy `realized_loss_pct` key for compatibility while introducing the clearer `net_daily_loss_pct` operator label
- add focused regression tests for section recounting, compact output, and non-null integrity counts

## Safety boundary
Reporting and observability only. No strategy, thresholds, sizing, risk controls, order placement, live authority, or ML authority changes.

## Validation
- focused tests must pass
- existing repository validation and startup smoke must remain healthy
- after merge, Railway must show compact default output, full output with `?full=1`, 11 checked sections, and unchanged trading authority