### PR TITLE
Recover paper ledger with action-first trade semantics

### DIFF
--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-10-v7-economic-ledger"
+VERSION = "data-integrity-startup-bridge-2026-08-10-v8-action-semantics-recovery"
 MODULES = (
     "orla_hygiene_overlay",
+    "paper_trade_action_semantics_recovery",
     "paper_accounting_integrity_guard",
     "paper_accounting_readonly_status",
     "paper_ledger_economic_integrity",
@@ -19,6 +20,7 @@ MODULES = (
     "mae_mfe_integration",
     "daily_data_integrity_audit_overlay",
     "paper_accounting_audit_bridge",
+    "post_recovery_evidence_epoch_guard",
     "provider_request_accounting_overlay",
     "daily_audit_response_reconciliation",
     "multi_asset_shadow_ranker",

--- a/paper_trade_action_semantics_recovery.py
+++ b/paper_trade_action_semantics_recovery.py
@@ -113,7 +113,7 @@ def _current_valid_path_rows() -> int:
     try:
         import intratrade_path_capture as path
         status = path.status_payload() if callable(getattr(path, "status_payload", None)) else {}
-        return int((status or {}).get("valid_rows") or 0)
+        return int((status or {}).get("training_eligible_rows") or 0)
     except Exception:
         return 0
 

--- a/paper_trade_action_semantics_recovery.py
+++ b/paper_trade_action_semantics_recovery.py
@@ -1,0 +1,211 @@
+"""Action-first paper trade semantics and controlled accounting recovery.
+
+The runtime's canonical trade rows contain both ``action`` (entry/exit/partial_exit)
+and ``side`` (long/short). The accounting incident occurred because reconciliation
+read ``side`` first, causing long exits to be interpreted as additional buys.
+
+This overlay makes ``action`` authoritative, preserves one forensic pre-repair
+snapshot, and invokes the existing paper-only reconciler after semantics are fixed.
+It never clears a hard risk halt and never places orders or changes strategy.
+"""
+from __future__ import annotations
+
+import copy
+import datetime as dt
+from typing import Any, Dict, Tuple
+
+VERSION = "paper-trade-action-semantics-recovery-2026-08-10-v1"
+_REGISTERED_APP_IDS: set[int] = set()
+_APPLIED = False
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or isinstance(value, bool):
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def _sym(value: Any) -> str:
+    return str(value or "").upper().strip()
+
+
+def _now(core: Any = None) -> str:
+    try:
+        return str(core.local_ts_text())
+    except Exception:
+        return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _portfolio(core: Any) -> Dict[str, Any]:
+    pf = getattr(core, "portfolio", None) if core is not None else None
+    return pf if isinstance(pf, dict) else {}
+
+
+def action_first_trade_fields(row: Dict[str, Any]) -> Tuple[str, str, float, float, str]:
+    """Return symbol, economic event, qty, price, timestamp.
+
+    ``action`` is authoritative when present. Long entry/exit rows map to buy/sell.
+    Short lifecycle rows are deliberately returned as unsupported event types so
+    the legacy long-lot reconciler cannot silently mis-reconstruct them.
+    Direct legacy rows that use side=buy/sell without action remain supported.
+    """
+    symbol = _sym(row.get("symbol") or row.get("ticker"))
+    action = str(row.get("action") or "").lower().strip()
+    direction = str(row.get("side") or "").lower().strip()
+    qty = _f(row.get("qty", row.get("shares", row.get("quantity"))), 0.0)
+    price = _f(row.get("price", row.get("fill_price", row.get("entry_price", row.get("exit_price")))), 0.0)
+    timestamp = str(row.get("timestamp") or row.get("time") or row.get("ts_local") or row.get("created_at") or "")
+
+    entry_actions = {"entry", "buy", "open", "open_long", "b"}
+    exit_actions = {"exit", "partial_exit", "sell", "close", "close_long", "s"}
+
+    if action in entry_actions:
+        event = "unsupported_short_entry" if direction == "short" else "buy"
+    elif action in exit_actions:
+        event = "unsupported_short_exit" if direction == "short" else "sell"
+    elif direction in {"buy", "b"}:
+        event = "buy"
+    elif direction in {"sell", "s"}:
+        event = "sell"
+    elif direction in {"long", "entry", "open_long"}:
+        # Backward-compatible fallback only for older rows with no action.
+        event = "buy"
+    elif direction == "short":
+        event = "unsupported_short_entry"
+    else:
+        event = action or direction
+
+    return symbol, event, qty, price, timestamp
+
+
+def _archive_before_repair(core: Any) -> Dict[str, Any]:
+    pf = _portfolio(core)
+    existing = pf.get("paper_accounting_semantics_recovery")
+    if isinstance(existing, dict) and existing.get("version") == VERSION:
+        return existing
+
+    trades = pf.get("trades") if isinstance(pf.get("trades"), list) else []
+    snapshot = {
+        "version": VERSION,
+        "recovery_started_local": _now(core),
+        "pre_repair": {
+            "cash": pf.get("cash"),
+            "equity": pf.get("equity"),
+            "positions": copy.deepcopy(pf.get("positions") if isinstance(pf.get("positions"), dict) else {}),
+            "realized_pnl": copy.deepcopy(pf.get("realized_pnl") if isinstance(pf.get("realized_pnl"), dict) else {}),
+            "performance": copy.deepcopy(pf.get("performance") if isinstance(pf.get("performance"), dict) else {}),
+            "risk_controls": copy.deepcopy(pf.get("risk_controls") if isinstance(pf.get("risk_controls"), dict) else {}),
+            "trade_count": len(trades),
+            "trades": copy.deepcopy(trades),
+        },
+        "hard_halt_preserved": bool((pf.get("risk_controls") or {}).get("halted", False)) if isinstance(pf.get("risk_controls"), dict) else False,
+        "recovery_epoch_valid_path_rows_baseline": 0,
+        "post_recovery_validation_required": True,
+    }
+    pf["paper_accounting_semantics_recovery"] = snapshot
+    return snapshot
+
+
+def _current_valid_path_rows() -> int:
+    try:
+        import intratrade_path_capture as path
+        status = path.status_payload() if callable(getattr(path, "status_payload", None)) else {}
+        return int((status or {}).get("valid_rows") or 0)
+    except Exception:
+        return 0
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _APPLIED
+    if core is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+
+    archive = _archive_before_repair(core)
+
+    try:
+        import paper_accounting_integrity_guard as accounting
+        import paper_ledger_economic_integrity as economics
+        accounting._trade_fields = action_first_trade_fields
+        economics._trade_fields = action_first_trade_fields
+    except Exception as exc:
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": f"{type(exc).__name__}: {exc}"}
+
+    # Capture the pre-recovery path-evidence baseline once. Existing rows remain
+    # historical evidence but cannot satisfy the post-recovery promotion gate.
+    if int(archive.get("recovery_epoch_valid_path_rows_baseline") or 0) <= 0:
+        archive["recovery_epoch_valid_path_rows_baseline"] = _current_valid_path_rows()
+
+    before_halt = bool((_portfolio(core).get("risk_controls") or {}).get("halted", False)) if isinstance(_portfolio(core).get("risk_controls"), dict) else False
+    try:
+        result = accounting.reconcile(core, persist=True)
+    except Exception as exc:
+        result = {"status": "error", "overall": "fail", "error": f"{type(exc).__name__}: {exc}"}
+
+    pf = _portfolio(core)
+    risk = pf.get("risk_controls") if isinstance(pf.get("risk_controls"), dict) else {}
+    after_halt = bool(risk.get("halted", False))
+    archive["recovery_applied_local"] = _now(core)
+    archive["hard_halt_before"] = before_halt
+    archive["hard_halt_after"] = after_halt
+    archive["hard_halt_preserved"] = (not before_halt) or after_halt
+    archive["post_repair"] = {
+        "cash": pf.get("cash"),
+        "equity": pf.get("equity"),
+        "open_positions_count": len(pf.get("positions") or {}) if isinstance(pf.get("positions"), dict) else 0,
+        "reconcile_status": copy.deepcopy(result),
+    }
+
+    try:
+        save = getattr(core, "save_state", None)
+        if callable(save):
+            try:
+                save(pf)
+            except TypeError:
+                save()
+    except Exception:
+        pass
+
+    _APPLIED = True
+    return status_payload(core)
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    pf = _portfolio(core) if core is not None else {}
+    row = pf.get("paper_accounting_semantics_recovery") if isinstance(pf.get("paper_accounting_semantics_recovery"), dict) else {}
+    return {
+        "status": "ok" if _APPLIED and row else "pending",
+        "overall": "pass" if _APPLIED and row and row.get("hard_halt_preserved", True) else "warn",
+        "type": "paper_trade_action_semantics_recovery_status",
+        "version": VERSION,
+        "applied": _APPLIED,
+        "recovery_epoch_valid_path_rows_baseline": int(row.get("recovery_epoch_valid_path_rows_baseline") or 0),
+        "post_recovery_validation_required": bool(row.get("post_recovery_validation_required", True)),
+        "hard_halt_preserved": bool(row.get("hard_halt_preserved", True)),
+        "pre_repair_trade_count": int(((row.get("pre_repair") or {}).get("trade_count")) or 0) if isinstance(row, dict) else 0,
+        "post_repair": copy.deepcopy(row.get("post_repair") or {}) if isinstance(row, dict) else {},
+        "authority": {
+            "paper_state_reconciliation_only": True,
+            "places_orders": False,
+            "clears_hard_halt": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    if flask_app is None:
+        return apply(core)
+    from flask import jsonify
+    if id(flask_app) not in _REGISTERED_APP_IDS:
+        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+        path = "/paper/accounting-semantics-recovery-status"
+        if path not in existing:
+            flask_app.add_url_rule(path, "paper_accounting_semantics_recovery_status", lambda: jsonify(status_payload(core)))
+        _REGISTERED_APP_IDS.add(id(flask_app))
+    return apply(core)

--- a/post_recovery_evidence_epoch_guard.py
+++ b/post_recovery_evidence_epoch_guard.py
@@ -1,0 +1,117 @@
+"""Block MAE/MFE promotion until a new clean lifecycle exists after accounting recovery."""
+from __future__ import annotations
+
+import functools
+from typing import Any, Dict
+
+VERSION = "post-recovery-evidence-epoch-guard-2026-08-10-v1"
+_APPLIED = False
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _state(core: Any) -> Dict[str, Any]:
+    pf = getattr(core, "portfolio", None) if core is not None else None
+    return pf if isinstance(pf, dict) else {}
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _APPLIED
+    try:
+        import daily_data_integrity_audit_overlay as audit
+    except Exception as exc:
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": f"{type(exc).__name__}: {exc}"}
+
+    current = getattr(audit, "build_integrity_section", None)
+    if not callable(current):
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": "integrity_builder_missing"}
+    if getattr(current, "_post_recovery_evidence_epoch_guard", None) == VERSION:
+        _APPLIED = True
+        return status_payload(core)
+
+    prior = getattr(current, "_post_recovery_evidence_epoch_guard_prior", current)
+
+    @functools.wraps(prior)
+    def wrapped(runtime: Any = None):
+        active = runtime or core
+        section = prior(active)
+        if not isinstance(section, dict):
+            return section
+
+        state = _state(active)
+        recovery = _d(state.get("paper_accounting_semantics_recovery"))
+        baseline = int(recovery.get("recovery_epoch_valid_path_rows_baseline") or 0)
+        forward = _d(section.get("forward_validation"))
+        current_valid = int(forward.get("valid_exact_lifecycle_rows_observed") or 0)
+        post_recovery_valid = max(0, current_valid - baseline)
+        required = bool(recovery.get("post_recovery_validation_required", False))
+        eligible = (not required) or post_recovery_valid >= 1
+
+        epoch = {
+            "version": VERSION,
+            "recovery_active": bool(recovery),
+            "baseline_valid_exact_lifecycle_rows": baseline,
+            "current_valid_exact_lifecycle_rows": current_valid,
+            "post_recovery_valid_exact_lifecycle_rows": post_recovery_valid,
+            "minimum_post_recovery_rows_required": 1,
+            "promotion_evidence_eligible": eligible,
+        }
+        section["post_recovery_evidence_epoch"] = epoch
+
+        if required and not eligible:
+            reason = "post_accounting_recovery_forward_validation_required"
+            reasons = list(section.get("reasons") or [])
+            if reason not in reasons:
+                reasons.insert(0, reason)
+            section["reasons"] = reasons
+            section["status"] = "fail"
+
+            forward["promotion_evidence_eligible"] = False
+            forward["promotion_block_reason"] = reason
+            forward["post_recovery_valid_exact_lifecycle_rows"] = post_recovery_valid
+            section["forward_validation"] = forward
+
+            mae = _d(section.get("mae_mfe_integrity"))
+            mae["promotion_evidence_eligible"] = False
+            mae["promotion_block_reason"] = reason
+            mae["post_recovery_training_eligible_rows"] = post_recovery_valid
+            section["mae_mfe_integrity"] = mae
+        elif required and eligible:
+            forward["promotion_evidence_eligible"] = True
+            forward["post_recovery_valid_exact_lifecycle_rows"] = post_recovery_valid
+            section["forward_validation"] = forward
+
+        return section
+
+    wrapped._post_recovery_evidence_epoch_guard = VERSION  # type: ignore[attr-defined]
+    wrapped._post_recovery_evidence_epoch_guard_prior = prior  # type: ignore[attr-defined]
+    audit.build_integrity_section = wrapped
+    _APPLIED = True
+    return status_payload(core)
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    recovery = _d(_state(core).get("paper_accounting_semantics_recovery")) if core is not None else {}
+    return {
+        "status": "ok" if _APPLIED else "pending",
+        "overall": "pass" if _APPLIED else "warn",
+        "type": "post_recovery_evidence_epoch_guard_status",
+        "version": VERSION,
+        "applied": _APPLIED,
+        "recovery_epoch_valid_path_rows_baseline": int(recovery.get("recovery_epoch_valid_path_rows_baseline") or 0),
+        "post_recovery_validation_required": bool(recovery.get("post_recovery_validation_required", False)),
+        "authority": {
+            "reporting_and_promotion_gate_only": True,
+            "places_orders": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    return apply(core)

--- a/test_paper_trade_action_semantics_recovery.py
+++ b/test_paper_trade_action_semantics_recovery.py
@@ -1,0 +1,75 @@
+import types
+import unittest
+
+import paper_accounting_integrity_guard as accounting
+import paper_ledger_economic_integrity as economics
+import paper_trade_action_semantics_recovery as recovery
+
+
+class TradeActionSemanticsRecoveryTests(unittest.TestCase):
+    def setUp(self):
+        accounting._trade_fields = recovery.action_first_trade_fields
+        economics._trade_fields = recovery.action_first_trade_fields
+
+    def _core(self, portfolio):
+        return types.SimpleNamespace(
+            portfolio=portfolio,
+            local_ts_text=lambda: "2026-08-10 12:00:00 CDT",
+        )
+
+    def test_long_exit_is_sell_not_second_buy(self):
+        row = {
+            "action": "exit",
+            "symbol": "MARA",
+            "side": "long",
+            "price": 10.0,
+            "shares": 100.0,
+        }
+        symbol, event, qty, price, _ = recovery.action_first_trade_fields(row)
+        self.assertEqual(symbol, "MARA")
+        self.assertEqual(event, "sell")
+        self.assertEqual(qty, 100.0)
+        self.assertEqual(price, 10.0)
+
+    def test_entry_partial_exit_full_exit_reconstructs_cleanly(self):
+        pf = {
+            "history": [10000.0],
+            "trades": [
+                {"action": "entry", "symbol": "AAPL", "side": "long", "shares": 10, "price": 100},
+                {"action": "partial_exit", "symbol": "AAPL", "side": "long", "shares": 4, "price": 110},
+                {"action": "exit", "symbol": "AAPL", "side": "long", "shares": 6, "price": 120},
+            ],
+            "positions": {},
+            "cash": 10160.0,
+            "equity": 10160.0,
+        }
+        rebuilt = accounting.reconstruct_from_ledger(pf, self._core(pf))
+        self.assertTrue(rebuilt["coverage_complete"])
+        self.assertAlmostEqual(rebuilt["cash"], 10160.0, places=4)
+        self.assertAlmostEqual(rebuilt["equity"], 10160.0, places=4)
+        self.assertAlmostEqual(rebuilt["realized_total"], 160.0, places=4)
+        self.assertEqual(rebuilt["open_positions"], {})
+
+        economic = economics.status_payload(self._core(pf))
+        self.assertEqual(economic["overall"], "pass")
+        self.assertTrue(economic["promotion_evidence_eligible"])
+        self.assertAlmostEqual(economic["reconstructed_cash_after_ledger"], 10160.0, places=4)
+
+    def test_short_lifecycle_is_not_silently_reconstructed_by_long_lot_model(self):
+        pf = {
+            "history": [10000.0],
+            "trades": [
+                {"action": "entry", "symbol": "XYZ", "side": "short", "shares": 10, "price": 100},
+                {"action": "exit", "symbol": "XYZ", "side": "short", "shares": 10, "price": 90},
+            ],
+            "positions": {},
+        }
+        rebuilt = accounting.reconstruct_from_ledger(pf, self._core(pf))
+        self.assertFalse(rebuilt["coverage_complete"])
+        economic = economics.status_payload(self._core(pf))
+        self.assertEqual(economic["overall"], "fail")
+        self.assertFalse(economic["promotion_evidence_eligible"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the accounting incident by making trade `action` authoritative over position `side` during ledger reconstruction. Preserves one forensic pre-repair snapshot, reconciles paper state through the existing paper-only accounting guard, preserves any hard risk halt, and requires at least one new post-recovery exact-lifecycle MAE/MFE row before promotion evidence can become eligible again. Adds focused regression tests for entry/partial-exit/full-exit semantics and deliberately leaves unsupported short-lifecycle reconstruction in fail-safe mode. No strategy, threshold, sizing, order-placement, live-authority, or ML-authority changes.