### PR TITLE
Update authoritative handoff for Stable Core ledger

### DIFF
--- a/PROJECT_HANDOFF_CURRENT.md
+++ b/PROJECT_HANDOFF_CURRENT.md
@@ -1,135 +1,191 @@
 # Project Handoff — Authoritative Current Runtime
 
-Last updated: 2026-08-10 12:51 CDT  
+Last updated: 2026-08-10 13:06 CDT  
 Repository: `sterlingfancher-cmyk/Trading-bot`  
 Branch: `main`  
-Runtime code head covered: `8fcf06622759cc5775a23361c12de1087f73e4b7`  
-Canonical paper service: `https://web-production-e1796.up.railway.app`
+GitHub main head covered: `6e7500a06935bc75a7f44d8ae742cd37b87bc5f6`  
+Canonical paper service: `https://web-production-e1796.up.railway.app`  
+Railway deployment of the current GitHub head: **not yet verified from the current session**
 
 This is the authoritative handoff for the next conversation. Older `PROJECT_HANDOFF_*` files are historical context unless this file explicitly references them.
 
 ## Executive Status
 
-The project is now in a **Stable Core + Performance Lab** phase.
+The project is in a **Stable Core + Performance Lab** phase.
 
-The goal is no longer to keep layering features onto the current runtime. The immediate priority is to produce a stable, operational paper/live-ready core without sacrificing the strategy components that have shown useful performance or the future upside from ML, crypto, MAE/MFE, LONA research, and shadow ranking.
+The immediate objective is to establish a stable, operational paper/live-ready core while preserving the strategy/scanner components that previously produced useful participation and preserving future upside from ML, crypto, MAE/MFE, LONA, and shadow ranking.
 
 The runtime remains **paper-only**. The rules engine remains the sole execution authority. ML and multi-asset ranking remain shadow/research-only and must not place orders, select or override entries/exits, change sizing, relax hard risk, change thresholds, or obtain live authority without an explicit later promotion decision.
 
-The current paper account is still under a **hard risk halt** due to accounting/state contamination discovered on 2026-08-10. Do not clear the halt manually until the account state is either successfully reconstructed from trustworthy evidence or a clean accounting epoch is intentionally started.
+The current paper account remains under a **hard risk halt** because of accounting/state contamination discovered on 2026-08-10. Do not clear the halt manually until the account is either reconstructed from trustworthy evidence or a clean accounting epoch is intentionally created.
 
 ## Operator Workflow — One Routine Test
 
-The user has repeatedly requested **one routine test only** unless a deeper diagnostic is specifically necessary.
+The user wants **one routine test only** unless a demonstrated blocker requires a targeted diagnostic.
 
 Routine test:
 
 `https://web-production-e1796.up.railway.app/paper/daily-audit`
 
-The default response must remain compact and copy/paste friendly. Full forensic output is available only when specifically needed:
+Full forensic output only when necessary:
 
 `https://web-production-e1796.up.railway.app/paper/daily-audit?full=1`
 
-Do not ask the user to run bootstrap + multiple accounting + multiple audit endpoints as a normal workflow. Use the single compact audit whenever possible and add targeted diagnostics only for a demonstrated blocker.
+Do not make bootstrap + multiple accounting + multiple audit endpoints the normal workflow. The compact audit must remain short enough to copy/paste from iPhone.
 
-PR #23 adds a final Flask response-stage compactor so later overlays cannot re-expand the routine audit.
+After PR #24 is deployed, the compact audit should include both:
 
-## Current Runtime Head / Latest Change
+- `journal_recovery_candidate` — historical recovery evidence from the existing mirrored journal
+- `execution_ledger` — health of the new canonical append-only ledger for **new** executions
 
-PR #23 — **Make daily audit one-link compact and add journal recovery candidate** — passed both repository CI workflows and was squash-merged into `main` as:
+## Current GitHub Head / Latest Change
 
-`8fcf06622759cc5775a23361c12de1087f73e4b7`
+PR #24 — **Add canonical execution ledger for Stable Core** — passed both repository CI workflows and was squash-merged into `main` as:
 
-It adds:
+`6e7500a06935bc75a7f44d8ae742cd37b87bc5f6`
 
-- `final_daily_audit_compactor.py`
-- `paper_journal_forensic_recovery.py`
-- startup bridge version `data-integrity-startup-bridge-2026-08-10-v10-one-link-journal-recovery`
-- regression coverage for compact output and semantic journal deduplication
+PR #24 adds:
 
-The forensic recovery candidate is **read-only**. It does not repair state, clear the halt, place orders, or change strategy/risk/sizing/live/ML authority.
+- `canonical_execution_ledger.py`
+- an append-only JSONL execution ledger on the persistent state volume
+- a SHA-256 hash chain across execution rows
+- a durable `execution_id` for every new `entry`, `exit`, and `partial_exit`
+- accounting epoch id and ledger hash metadata propagated into the corresponding `state.trades` row
+- direct wiring at the canonical `record_trade` boundary
+- fail-safe hard-halt behavior if the canonical ledger cannot be written or its hash chain is invalid
+- preservation of an already-active halt reason rather than overwriting it
+- `/paper/canonical-execution-ledger-status`
+- compact `execution_ledger` health inside `/paper/daily-audit`
+- regression coverage for hash chaining, tamper detection, state-row linkage, fail-safe halting, and compact audit exposure
+- startup bridge version `data-integrity-startup-bridge-2026-08-10-v11-canonical-execution-ledger`
+- compact audit compactor version `final-daily-audit-compactor-2026-08-10-v2-canonical-ledger`
+
+Important boundary: the canonical ledger is authoritative for **new executions after it is deployed and hooked**. It is deliberately **not** a fabricated historical recovery source and does not claim to reconstruct the contaminated pre-ledger account.
+
+The two repository validation workflows passed before merge:
+
+- Repository Safety and Performance Audit Validation
+- Refactor, Ownership, Configuration, State, Decision, Runtime, Startup, and Research Audit
 
 ## Accounting Incident — Root Cause and Current Understanding
 
-On 2026-08-10 the paper account began reporting economically impossible values, including very large negative cash and oversized positions. Initial symptoms included repeated apparent MARA purchases and an impossible QQQ cost basis.
+On 2026-08-10 the paper account began reporting economically impossible values, including very large negative cash and oversized positions. Symptoms included repeated apparent MARA purchases and an impossible QQQ cost basis.
 
-The first major root cause was identified in the trade parser:
+### Defect 1 — side-first reconstruction
 
-- canonical trade rows store `action` separately from `side`
-- examples: `action="exit"`, `side="long"`
-- older accounting reconstruction treated `side="long"` as a buy before consulting `action`
-- legitimate long exits were therefore reconstructed as additional buys
+Canonical trade rows store `action` separately from `side`, for example:
 
-That created cascading fake position growth, negative cash, and contaminated P&L/account state.
+- `action="exit"`
+- `side="long"`
+
+Older reconstruction treated `side="long"` as a buy before consulting `action`. Legitimate long exits were therefore reconstructed as additional buys, causing fake position growth, negative cash, and contaminated P&L/account state.
 
 PR #21 corrected this by making **action authoritative**.
 
-A second defect was then exposed: unmatched or duplicate exits could create synthetic cash during reconstruction. PR #22 corrected this so exit proceeds are credited only for quantity proven to exist in reconstructed lots.
+### Defect 2 — unmatched exits creating synthetic cash
 
-The remaining issue is now clearer and more fundamental:
+Once action semantics were corrected, unmatched/duplicate exits could still credit proceeds even when no reconstructed lot existed.
 
-- `state.trades` contains **30 execution rows** in the latest captured audit
-- **19 exit/partial-exit rows have no matching entry lots available in `state.trades`**
-- therefore exact account reconstruction from `state.trades` alone is impossible
-- the matched-exit guard now correctly reports `coverage_complete: false`
-- it no longer fabricates cash from those unmatched exits
+PR #22 changed reconstruction so exit proceeds are credited only for quantity proven to exist in reconstructed lots.
 
-The last single audit before PR #23 showed a bounded reconstructed candidate around:
+### Remaining historical coverage problem
 
-- reconstructed cash: approximately `$14,386.33`
-- reconstructed equity: approximately `$18,004.11`
-- one reconstructed QQQ lot remained
+The latest captured pre-PR #23 audit showed:
+
+- `state.trades`: **30 execution rows**
+- unmatched exit/partial-exit rows: **19**
+- `coverage_complete: false`
+
+Therefore exact historical reconstruction from `state.trades` alone is impossible.
+
+The bounded reconstructed candidate at that point was approximately:
+
+- cash: `$14,386.33`
+- equity: `$18,004.11`
+- one reconstructed QQQ lot
 - ignored/unmatched execution rows: `19`
-- economic/accounting integrity: fail due incomplete ledger coverage
 
-These values are **not yet trusted account values** because coverage is incomplete.
+Those values are **not trusted account values** because ledger coverage is incomplete.
 
-## Append-Only Trade Journal Recovery Candidate
+## Historical Append-Only Journal Recovery Candidate
 
-The bot already maintains a separate persistent append-only trade journal at `/data/trade_journal.json` through `trade_journal.py`.
+The bot has an older persistent mirrored journal at `/data/trade_journal.json` through `trade_journal.py`.
 
-Important properties:
+It:
 
 - mirrors trade history from state and backup files
 - does not shrink existing journal history
 - maintains a backup journal
 - seeds from state backups and current state
 - does not write to `state.json`
-- was designed specifically to preserve execution history across state resets/redeployments
 
-PR #23 now builds a **read-only deduplicated execution candidate** from this journal and runs it through the corrected matched-exit accounting guard.
+PR #23 added `paper_journal_forensic_recovery.py`, which builds a **read-only semantic-deduplicated execution candidate** from that journal and analyzes it through the matched-exit accounting guard.
 
-The compact daily audit will report whether this journal candidate is:
+The routine audit reports whether this historical journal candidate is:
 
 - available
 - complete
 - economically consistent
 - a `trusted_recovery_candidate`
 
-### Recovery Decision Rule
+### Historical Recovery Decision Rule
 
-1. If the journal candidate has complete entry/exit coverage and no economic issues, use it as the evidence base for a controlled state rebuild.
-2. If the journal candidate is still incomplete, **stop spending time reverse-engineering contaminated history**.
-3. Archive the current state/journal/backups as forensic evidence and start a **clean accounting epoch** using the existing proven strategy logic.
+1. If `journal_recovery_candidate.trusted_recovery_candidate == true`, use the journal as the evidence base for **one controlled state rebuild**.
+2. If the journal candidate remains incomplete or economically inconsistent, **stop reverse-engineering contaminated history**.
+3. Archive current state/journal/backups as forensic evidence and start a **clean accounting epoch** using the existing proven strategy logic.
 4. Do not carry contaminated historical MAE/MFE promotion evidence into the new epoch.
 
-This decision rule is intended to prevent another prolonged historical repair loop.
+This decision has **not** been made yet because the current session could not reach the deployed Railway audit endpoint to read the live candidate. Do not guess the answer from repository code alone.
 
-## PR History — Accounting / Recovery Incident
+## New Canonical Execution Ledger — Stable Core Foundation
+
+PR #24 closes the forward-looking execution-history gap that allowed `state.trades` resets/truncation to become existential accounting problems.
+
+For each new execution, the ledger records before the event is mirrored into the capped state trade list:
+
+- `execution_id`
+- ledger version
+- local timestamp
+- accounting epoch id
+- action
+- symbol
+- side
+- fill price
+- shares
+- execution metadata
+- previous event hash
+- event hash
+
+The ledger is append-only and hash-chained. Existing rows are verified before a new row is appended.
+
+If the ledger is unreadable, unparseable, hash-invalid, or unwritable, the runtime records the error in risk state and ensures a hard halt is active. An already-active halt and its reason are preserved.
+
+The new ledger does **not**:
+
+- clear the current accounting halt
+- repair historical state
+- place orders itself
+- change scanner or strategy logic
+- change thresholds
+- change sizing
+- loosen risk
+- enable crypto execution
+- grant live authority
+- grant ML authority
+
+Default epoch label before a deliberate clean/recovered epoch is established:
+
+`legacy-pre-stable-core`
+
+A future controlled recovery or clean-epoch action should establish an explicit new accounting epoch id so forward evidence is cleanly separable from contaminated history.
+
+## PR History — Accounting / Stable Core Incident
 
 ### PR #20 — Harden paper ledger economics and block ORLA
 
 Merged as `73e118a...`.
 
-Added:
-
-- economic-ledger validator
-- detection of buys exceeding cash
-- negative reconstructed cash detection
-- MAE/MFE promotion block when accounting integrity is not clean
-- ORLA static no-data/delisting hygiene block
-
-This correctly exposed the impossible paper ledger instead of allowing a false green accounting result.
+Added economic-ledger validation, cash overspend detection, negative reconstructed-cash detection, MAE/MFE promotion blocking while accounting is dirty, and ORLA static no-data/delisting hygiene.
 
 ### PR #21 — Recover paper ledger with action-first trade semantics
 
@@ -137,9 +193,7 @@ Merged as:
 
 `60014694b829c2433e20bca32bd41920e7801095`
 
-Corrected the core semantic bug where exits from long positions were being reconstructed as buys.
-
-Also established a post-recovery MAE/MFE evidence epoch and preserved the hard halt.
+Made `action` authoritative and established a post-recovery MAE/MFE evidence epoch while preserving the hard halt.
 
 ### PR #22 — Prevent unmatched exits from creating synthetic paper cash
 
@@ -147,7 +201,7 @@ Merged as:
 
 `ce51bb72c727147914371b0618dc714d4fcd335e`
 
-Added matched-lot exit accounting and made incomplete coverage an explicit integrity failure.
+Added matched-lot exit accounting and explicit incomplete-coverage failure.
 
 ### PR #23 — Make daily audit one-link compact and add journal recovery candidate
 
@@ -155,15 +209,21 @@ Merged as:
 
 `8fcf06622759cc5775a23361c12de1087f73e4b7`
 
-This is the current `main` head covered by this handoff.
+Added final response-stage compacting and the read-only historical journal recovery candidate.
+
+### PR #24 — Add canonical execution ledger for Stable Core
+
+Merged as:
+
+`6e7500a06935bc75a7f44d8ae742cd37b87bc5f6`
+
+Established the immutable source of truth for **new** execution events and exposed its health in the one-link audit.
 
 ## What We Know Works / Should Be Preserved
 
-The stabilization audit concluded that the largest failure cluster is **accounting/state reconstruction and overlapping runtime plumbing**, not the market-data/scanner side.
+The stabilization audit indicates the largest failure cluster is **accounting/state reconstruction and overlapping runtime plumbing**, not the market-data/scanner side.
 
-Preserve these components unless new evidence proves otherwise:
-
-### Stable Core candidates
+Preserve unless new evidence proves a specific defect:
 
 - rules-engine execution authority
 - broad-market momentum discovery
@@ -186,7 +246,7 @@ Preserve these components unless new evidence proves otherwise:
 - absolute daily-loss ceiling: `3.0%`
 - maximum account risk per trade at configured stop: `2.0%`
 
-Do not loosen these merely to generate more trades or speed validation.
+Do not loosen these merely to generate more trades or accelerate validation.
 
 ### Scanner / discovery architecture worth preserving
 
@@ -198,38 +258,40 @@ Historical handoff bounds:
 - maximum detailed-scanner input: `110`
 - discovery cache: `900` seconds
 
-The scanner/provider layer has repeatedly shown healthy request accounting and clean provider operation during good runtime periods.
+Provider/scanner infrastructure repeatedly showed healthy request accounting and clean operation during good runtime periods.
 
-## Performance Evidence to Preserve — But Treat Carefully
+## Performance Evidence — Preserve the Engine, Not Corrupted P&L
 
-The user recalls an earlier paper period roughly a month into development where the account increased from about `$10,000` to around `$11,000` within roughly a week.
+There were earlier paper periods with strong positive account movement, including a remembered period from roughly `$10,000` to around `$11,000` in about a week.
 
-Later captured paper results also showed periods of strong positive account movement. However, because the historical account ledger has now been proven incomplete/contaminated, **do not treat all displayed historical P&L as audited performance evidence**.
+Because historical accounting has now been proven incomplete/contaminated, do **not** treat all displayed historical P&L as audited evidence.
 
-What should be preserved is the **strategy configuration and scanner behavior from the stronger periods**, not the corrupted account balances themselves.
+Preserve the strategy configuration, scanner behavior, participation logic, and risk architecture from stronger periods where they can be separated from accounting/runtime defects.
 
-The next architecture should attempt to retain those strategy components while simplifying the plumbing around them.
+Principle:
+
+**Simplify the plumbing, preserve the performance engine.**
 
 ## Stable Core + Performance Lab Architecture
 
 ### Stable Core
 
-Production/paper authority should converge toward only:
+Production/paper authority should converge toward:
 
 1. one canonical scanner/selection path
 2. one execution pipeline
-3. one immutable execution ledger
+3. one immutable execution ledger — **forward foundation now added in PR #24**
 4. one authoritative account/position state
 5. execution-boundary cash/notional/position invariants
 6. one risk controller
 7. one persistence/backup contract
 8. one compact daily audit
 
-The Stable Core should not depend on experimental ML, crypto, MAE/MFE optimization, or alternative research policies to execute trades.
+The next Stable Core engineering work, after the historical recovery-vs-clean-epoch decision, should focus on items 4–7 and reducing redundant execution-path wrappers.
 
 ### Performance Lab
 
-Keep — do not delete — the following as shadow/research systems:
+Keep, but do not grant execution authority to:
 
 - ML recommendation/counterfactual work
 - MAE/MFE research and future stop/target optimization
@@ -239,93 +301,101 @@ Keep — do not delete — the following as shadow/research systems:
 - alternate regime/participation policies
 - future walk-forward / Monte Carlo / stress testing
 
-These systems may score, compare, and record what they would have done, but must not mutate live/paper execution authority until promotion gates are satisfied.
-
 ## ML / MAE-MFE Status
 
 ML remains shadow-only.
 
-The current evidence epoch guard requires **new clean post-recovery exact-lifecycle evidence** before MAE/MFE-derived evidence can become promotable again.
+The evidence-epoch guard requires new clean exact-lifecycle evidence after accounting truth is restored.
 
-The latest captured audit before PR #23 showed:
+Latest captured pre-PR #23 state:
 
 - valid exact-lifecycle rows: `3`
 - post-recovery valid exact-lifecycle rows: `0`
 - promotion evidence eligible: `false`
 - promotion block: `post_accounting_recovery_forward_validation_required`
 
-Do not allow old contaminated/recovery-era rows to satisfy future ML promotion gates.
+Old contaminated/recovery-era rows must not satisfy future ML promotion gates.
 
 ## Multi-Asset / Crypto Research
 
-PR #19 added the shadow multi-asset ranking foundation and was merged as `1892068...`.
+PR #19 added the shadow multi-asset ranking foundation, merged as `1892068...`.
 
 It compares equities/ETFs with BTC, ETH, and SOL while remaining research-only.
 
-It has no execution authority and must remain outside the Stable Core hot path until the base system is stable.
+No crypto execution until Stable Core is proven.
 
 ## LONA Status
 
-LONA remains useful for independent validation, but the connector currently has a backend/schema mismatch for datasets that contain multiple frequencies: the backend requires a frequency/timeframe, while the exposed backtest action did not provide a frequency parameter during the last attempt.
+LONA remains useful for independent validation. The last known limitation was a connector/backend schema mismatch for datasets with multiple frequencies: the backend required a timeframe/frequency while the exposed backtest action did not provide one.
 
 Do not modify the trading bot merely to work around that connector limitation.
 
-Use LONA later for independent backtesting, walk-forward validation, Monte Carlo analysis, slippage/commission stress, and comparison against the Stable Core when the connector path supports it.
+Use LONA later for independent backtesting, walk-forward validation, Monte Carlo analysis, slippage/commission stress, and Stable Core comparison when the connector interface supports it.
 
 ## Provider / Runtime Health Evidence
 
-Before the accounting incident, provider and runtime infrastructure repeatedly demonstrated healthy behavior:
+Before the accounting incident, runtime/provider infrastructure repeatedly demonstrated:
 
 - provider request accounting reconciled
 - no active recursion errors
 - persistent state matched memory/disk
 - after-hours cycles skipped correctly
-- entry pipeline ownership was stable
-- protected benchmark symbols were not blocked
-- provider circuit remained closed
+- entry-pipeline ownership stable
+- protected benchmark symbols not blocked
+- provider circuit closed
 
-The accounting incident should therefore not be interpreted as proof that scanner/provider/market-data logic is fundamentally broken.
+The accounting incident is not evidence that scanner/provider/market-data logic is fundamentally broken.
 
 ## Known Operational Weaknesses
 
-### 1. Accounting/state truth
+### 1. Historical accounting/state truth — primary blocker
 
-Primary current blocker.
+`state.trades` is incomplete for the contaminated history. The older mirrored journal may or may not contain enough evidence; the live compact audit must decide that.
 
-`state.trades` is not a sufficient immutable execution source of truth.
+PR #24 prevents this same class of forward execution-history loss from depending solely on `state.trades`, but it cannot retroactively create missing historical entries.
 
-### 2. Overlay accumulation
+### 2. Authoritative account/position state
 
-The runtime currently contains many historical overlays and wrappers. They were useful for diagnosis but create startup complexity and ownership ambiguity.
+After recovery or clean epoch, Stable Core still needs one explicit account/position authority derived consistently from the canonical execution ledger plus current marks.
 
-The medium-term refactor should move important behavior into explicit canonical modules and remove redundant wrappers from the execution hot path.
+### 3. Execution invariants
 
-### 3. Startup duration
+Add explicit execution-boundary invariants for cash, notional, lot ownership, position quantity, duplicate execution ids, and ledger/state synchronization.
 
-Cold-start/runtime registration has often taken roughly 1–3+ minutes. Slow startup alone has not meant failure when heartbeat continues, but Stable Core should reduce this materially if possible.
+### 4. Overlay accumulation
 
-### 4. Audit payload size
+The runtime contains many historical overlays/wrappers. They were useful diagnostically but create startup complexity and ownership ambiguity.
 
-Addressed by PR #23. Routine audit must remain one-link and compact.
+Move important behavior into explicit canonical modules and remove/bypass redundant execution-path wrappers gradually, with regression gates.
+
+### 5. Startup duration
+
+Cold-start/runtime registration has often taken roughly 1–3+ minutes. Slow startup alone has not meant failure when heartbeat continues, but Stable Core should reduce this materially where possible.
+
+### 6. Audit payload size
+
+Addressed by PR #23 and extended carefully by PR #24. Routine audit must remain one-link and compact.
 
 ## Current Safety State
 
-Until accounting recovery is proven:
+Until accounting truth is established:
 
 - keep hard halt active
 - do not manually reset cash, positions, P&L, or halt based on contaminated state
 - do not trust historical reconstructed P&L as strategy evidence
 - do not promote ML/MAE-MFE authority
-- do not expand execution features
+- do not expand execution strategies
+- do not enable crypto execution
 - do not start live trading
 
 ## Revised Stabilization Strategy
 
-Feature freeze for execution authority.
+Execution-authority feature freeze remains in force.
 
 Allowed work:
 
-- canonical ledger/accounting repair or clean-epoch creation
+- historical recovery or clean-epoch creation
+- canonical ledger/account-state integration
 - execution invariants
 - state/persistence simplification
 - startup simplification
@@ -344,7 +414,7 @@ Not allowed until Stable Core is proven:
 
 ## Stable Paper v1 Acceptance Gate
 
-After accounting truth is restored — either by trusted recovery or a clean epoch — run the **same Stable Core unchanged**.
+After accounting truth is restored — by trusted recovery or clean epoch — run the **same Stable Core unchanged**.
 
 Minimum acceptance target:
 
@@ -352,6 +422,8 @@ Minimum acceptance target:
 - no state corruption
 - no impossible accounting
 - no duplicate execution
+- canonical execution hash chain remains valid
+- every state execution maps to a canonical `execution_id`
 - no unexplained startup failure
 - no manual state repair
 - one compact daily audit per day
@@ -364,43 +436,34 @@ A longer `7–10` day evidence window remains preferable if defects recur.
 
 ## Live-Readiness Direction
 
-The previous long calendar-based roadmap is now secondary to a shorter evidence-gated path.
-
 Desired sequence:
 
-1. establish accounting truth / clean epoch
-2. freeze Stable Core
-3. complete at least 5 unchanged clean paper trading days
-4. validate actual entry/exit/sizing/risk behavior from the canonical ledger
-5. run live-readiness simulation against broker-state assumptions
-6. move to a controlled live pilot at a funding level large enough to exercise the real strategy architecture without forcing redesign
+1. verify current GitHub head is deployed
+2. determine trusted historical recovery vs clean epoch from one compact audit
+3. establish accounting truth and an explicit clean accounting epoch id
+4. finish authoritative account state + execution invariants + persistence contract
+5. freeze Stable Core
+6. complete at least 5 unchanged clean paper trading days
+7. validate entry/exit/sizing/risk behavior from the canonical ledger
+8. run live-readiness simulation against broker-state assumptions
+9. move to a controlled live pilot at a funding level large enough to exercise the real architecture without forcing immediate redesign
 
-Do **not** automatically default to an extremely small `$500` pilot if that would distort sizing, diversification, minimum-notional behavior, or transaction-cost assumptions. Determine the minimum viable live capital from the final Stable Core sizing rules.
-
-The user does not want to start so small that the architecture immediately requires redesign once live.
-
-## Performance vs Stability Principle
-
-Do not simplify the strategy merely for simplicity.
-
-**Simplify the plumbing, preserve the performance engine.**
-
-Retain strong scanner/strategy components from the better-performing periods where they can be separated from accounting/runtime complexity.
-
-Keep ML and other future enhancement paths alive in the Performance Lab so they can be promoted later without another architectural rewrite.
+Do **not** automatically default to an extremely small `$500` pilot if that would distort sizing, diversification, minimum-notional behavior, or transaction-cost assumptions. Determine minimum viable live capital from final Stable Core sizing rules.
 
 ## Immediate Priority Order for the Next Chat
 
-1. Verify Railway deploys `8fcf06622759cc5775a23361c12de1087f73e4b7` / startup bridge v10.
-2. Run only the normal compact daily audit.
-3. Inspect the `journal_recovery_candidate` fields from that one audit.
-4. Decide whether the append-only journal is a trusted complete recovery source.
-5. If yes: design one controlled state rebuild with immutable archive and halt preserved until post-rebuild audit passes.
-6. If no: archive contaminated state and intentionally create a **clean accounting epoch** rather than continuing historical repair loops.
-7. Begin Stable Core refactor: canonical ledger + account state + execution invariants + single risk controller + single persistence contract.
-8. Preserve current rules/scanner performance logic unless evidence shows a specific component is defective.
-9. Keep ML/crypto/LONA/MAE-MFE in Performance Lab shadow mode.
-10. Start the 5-day Stable Paper v1 clock only after accounting truth is clean.
+1. Verify Railway deploys GitHub head `6e7500a06935bc75a7f44d8ae742cd37b87bc5f6` and startup bridge v11.
+2. Run **only** the normal compact daily audit.
+3. Confirm `execution_ledger` reports a healthy hook/hash chain and is authoritative for new executions.
+4. Inspect `journal_recovery_candidate.trusted_recovery_candidate`.
+5. If trusted: implement one controlled journal-based state rebuild with immutable forensic archive and halt preserved until the post-rebuild audit passes.
+6. If not trusted: archive contaminated state/journal/backups and intentionally create a **clean accounting epoch** rather than continuing historical repair loops.
+7. Establish an explicit accounting epoch id for all new canonical ledger rows.
+8. Build authoritative account/position state and execution-boundary invariants around the canonical ledger.
+9. Simplify persistence/risk ownership and remove redundant hot-path wrappers incrementally.
+10. Preserve current rules/scanner performance logic unless evidence proves a specific component defective.
+11. Keep ML/crypto/LONA/MAE-MFE in Performance Lab shadow mode.
+12. Start the 5-day Stable Paper v1 clock only after accounting truth is clean.
 
 ## Tooling / Connected Services
 
@@ -408,16 +471,16 @@ Use GitHub/Codex tooling for code inspection, implementation, CI, regression rev
 
 LONA is connected and may be used for independent research/backtesting when its frequency interface is usable.
 
-Railway is the canonical deployment environment, but there is no direct Railway connector in the current toolset. Use the user's Railway logs/status and deployed HTTP audit output for live verification.
+Railway is the canonical deployment environment, but there is no direct Railway connector in the current toolset. Use deployed HTTP audit output and/or user-provided Railway status/logs for live verification.
 
 ## Important User Operating Preferences
 
 - Prefer **one routine test link** per day.
-- Avoid making the user run multiple diagnostics unless a specific failure requires it.
-- Keep the routine audit short enough to copy/paste from iPhone.
+- Avoid multiple diagnostics unless a specific failure requires them.
+- Keep routine audit output short enough to copy/paste from iPhone.
 - Prefer complete/codebase-level fixes over repeated manual patches.
 - Prioritize reaching an operational live-ready system sooner rather than indefinite feature work.
-- Do not sacrifice the long-term performance ceiling or future ML capability merely to simplify the current runtime.
+- Do not sacrifice long-term performance ceiling or future ML capability merely to simplify the current runtime.
 
 ## Non-Negotiable Boundaries
 
@@ -430,13 +493,15 @@ Railway is the canonical deployment environment, but there is no direct Railway 
 - No fabricated ledger rows or synthetic historical entries.
 - No automatic clearing of halt during accounting recovery.
 - Preserve forensic state/backups before any destructive clean-epoch action.
+- The new canonical execution ledger is authoritative only for executions actually recorded through it; do not use it to invent pre-deployment history.
 
 ## Continuation Prompt for New Chat
 
-A new chat should begin by reviewing this file and then checking the latest GitHub `main` head / Railway compact audit.
+A new chat should begin by reviewing this file, confirming the latest GitHub `main` head, and then using only the normal Railway compact audit.
 
-The most important next question is:
+The two immediate questions are:
 
-**Does PR #23's append-only journal recovery candidate provide complete, economically consistent execution coverage?**
+1. **Is PR #24 deployed and is `execution_ledger` healthy/authoritative for new executions?**
+2. **Does `journal_recovery_candidate.trusted_recovery_candidate` provide complete, economically consistent historical coverage?**
 
-If yes, perform a controlled recovery. If no, start a clean accounting epoch and move immediately into Stable Core validation rather than continuing to patch contaminated history.
+If the journal candidate is trusted, perform a controlled recovery. If it is not trusted, start a clean accounting epoch and move immediately into Stable Core validation rather than continuing to patch contaminated history.


### PR DESCRIPTION
Updates `PROJECT_HANDOFF_CURRENT.md` after PR #24 so the next session starts from the correct GitHub head and Stable Core state. Documents the new canonical execution ledger, preserves the historical recovery-vs-clean-epoch decision rule, and updates the immediate priority list without changing runtime behavior.