### PR TITLE
Make daily audit one-link compact and add journal recovery candidate

### DIFF
--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -9,14 +9,17 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-10-v9-matched-exit-recovery"
+VERSION = "data-integrity-startup-bridge-2026-08-10-v10-one-link-journal-recovery"
 MODULES = (
+    # Registered first so Flask executes its after_request handler last.
+    "final_daily_audit_compactor",
     "orla_hygiene_overlay",
     "paper_ledger_matched_exit_guard",
     "paper_trade_action_semantics_recovery",
     "paper_accounting_integrity_guard",
     "paper_accounting_readonly_status",
     "paper_ledger_economic_integrity",
+    "paper_journal_forensic_recovery",
     "intratrade_path_capture",
     "mae_mfe_integration",
     "daily_data_integrity_audit_overlay",

--- a/final_daily_audit_compactor.py
+++ b/final_daily_audit_compactor.py
@@ -1,0 +1,165 @@
+"""Final-stage compact response for the routine daily audit.
+
+Registered early so Flask executes this after_request handler last. The routine
+/paper/daily-audit response is intentionally small and operator-oriented.
+?full=1 preserves the complete forensic audit.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+VERSION = "final-daily-audit-compactor-2026-08-10-v1"
+_REGISTERED = set()
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> list:
+    return value if isinstance(value, list) else []
+
+
+def _journal_status(core: Any = None) -> Dict[str, Any]:
+    try:
+        import paper_journal_forensic_recovery as module
+        return module.status_payload(core)
+    except Exception as exc:
+        return {"status": "warn", "error": f"{type(exc).__name__}: {exc}"}
+
+
+def compact_payload(payload: Dict[str, Any], core: Any = None) -> Dict[str, Any]:
+    sections = _d(payload.get("sections"))
+    account = _d(sections.get("01_account_and_open_position_performance"))
+    runner = _d(sections.get("02_auto_runner_liveness"))
+    errors = _d(sections.get("03_active_errors_and_recursion"))
+    risk = _d(sections.get("04_risk_controls_and_drawdown"))
+    scanner = _d(sections.get("05_scanner_signals_entries_rejections"))
+    integrity = _d(sections.get("10b_market_data_and_path_integrity"))
+    accounting = _d(integrity.get("paper_accounting_integrity"))
+    rebuilt = _d(accounting.get("reconstructed"))
+    economics = _d(integrity.get("paper_ledger_economic_integrity"))
+    forward = _d(integrity.get("forward_validation"))
+    provider = _d(integrity.get("provider_request_accounting"))
+    conclusion = _d(sections.get("11_conclusion"))
+    next_action = _d(sections.get("12_next_action"))
+    journal = _journal_status(core)
+
+    reasons = []
+    for value in _l(risk.get("reasons")) + _l(integrity.get("reasons")):
+        if value and value not in reasons:
+            reasons.append(value)
+
+    return {
+        "status": payload.get("status"),
+        "overall": payload.get("overall"),
+        "type": "daily_operational_audit_compact_final",
+        "version": payload.get("version"),
+        "generated_local": payload.get("generated_local"),
+        "duration_seconds": payload.get("duration_seconds"),
+        "summary": {
+            "pass": conclusion.get("pass_count"),
+            "warn": conclusion.get("warn_count"),
+            "fail": conclusion.get("fail_count"),
+            "reasons": reasons[:6],
+        },
+        "account": {
+            "cash": account.get("cash"),
+            "equity": account.get("equity"),
+            "positions": account.get("positions") or [],
+            "realized_today": account.get("realized_today"),
+            "unrealized_pnl": account.get("unrealized_pnl"),
+        },
+        "runner": {
+            "status": runner.get("status"),
+            "enabled": runner.get("enabled"),
+            "last_completed_cycle": runner.get("last_completed_cycle_contract") or runner.get("last_completed_cycle"),
+            "last_completed_cycle_duration_seconds": runner.get("last_completed_cycle_duration_seconds"),
+        },
+        "risk": {
+            "status": risk.get("status"),
+            "halted": risk.get("halted"),
+            "halt_reason": risk.get("halt_reason"),
+            "self_defense_active": risk.get("self_defense_active"),
+            "net_daily_loss_pct": risk.get("net_daily_loss_pct", risk.get("realized_loss_pct")),
+            "intraday_drawdown_pct": risk.get("intraday_drawdown_pct"),
+        },
+        "scanner": {
+            "signals_found": scanner.get("signals_found"),
+            "entries_count": scanner.get("entries_count"),
+            "rejected_signals_count": scanner.get("rejected_signals_count"),
+        },
+        "accounting_integrity": {
+            "status": accounting.get("status"),
+            "coverage_complete": accounting.get("coverage_complete"),
+            "ignored_trade_rows": rebuilt.get("ignored_trade_rows"),
+            "coverage_issue_count": rebuilt.get("coverage_issue_count"),
+            "economic_issue_count": economics.get("economic_issue_count"),
+            "reconstructed_cash": rebuilt.get("cash"),
+            "reconstructed_equity": rebuilt.get("equity"),
+        },
+        "journal_recovery_candidate": {
+            "status": journal.get("status"),
+            "journal_trade_rows": journal.get("journal_trade_rows"),
+            "deduplicated_execution_rows": journal.get("deduplicated_execution_rows"),
+            "entry_rows": journal.get("entry_rows"),
+            "exit_rows": journal.get("exit_rows"),
+            "coverage_complete": journal.get("coverage_complete"),
+            "coverage_issue_count": journal.get("coverage_issue_count"),
+            "economic_issue_count": journal.get("economic_issue_count"),
+            "candidate_cash": journal.get("candidate_cash"),
+            "candidate_equity": journal.get("candidate_equity"),
+            "trusted_recovery_candidate": journal.get("trusted_recovery_candidate"),
+        },
+        "market_data": {
+            "status": integrity.get("status"),
+            "requests": provider.get("requests"),
+            "classified_terminal_outcomes": provider.get("classified_terminal_outcomes"),
+            "provider_circuit_open": integrity.get("provider_circuit_open"),
+        },
+        "ml_evidence": {
+            "promotion_evidence_eligible": forward.get("promotion_evidence_eligible"),
+            "promotion_block_reason": forward.get("promotion_block_reason"),
+            "valid_exact_lifecycle_rows": forward.get("valid_exact_lifecycle_rows_observed"),
+            "post_recovery_valid_exact_lifecycle_rows": forward.get("post_recovery_valid_exact_lifecycle_rows"),
+        },
+        "next_action": {
+            "status": next_action.get("status"),
+            "priority": next_action.get("priority"),
+            "reason": next_action.get("reason"),
+            "action": next_action.get("action"),
+        },
+        "full_audit": "https://web-production-e1796.up.railway.app/paper/daily-audit?full=1",
+        "compactor_version": VERSION,
+    }
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    return {"status": "ok", "overall": "pass", "version": VERSION, "reporting_only": True}
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    if flask_app is None:
+        return {"status": "warn", "overall": "warn", "version": VERSION}
+    app_id = id(flask_app)
+    if app_id not in _REGISTERED:
+        from flask import request
+
+        @flask_app.after_request
+        def _compact_daily_audit_response(response):
+            try:
+                if request.path != "/paper/daily-audit" or request.args.get("full") == "1":
+                    return response
+                payload = response.get_json(silent=True)
+                if not isinstance(payload, dict):
+                    return response
+                compact = compact_payload(payload, core)
+                response.set_data(flask_app.json.dumps(compact))
+                response.content_type = "application/json"
+                response.content_length = len(response.get_data())
+            except Exception:
+                return response
+            return response
+
+        _REGISTERED.add(app_id)
+    return {"status": "ok", "overall": "pass", "version": VERSION, "registered": True}

--- a/paper_journal_forensic_recovery.py
+++ b/paper_journal_forensic_recovery.py
@@ -1,0 +1,142 @@
+"""Read-only forensic recovery candidate from the append-only trade journal.
+
+Builds a deduplicated execution candidate from /data/trade_journal.json and
+checks whether it can reconstruct a complete, economically plausible paper
+account. It never mutates portfolio state, clears halts, or places orders.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Tuple
+
+VERSION = "paper-journal-forensic-recovery-2026-08-10-v1"
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or isinstance(value, bool):
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def _portfolio(core: Any) -> Dict[str, Any]:
+    pf = getattr(core, "portfolio", None) if core is not None else None
+    return pf if isinstance(pf, dict) else {}
+
+
+def _semantic_key(row: Dict[str, Any]) -> Tuple[Any, ...]:
+    return (
+        str(row.get("time") or row.get("timestamp") or row.get("ts_local") or ""),
+        str(row.get("action") or "").lower(),
+        str(row.get("symbol") or row.get("ticker") or "").upper(),
+        str(row.get("side") or "").lower(),
+        round(_f(row.get("shares", row.get("qty", row.get("quantity"))), 0.0), 9),
+        round(_f(row.get("price", row.get("fill_price", row.get("entry_price", row.get("exit_price")))), 0.0), 6),
+        str(row.get("exit_reason") or ""),
+    )
+
+
+def _load_journal() -> Tuple[Dict[str, Any], str | None]:
+    try:
+        import trade_journal as tj
+        path = str(getattr(tj, "TRADE_JOURNAL_FILE", "") or "")
+        if not path:
+            return {}, "journal_path_missing"
+        with open(path, "r", encoding="utf-8") as handle:
+            obj = json.load(handle)
+        return (obj if isinstance(obj, dict) else {}), None
+    except Exception as exc:
+        return {}, f"{type(exc).__name__}: {exc}"
+
+
+def _candidate_rows(journal: Dict[str, Any]) -> List[Dict[str, Any]]:
+    supported = {"entry", "exit", "partial_exit"}
+    out: List[Dict[str, Any]] = []
+    seen = set()
+    for raw in _l(journal.get("trades")):
+        if not isinstance(raw, dict):
+            continue
+        action = str(raw.get("action") or "").lower().strip()
+        if action not in supported:
+            continue
+        key = _semantic_key(raw)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(dict(raw))
+    return out
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    if core is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+
+    journal, error = _load_journal()
+    rows = _candidate_rows(journal)
+    entries = sum(1 for row in rows if str(row.get("action") or "").lower() == "entry")
+    exits = sum(1 for row in rows if str(row.get("action") or "").lower() in {"exit", "partial_exit"})
+    if error:
+        return {
+            "status": "warn", "overall": "warn", "version": VERSION,
+            "journal_available": False, "error": error,
+            "authority": {"reporting_only": True, "repairs_state": False, "places_orders": False},
+        }
+
+    try:
+        import paper_ledger_matched_exit_guard as matched
+        pf = dict(_portfolio(core))
+        pf["trades"] = rows
+        rebuilt = matched.analyze_ledger(pf, core)
+    except Exception as exc:
+        rebuilt = {"coverage_complete": False, "status": "error", "error": f"{type(exc).__name__}: {exc}"}
+
+    economic_issue_count = int(rebuilt.get("economic_issue_count") or 0)
+    coverage_issue_count = int(rebuilt.get("coverage_issue_count") or 0)
+    coverage_complete = bool(rebuilt.get("coverage_complete"))
+    trustworthy = coverage_complete and economic_issue_count == 0 and coverage_issue_count == 0
+    return {
+        "status": "ok" if trustworthy else "warn",
+        "overall": "pass" if trustworthy else "warn",
+        "type": "paper_journal_forensic_recovery_status",
+        "version": VERSION,
+        "journal_available": True,
+        "journal_trade_rows": len(_l(journal.get("trades"))),
+        "deduplicated_execution_rows": len(rows),
+        "entry_rows": entries,
+        "exit_rows": exits,
+        "coverage_complete": coverage_complete,
+        "coverage_issue_count": coverage_issue_count,
+        "economic_issue_count": economic_issue_count,
+        "candidate_cash": rebuilt.get("cash"),
+        "candidate_equity": rebuilt.get("equity"),
+        "candidate_open_positions": sorted(_d(rebuilt.get("open_positions")).keys()),
+        "trusted_recovery_candidate": trustworthy,
+        "authority": {
+            "reporting_only": True,
+            "repairs_state": False,
+            "clears_hard_halt": False,
+            "places_orders": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    return status_payload(core)
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    return status_payload(core)

--- a/test_one_link_journal_recovery.py
+++ b/test_one_link_journal_recovery.py
@@ -1,0 +1,58 @@
+import json
+import types
+
+import final_daily_audit_compactor as compact
+import paper_journal_forensic_recovery as recovery
+
+
+def test_compactor_omits_large_forensic_arrays():
+    payload = {
+        "status": "ok",
+        "overall": "fail",
+        "generated_local": "2026-08-10 12:00:00 CDT",
+        "duration_seconds": 0.2,
+        "version": "x",
+        "sections": {
+            "01_account_and_open_position_performance": {"cash": 1, "equity": 2, "positions": ["QQQ"]},
+            "02_auto_runner_liveness": {"status": "pass", "enabled": True},
+            "04_risk_controls_and_drawdown": {"status": "fail", "halted": True, "reasons": ["risk_halted"]},
+            "05_scanner_signals_entries_rejections": {"signals_found": 3, "entries_count": 0},
+            "10b_market_data_and_path_integrity": {
+                "status": "fail",
+                "reasons": ["paper_accounting_integrity_not_reconciled"],
+                "paper_accounting_integrity": {
+                    "status": "warn", "coverage_complete": False,
+                    "reconstructed": {"ignored_trade_rows": 19, "coverage_issue_count": 19, "coverage_issues": [{"x": 1}] * 50},
+                },
+                "paper_ledger_economic_integrity": {"economic_issue_count": 19, "economic_issues": [{"x": 1}] * 20},
+                "forward_validation": {"promotion_evidence_eligible": False},
+                "provider_request_accounting": {"requests": 10, "classified_terminal_outcomes": 10},
+            },
+            "11_conclusion": {"pass_count": 9, "warn_count": 0, "fail_count": 2},
+            "12_next_action": {"status": "required", "priority": "high", "reason": "risk_halted"},
+        },
+    }
+    out = compact.compact_payload(payload, None)
+    text = json.dumps(out)
+    assert "coverage_issues" not in text
+    assert "economic_issues" not in text
+    assert out["summary"]["fail"] == 2
+    assert out["accounting_integrity"]["coverage_issue_count"] == 19
+
+
+def test_journal_semantic_dedupe():
+    row = {"time": "1", "action": "entry", "symbol": "QQQ", "side": "long", "shares": 2, "price": 100}
+    dup = dict(row, journal_key="different", journal_source="backup")
+    rows = recovery._candidate_rows({"trades": [row, dup]})
+    assert len(rows) == 1
+
+
+def test_journal_status_is_read_only(monkeypatch, tmp_path):
+    journal_path = tmp_path / "trade_journal.json"
+    journal_path.write_text(json.dumps({"trades": []}), encoding="utf-8")
+    fake_tj = types.SimpleNamespace(TRADE_JOURNAL_FILE=str(journal_path))
+    monkeypatch.setitem(__import__("sys").modules, "trade_journal", fake_tj)
+    core = types.SimpleNamespace(portfolio={"history": [10000], "trades": []})
+    out = recovery.status_payload(core)
+    assert out["journal_available"] is True
+    assert out["authority"]["repairs_state"] is False


### PR DESCRIPTION
Makes /paper/daily-audit reliably compact at the final Flask response stage while preserving ?full=1 for forensic detail. Adds a read-only recovery candidate built from the append-only persistent trade journal, deduplicated by semantic execution identity and analyzed through the matched-exit accounting guard. No state repair, no halt clearing, no order placement, and no strategy/threshold/risk/sizing/live/ML authority changes. Adds regression coverage for compact output and journal deduplication.