### PR TITLE
Fix daily audit recount and provider denominator reporting

### DIFF
--- a/daily_audit_response_reconciliation.py
+++ b/daily_audit_response_reconciliation.py
@@ -1,0 +1,180 @@
+"""Final read-only reconciliation for daily-audit HTTP responses.
+
+Wrapper installation order can change during deferred startup. This guard runs
+at the Flask response boundary so both compact and full daily-audit payloads
+retain the 11-operational-check contract after every reporting overlay.
+
+It changes no strategy, thresholds, sizing, risk controls, orders, provider
+behavior, live authority, or ML authority.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+VERSION = "daily-audit-response-reconciliation-2026-08-06-v1"
+_APPLIED = False
+_REGISTERED_APP_IDS: set[int] = set()
+_VALID = {"pass", "warn", "fail"}
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _i(value: Any) -> int:
+    try:
+        if value is None or isinstance(value, bool):
+            return 0
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _overall(pass_count: int, warn_count: int, fail_count: int) -> str:
+    if fail_count:
+        return "fail"
+    if warn_count:
+        return "warn"
+    return "pass"
+
+
+def _reconcile_full(payload: Dict[str, Any]) -> Dict[str, Any]:
+    sections = _d(payload.get("sections"))
+    operational_keys = [
+        key for key in sections if key not in {"11_conclusion", "12_next_action"}
+    ]
+    if not operational_keys:
+        return payload
+
+    statuses = []
+    for key in operational_keys:
+        status = str(_d(sections.get(key)).get("status") or "").lower()
+        statuses.append(status if status in _VALID else "warn")
+
+    pass_count = statuses.count("pass")
+    warn_count = statuses.count("warn")
+    fail_count = statuses.count("fail")
+    overall = _overall(pass_count, warn_count, fail_count)
+    sections["11_conclusion"] = {
+        "status": overall,
+        "pass_count": pass_count,
+        "warn_count": warn_count,
+        "fail_count": fail_count,
+        "checked_sections": len(operational_keys),
+    }
+    payload["overall"] = overall
+    payload["daily_audit_response_reconciliation_version"] = VERSION
+    return payload
+
+
+def _reconcile_compact(payload: Dict[str, Any]) -> Dict[str, Any]:
+    summary = _d(payload.get("section_summary"))
+    if not summary:
+        return payload
+
+    pass_count = _i(summary.get("pass"))
+    warn_count = _i(summary.get("warn"))
+    fail_count = _i(summary.get("fail"))
+    classified = pass_count + warn_count + fail_count
+    integrity_status = str(
+        _d(payload.get("data_integrity")).get("status") or ""
+    ).lower()
+
+    # The legacy repair layer counted the ten pre-integrity sections. Add the
+    # integrity result exactly once when that legacy count reaches the response.
+    if classified == 10 and integrity_status in _VALID:
+        if integrity_status == "pass":
+            pass_count += 1
+        elif integrity_status == "warn":
+            warn_count += 1
+        else:
+            fail_count += 1
+        classified += 1
+
+    summary.update(
+        {
+            "checked": classified,
+            "pass": pass_count,
+            "warn": warn_count,
+            "fail": fail_count,
+        }
+    )
+    payload["overall"] = _overall(pass_count, warn_count, fail_count)
+    payload["daily_audit_response_reconciliation_version"] = VERSION
+    return payload
+
+
+def reconcile_payload(payload: Any) -> Any:
+    if not isinstance(payload, dict):
+        return payload
+    payload_type = str(payload.get("type") or "")
+    if payload_type == "daily_operational_audit":
+        return _reconcile_full(payload)
+    if payload_type == "daily_operational_audit_compact":
+        return _reconcile_compact(payload)
+    return payload
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    return status_payload()
+
+
+def status_payload() -> Dict[str, Any]:
+    return {
+        "status": "ok" if _APPLIED else "pending",
+        "overall": "pass" if _APPLIED else "warn",
+        "type": "daily_audit_response_reconciliation_status",
+        "version": VERSION,
+        "applied": _APPLIED,
+        "registered_app_count": len(_REGISTERED_APP_IDS),
+        "authority": {
+            "reporting_only": True,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "places_orders": False,
+            "changes_provider_behavior": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    global _APPLIED
+    if flask_app is None:
+        return {"status": "error", "version": VERSION, "error": "flask_app_missing"}
+    if id(flask_app) in _REGISTERED_APP_IDS:
+        _APPLIED = True
+        return status_payload()
+
+    from flask import request
+
+    @flask_app.after_request
+    def daily_audit_response_reconciliation(response):
+        try:
+            if (
+                request.path == "/paper/daily-audit"
+                and response.status_code < 400
+                and response.is_json
+            ):
+                payload = response.get_json(silent=True)
+                reconciled = reconcile_payload(payload)
+                if isinstance(reconciled, dict):
+                    response.set_data(
+                        json.dumps(
+                            reconciled,
+                            sort_keys=True,
+                            separators=(",", ":"),
+                            default=str,
+                        )
+                    )
+                    response.mimetype = "application/json"
+        except Exception:
+            # Never turn a successful read-only audit into an HTTP failure.
+            pass
+        return response
+
+    _REGISTERED_APP_IDS.add(id(flask_app))
+    _APPLIED = True
+    return status_payload()

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-06-v2-provider-accounting"
+VERSION = "data-integrity-startup-bridge-2026-08-06-v3-response-reconciliation"
 MODULES = (
     "intratrade_path_capture",
     "mae_mfe_integration",
     "daily_data_integrity_audit_overlay",
     "provider_request_accounting_overlay",
+    "daily_audit_response_reconciliation",
 )
 
 

--- a/provider_request_accounting_overlay.py
+++ b/provider_request_accounting_overlay.py
@@ -1,16 +1,18 @@
 """Read-only accounting overlay for market-data provider request totals.
 
-The provider-health counters can be sampled while another request is in flight.
-This overlay makes that gap explicit instead of leaving operators to infer it
-from totals. It does not call providers, change retries/backoff, alter strategy,
-change risk or sizing, place orders, or change live/ML authority.
+The provider-health counters distinguish actual provider requests from symbols
+filtered before a request is made. This overlay makes any in-flight snapshot gap
+explicit without double-counting failure subtypes or pre-provider filters.
+
+It does not call providers, change retries/backoff, alter strategy, change risk
+or sizing, place orders, or change live/ML authority.
 """
 from __future__ import annotations
 
 import functools
 from typing import Any, Dict
 
-VERSION = "provider-request-accounting-overlay-2026-08-06-v1"
+VERSION = "provider-request-accounting-overlay-2026-08-06-v2-denominator-safe"
 _APPLIED = False
 
 
@@ -30,29 +32,39 @@ def _i(value: Any) -> int:
 def accounting_payload(totals: Any) -> Dict[str, Any]:
     row = dict(_d(totals))
     requests = _i(row.get("requests"))
-    # `timeouts` is treated as a failure subtype and therefore is not added a
-    # second time. The other counters represent terminal or intentionally
-    # skipped request outcomes.
+
+    # `failures` already includes empty responses and timeouts. Provider-circuit
+    # skips are counted after the request counter is incremented, so they share
+    # the provider-request denominator. Hygiene and symbol-backoff counters are
+    # pre-provider symbol filters and must not be added to provider outcomes.
     classified = sum(
         _i(row.get(key))
         for key in (
             "successes",
             "failures",
-            "empty",
-            "hygiene_blocked",
             "provider_circuit_skips",
-            "symbol_backoff_skips",
         )
     )
     gap = max(0, requests - classified)
+    over = max(0, classified - requests)
+    pre_provider_filtered = _i(row.get("hygiene_blocked")) + _i(
+        row.get("symbol_backoff_skips")
+    )
     return {
         "requests": requests,
         "classified_terminal_outcomes": classified,
         "in_flight_or_unclassified_requests": gap,
-        "accounting_complete_at_snapshot": gap == 0,
+        "provider_outcomes_over_request_count": over,
+        "accounting_complete_at_snapshot": gap == 0 and over == 0,
+        "pre_provider_filtered_symbols": pre_provider_filtered,
+        "hygiene_blocked_symbols": _i(row.get("hygiene_blocked")),
+        "symbol_backoff_filtered_symbols": _i(row.get("symbol_backoff_skips")),
+        "empty_failures_reported_separately": _i(row.get("empty")),
         "timeouts_reported_separately": _i(row.get("timeouts")),
         "interpretation": (
-            "A small positive gap can be a request that was in flight when the read-only status snapshot was taken."
+            "Provider outcomes use requests as their denominator. Hygiene and "
+            "symbol-backoff counters are pre-provider symbol filters; a small "
+            "positive request gap can be a request in flight at snapshot time."
         ),
     }
 
@@ -85,9 +97,21 @@ def apply(core: Any = None) -> Dict[str, Any]:
         totals = dict(_d(section.get("provider_totals")))
         totals.update(
             {
-                "classified_terminal_outcomes": accounting["classified_terminal_outcomes"],
-                "in_flight_or_unclassified_requests": accounting["in_flight_or_unclassified_requests"],
-                "accounting_complete_at_snapshot": accounting["accounting_complete_at_snapshot"],
+                "classified_terminal_outcomes": accounting[
+                    "classified_terminal_outcomes"
+                ],
+                "in_flight_or_unclassified_requests": accounting[
+                    "in_flight_or_unclassified_requests"
+                ],
+                "provider_outcomes_over_request_count": accounting[
+                    "provider_outcomes_over_request_count"
+                ],
+                "accounting_complete_at_snapshot": accounting[
+                    "accounting_complete_at_snapshot"
+                ],
+                "pre_provider_filtered_symbols": accounting[
+                    "pre_provider_filtered_symbols"
+                ],
             }
         )
         section["provider_totals"] = totals

--- a/test_daily_data_integrity_overlay_v2.py
+++ b/test_daily_data_integrity_overlay_v2.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import daily_audit_response_reconciliation as response_reconciliation
 import daily_data_integrity_audit_overlay as overlay
 import provider_request_accounting_overlay as provider_accounting
 
@@ -171,6 +172,49 @@ class DailyDataIntegrityOverlayV2Tests(unittest.TestCase):
         self.assertEqual(accounting["classified_terminal_outcomes"], 10)
         self.assertEqual(accounting["in_flight_or_unclassified_requests"], 0)
         self.assertEqual(accounting["timeouts_reported_separately"], 1)
+
+    def test_pre_provider_filters_do_not_exceed_request_denominator(self):
+        accounting = provider_accounting.accounting_payload(
+            {
+                "requests": 5081,
+                "successes": 5081,
+                "failures": 0,
+                "hygiene_blocked": 3,
+                "provider_circuit_skips": 0,
+                "symbol_backoff_skips": 0,
+            }
+        )
+        self.assertEqual(accounting["classified_terminal_outcomes"], 5081)
+        self.assertEqual(accounting["pre_provider_filtered_symbols"], 3)
+        self.assertEqual(accounting["provider_outcomes_over_request_count"], 0)
+        self.assertTrue(accounting["accounting_complete_at_snapshot"])
+
+    def test_response_guard_recounts_full_audit_after_outer_overlay(self):
+        payload = _base_payload()
+        payload["type"] = "daily_operational_audit"
+        payload["sections"]["10b_market_data_and_path_integrity"] = _integrity_section()
+        response_reconciliation.reconcile_payload(payload)
+
+        conclusion = payload["sections"]["11_conclusion"]
+        self.assertEqual(conclusion["checked_sections"], 11)
+        self.assertEqual(conclusion["pass_count"], 11)
+        self.assertEqual(payload["overall"], "pass")
+
+    def test_response_guard_recounts_compact_legacy_summary_once(self):
+        payload = {
+            "type": "daily_operational_audit_compact",
+            "overall": "pass",
+            "section_summary": {"checked": 10, "pass": 10, "warn": 0, "fail": 0},
+            "data_integrity": {"status": "pass"},
+        }
+        response_reconciliation.reconcile_payload(payload)
+        self.assertEqual(
+            payload["section_summary"],
+            {"checked": 11, "pass": 11, "warn": 0, "fail": 0},
+        )
+        response_reconciliation.reconcile_payload(payload)
+        self.assertEqual(payload["section_summary"]["checked"], 11)
+        self.assertEqual(payload["section_summary"]["pass"], 11)
 
     def test_bootstrap_source_contains_registration_heartbeat_contract(self):
         source = Path("bootstrap_wsgi.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a final read-only HTTP response reconciliation guard for `/paper/daily-audit`
- guarantee the full audit conclusion counts all 11 operational sections after every wrapper layer
- repair compact summaries that still receive the legacy 10-section count
- separate actual provider request outcomes from pre-provider hygiene/backoff symbol filters
- keep empty responses and timeouts as failure subtypes rather than double-counting them
- add focused regression coverage for the exact after-close payload that exposed both defects

## Root cause
The reconciliation overlay recalculated the conclusion from only the first ten section objects after the integrity overlay had added section `10b`. Separately, provider accounting added hygiene and symbol-backoff filters to provider terminal outcomes even though those filters occur before the provider request counter is incremented.

## Safety boundary
Reporting and observability only. No strategy, thresholds, sizing, risk controls, provider retry/backoff behavior, order placement, live authority, or ML authority changes.

## Validation
- modified modules compile successfully
- focused standalone assertions passed for 11-section full/compact reconciliation
- provider sample `5081 requests / 5081 successes / 3 hygiene-blocked symbols` now reports 5081 terminal outcomes, 3 pre-provider filtered symbols, zero gap, and complete accounting