### PR TITLE
Add bootstrap registration heartbeat and provider accounting

### DIFF
--- a/.github/workflows/daily-operational-audit.yml
+++ b/.github/workflows/daily-operational-audit.yml
@@ -8,6 +8,8 @@ on:
       - "daily_audit_repair_overlay.py"
       - "daily_data_integrity_audit_overlay.py"
       - "data_integrity_startup_bridge.py"
+      - "provider_request_accounting_overlay.py"
+      - "bootstrap_wsgi.py"
       - "cycle_completion_contract.py"
       - "provider_timeout_contract.py"
       - "state_persistence_contract.py"
@@ -112,9 +114,13 @@ jobs:
           contract = daily.get("performance_contract", {})
           authority = daily.get("authority", {})
           conclusion = (sections or {}).get("11_conclusion", {})
+          integrity = (sections or {}).get("10b_market_data_and_path_integrity", {})
+          accounting = integrity.get("provider_request_accounting", {})
 
           assert bootstrap.get("status") == "ready", bootstrap
           assert bootstrap.get("delegate_ready") is True, bootstrap
+          assert bootstrap.get("version") == "deferred-wsgi-bootstrap-2026-08-06-v6-registration-heartbeat", bootstrap
+          assert isinstance(bootstrap.get("registration_duration_seconds"), (int, float)), bootstrap
           assert daily.get("status") == "ok", daily
           assert daily.get("type") == "daily_operational_audit", daily
           assert isinstance(sections, dict) and len(sections) == 13, sections
@@ -129,7 +135,9 @@ jobs:
           assert float(daily.get("duration_seconds", 999.0)) <= 5.0, daily.get("duration_seconds")
           assert conclusion.get("status") in {"pass", "warn", "fail"}, conclusion
           assert conclusion.get("checked_sections") == 11, conclusion
-          assert sections.get("10b_market_data_and_path_integrity", {}).get("status") in {"pass", "warn", "fail"}
+          assert integrity.get("status") in {"pass", "warn", "fail"}, integrity
+          assert isinstance(accounting.get("in_flight_or_unclassified_requests"), int), accounting
+          assert isinstance(accounting.get("accounting_complete_at_snapshot"), bool), accounting
           assert sections.get("12_next_action", {}).get("status") in {"none", "required"}
 
           assert cycle.get("status") == "ok" and cycle.get("installed") is True, cycle
@@ -144,6 +152,8 @@ jobs:
               "duration_seconds": daily.get("duration_seconds"),
               "section_count": len(sections),
               "checked_sections": conclusion.get("checked_sections"),
+              "registration_duration_seconds": bootstrap.get("registration_duration_seconds"),
+              "provider_request_gap": accounting.get("in_flight_or_unclassified_requests"),
               "cycle_health": cycle.get("cycle_health"),
               "cycle_phase": cycle.get("cycle_phase"),
               "cycle_in_progress": cycle.get("cycle_in_progress"),

--- a/bootstrap_wsgi.py
+++ b/bootstrap_wsgi.py
@@ -15,11 +15,13 @@ import time
 import traceback
 from typing import Any, Callable, Iterable
 
-VERSION = "deferred-wsgi-bootstrap-2026-08-06-v5-data-integrity-bridge"
+VERSION = "deferred-wsgi-bootstrap-2026-08-06-v6-registration-heartbeat"
 _START_MONOTONIC = time.monotonic()
 _LOCK = threading.RLock()
 _DELEGATE: Callable[..., Any] | None = None
 _LOADER_THREAD: threading.Thread | None = None
+_REGISTRATION_HEARTBEAT_INTERVAL_SECONDS = 5.0
+_REGISTRATION_SLOW_AFTER_SECONDS = 60.0
 _V2_ENABLED_VALUE = (
     os.environ["PERFORMANCE_AUDIT_V2_ENABLED"]
     if "PERFORMANCE_AUDIT_V2_ENABLED" in os.environ
@@ -79,8 +81,38 @@ def _bridge_has_error(payload: Any) -> bool:
     )
 
 
+def _registration_heartbeat_payload(
+    started_monotonic: float,
+    now_monotonic: float | None = None,
+) -> dict[str, Any]:
+    now_value = time.monotonic() if now_monotonic is None else float(now_monotonic)
+    elapsed = max(0.0, now_value - float(started_monotonic))
+    return {
+        "status": "loading",
+        "phase": "runtime_worker_registration",
+        "registration_elapsed_seconds": round(elapsed, 3),
+        "registration_slow": elapsed >= _REGISTRATION_SLOW_AFTER_SECONDS,
+        "registration_heartbeat_interval_seconds": _REGISTRATION_HEARTBEAT_INTERVAL_SECONDS,
+        "registration_message": (
+            "Runtime registration is still active; startup has not failed."
+            if elapsed < _REGISTRATION_SLOW_AFTER_SECONDS
+            else "Runtime registration is taking longer than 60 seconds but remains active."
+        ),
+    }
+
+
+def _registration_heartbeat_loop(
+    stop_event: threading.Event,
+    started_monotonic: float,
+) -> None:
+    while not stop_event.wait(_REGISTRATION_HEARTBEAT_INTERVAL_SECONDS):
+        _set_state(**_registration_heartbeat_payload(started_monotonic))
+
+
 def _load_application() -> None:
     global _DELEGATE
+    registration_heartbeat_stop: threading.Event | None = None
+    registration_started_monotonic: float | None = None
     try:
         _set_state(status="loading", phase="legacy_wsgi_import")
         import wsgi as legacy_wsgi
@@ -108,12 +140,46 @@ def _load_application() -> None:
                 )[:3000]
             )
 
-        _set_state(status="loading", phase="runtime_worker_registration")
+        registration_started_monotonic = time.monotonic()
+        _set_state(
+            status="loading",
+            phase="runtime_worker_registration",
+            registration_started_local=dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            registration_elapsed_seconds=0.0,
+            registration_slow=False,
+            registration_heartbeat_interval_seconds=_REGISTRATION_HEARTBEAT_INTERVAL_SECONDS,
+            registration_message="Runtime registration started.",
+        )
+        registration_heartbeat_stop = threading.Event()
+        registration_heartbeat_thread = threading.Thread(
+            target=_registration_heartbeat_loop,
+            args=(registration_heartbeat_stop, registration_started_monotonic),
+            daemon=True,
+            name="runtime-registration-bootstrap-heartbeat",
+        )
+        registration_heartbeat_thread.start()
+
         import runtime_worker_registration
 
-        registration = runtime_worker_registration.register(
-            core,
-            research_isolated=bool(_STATE.get("research_isolated", True)),
+        try:
+            registration = runtime_worker_registration.register(
+                core,
+                research_isolated=bool(_STATE.get("research_isolated", True)),
+            )
+        finally:
+            registration_heartbeat_stop.set()
+
+        registration_duration = round(
+            time.monotonic() - registration_started_monotonic,
+            3,
+        )
+        _set_state(
+            status="loading",
+            phase="runtime_worker_registration_complete",
+            registration_elapsed_seconds=registration_duration,
+            registration_duration_seconds=registration_duration,
+            registration_slow=registration_duration >= _REGISTRATION_SLOW_AFTER_SECONDS,
+            registration_message="Runtime registration completed; delegate activation is next.",
         )
         if registration.get("status") != "ok":
             raise RuntimeError(
@@ -127,6 +193,7 @@ def _load_application() -> None:
             status="ready",
             phase="delegating",
             registration=registration,
+            registration_duration_seconds=registration_duration,
             data_integrity_registration={
                 "apply": integrity_apply,
                 "routes": integrity_routes,
@@ -134,6 +201,14 @@ def _load_application() -> None:
             app_module=getattr(core, "__name__", "app"),
         )
     except Exception as exc:
+        if registration_heartbeat_stop is not None:
+            registration_heartbeat_stop.set()
+        failure_values: dict[str, Any] = {}
+        if registration_started_monotonic is not None:
+            failure_values["registration_elapsed_seconds"] = round(
+                time.monotonic() - registration_started_monotonic,
+                3,
+            )
         _set_state(
             status="error",
             phase="startup_failed",
@@ -141,6 +216,7 @@ def _load_application() -> None:
             traceback="".join(
                 traceback.format_exception(type(exc), exc, exc.__traceback__)
             )[-6000:],
+            **failure_values,
         )
 
 

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-06-v1"
+VERSION = "data-integrity-startup-bridge-2026-08-06-v2-provider-accounting"
 MODULES = (
     "intratrade_path_capture",
     "mae_mfe_integration",
     "daily_data_integrity_audit_overlay",
+    "provider_request_accounting_overlay",
 )
 
 

--- a/provider_request_accounting_overlay.py
+++ b/provider_request_accounting_overlay.py
@@ -1,0 +1,130 @@
+"""Read-only accounting overlay for market-data provider request totals.
+
+The provider-health counters can be sampled while another request is in flight.
+This overlay makes that gap explicit instead of leaving operators to infer it
+from totals. It does not call providers, change retries/backoff, alter strategy,
+change risk or sizing, place orders, or change live/ML authority.
+"""
+from __future__ import annotations
+
+import functools
+from typing import Any, Dict
+
+VERSION = "provider-request-accounting-overlay-2026-08-06-v1"
+_APPLIED = False
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _i(value: Any) -> int:
+    try:
+        if value is None or isinstance(value, bool):
+            return 0
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def accounting_payload(totals: Any) -> Dict[str, Any]:
+    row = dict(_d(totals))
+    requests = _i(row.get("requests"))
+    # `timeouts` is treated as a failure subtype and therefore is not added a
+    # second time. The other counters represent terminal or intentionally
+    # skipped request outcomes.
+    classified = sum(
+        _i(row.get(key))
+        for key in (
+            "successes",
+            "failures",
+            "empty",
+            "hygiene_blocked",
+            "provider_circuit_skips",
+            "symbol_backoff_skips",
+        )
+    )
+    gap = max(0, requests - classified)
+    return {
+        "requests": requests,
+        "classified_terminal_outcomes": classified,
+        "in_flight_or_unclassified_requests": gap,
+        "accounting_complete_at_snapshot": gap == 0,
+        "timeouts_reported_separately": _i(row.get("timeouts")),
+        "interpretation": (
+            "A small positive gap can be a request that was in flight when the read-only status snapshot was taken."
+        ),
+    }
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _APPLIED
+    try:
+        import daily_data_integrity_audit_overlay as audit_overlay
+    except Exception as exc:
+        return {
+            "status": "error",
+            "version": VERSION,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+    current = getattr(audit_overlay, "build_integrity_section", None)
+    if not callable(current):
+        return {"status": "error", "version": VERSION, "error": "integrity_builder_missing"}
+    if getattr(current, "_provider_request_accounting_overlay", None) == VERSION:
+        _APPLIED = True
+        return status_payload()
+
+    @functools.wraps(current)
+    def wrapped_build_integrity_section(runtime: Any = None):
+        section = current(runtime)
+        if not isinstance(section, dict):
+            return section
+        accounting = accounting_payload(section.get("provider_totals"))
+        section["provider_request_accounting"] = accounting
+        totals = dict(_d(section.get("provider_totals")))
+        totals.update(
+            {
+                "classified_terminal_outcomes": accounting["classified_terminal_outcomes"],
+                "in_flight_or_unclassified_requests": accounting["in_flight_or_unclassified_requests"],
+                "accounting_complete_at_snapshot": accounting["accounting_complete_at_snapshot"],
+            }
+        )
+        section["provider_totals"] = totals
+        return section
+
+    wrapped_build_integrity_section._provider_request_accounting_overlay = VERSION  # type: ignore[attr-defined]
+    audit_overlay.build_integrity_section = wrapped_build_integrity_section
+    _APPLIED = True
+    return status_payload()
+
+
+def status_payload() -> Dict[str, Any]:
+    return {
+        "status": "ok" if _APPLIED else "pending",
+        "overall": "pass" if _APPLIED else "warn",
+        "type": "provider_request_accounting_overlay_status",
+        "version": VERSION,
+        "applied": _APPLIED,
+        "authority": {
+            "reporting_only": True,
+            "changes_provider_behavior": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "places_orders": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    # No additional route is needed; this enriches the existing daily audit and
+    # data-integrity status surfaces.
+    return apply(core)
+
+
+try:
+    apply(None)
+except Exception:
+    pass

--- a/test_daily_data_integrity_overlay_v2.py
+++ b/test_daily_data_integrity_overlay_v2.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import daily_data_integrity_audit_overlay as overlay
+import provider_request_accounting_overlay as provider_accounting
 
 
 class _Daily:
@@ -139,6 +141,44 @@ class DailyDataIntegrityOverlayV2Tests(unittest.TestCase):
         self.assertEqual(counts["quarantined_feature_rows"], 4)
         self.assertEqual(counts["recomputed_rows"], 0)
         self.assertTrue(all(isinstance(value, int) for value in counts.values()))
+
+    def test_provider_accounting_exposes_one_in_flight_request(self):
+        accounting = provider_accounting.accounting_payload(
+            {
+                "requests": 228,
+                "successes": 227,
+                "failures": 0,
+                "empty": 0,
+                "hygiene_blocked": 0,
+                "provider_circuit_skips": 0,
+                "symbol_backoff_skips": 0,
+                "timeouts": 0,
+            }
+        )
+        self.assertEqual(accounting["classified_terminal_outcomes"], 227)
+        self.assertEqual(accounting["in_flight_or_unclassified_requests"], 1)
+        self.assertFalse(accounting["accounting_complete_at_snapshot"])
+
+    def test_provider_timeouts_are_not_double_counted(self):
+        accounting = provider_accounting.accounting_payload(
+            {
+                "requests": 10,
+                "successes": 8,
+                "failures": 2,
+                "timeouts": 1,
+            }
+        )
+        self.assertEqual(accounting["classified_terminal_outcomes"], 10)
+        self.assertEqual(accounting["in_flight_or_unclassified_requests"], 0)
+        self.assertEqual(accounting["timeouts_reported_separately"], 1)
+
+    def test_bootstrap_source_contains_registration_heartbeat_contract(self):
+        source = Path("bootstrap_wsgi.py").read_text(encoding="utf-8")
+        self.assertIn("v6-registration-heartbeat", source)
+        self.assertIn("registration_elapsed_seconds", source)
+        self.assertIn("registration_slow", source)
+        self.assertIn("runtime-registration-bootstrap-heartbeat", source)
+        compile(source, "bootstrap_wsgi.py", "exec")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- keep `/bootstrap-status` fresh during long synchronous runtime-worker registration
- report registration elapsed time, a 60-second slow-start flag, heartbeat cadence, and completed registration duration
- expose provider request accounting so a snapshot gap such as 228 requests versus 227 terminal outcomes is explicitly labeled as in-flight or unclassified
- register the accounting overlay through the existing deterministic data-integrity startup bridge
- add focused regression coverage

## Safety boundary
Observability only. No strategy, thresholds, provider behavior, retries/backoff, sizing, risk controls, order placement, live authority, or ML authority changes.

## Motivation
The first post-deployment requests returned expected bootstrap 503 responses for 83–96 seconds while the loader remained alive in `runtime_worker_registration`, but `updated_local` did not advance. The application later served the data-integrity route successfully. This patch distinguishes a slow active cold start from a frozen loader and makes the one-request provider snapshot gap explicit.