### PR TITLE
Repair paper-simulation accounting with a clean epoch

### DIFF
--- a/clean_accounting_epoch.py
+++ b/clean_accounting_epoch.py
@@ -1,0 +1,641 @@
+"""One-time clean accounting epoch cutover after failed historical recovery.
+
+The 2026-08-10 compact audit proved that the mirrored historical trade journal is
+not a trustworthy recovery source (incomplete entry/exit coverage).  Stable Core
+therefore starts a new paper-accounting epoch instead of fabricating missing
+history.
+
+This module is intentionally narrow and one-shot:
+
+* paper runtime only
+* requires the known contaminated-account signature
+* requires the historical journal recovery candidate to be untrusted
+* requires the new canonical execution ledger to be healthy and still empty
+* archives the entire persistent state directory before mutation
+* starts a clean $10,000 accounting epoch with no positions/trades/P&L
+* rotates state backups, mirrored journal, canonical ledger, and snapshots so
+  contaminated persistence cannot be resurrected by fallback recovery
+* keeps a hard validation hold active after cutover
+
+It does not alter scanner/strategy logic, thresholds, sizing, risk limits, live
+or ML authority.  The validation hold is deliberately not cleared here.
+"""
+from __future__ import annotations
+
+import contextlib
+import datetime as dt
+import hashlib
+import json
+import os
+import shutil
+import threading
+from typing import Any, Dict, Iterator, List
+
+VERSION = "clean-accounting-epoch-2026-08-10-v1"
+DECISION_ID = "journal-recovery-incomplete-2026-08-10"
+TARGET_EPOCH_ID = "stable-paper-v1-20260810-clean01"
+STARTING_CASH = float(os.environ.get("CLEAN_EPOCH_STARTING_CASH", "10000"))
+
+STATE_DIR = os.environ.get("STATE_DIR") or os.environ.get("PERSISTENT_STATE_DIR") or os.environ.get("RAILWAY_VOLUME_MOUNT_PATH") or "."
+ARCHIVE_ROOT = os.path.join(STATE_DIR, "forensic_archives")
+MARKER_FILE = os.path.join(STATE_DIR, f"clean_epoch_{DECISION_ID}.json")
+
+_LOCK = threading.RLock()
+_REGISTERED_APP_IDS: set[int] = set()
+_LAST_STATUS: Dict[str, Any] = {}
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or isinstance(value, bool):
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def _now(core: Any = None) -> str:
+    try:
+        return str(core.local_ts_text())
+    except Exception:
+        return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _paper_only() -> bool:
+    live = os.environ.get("LIVE_TRADING_ENABLED", "false").lower() in {"1", "true", "yes", "on"}
+    broker_live = os.environ.get("BROKER_MODE", "").lower() in {"live", "real", "production"}
+    return not live and not broker_live
+
+
+def _portfolio(core: Any = None) -> Dict[str, Any]:
+    pf = getattr(core, "portfolio", None) if core is not None else None
+    return pf if isinstance(pf, dict) else {}
+
+
+def _epoch(pf: Dict[str, Any]) -> Dict[str, Any]:
+    return _d(pf.get("paper_accounting_epoch"))
+
+
+def _marker() -> Dict[str, Any]:
+    try:
+        with open(MARKER_FILE, "r", encoding="utf-8") as handle:
+            obj = json.load(handle)
+        return obj if isinstance(obj, dict) else {}
+    except Exception:
+        return {}
+
+
+def _atomic_json(path: str, payload: Dict[str, Any]) -> None:
+    folder = os.path.dirname(path)
+    if folder:
+        os.makedirs(folder, exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True, default=str)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def _sha256(path: str) -> str | None:
+    if not os.path.isfile(path):
+        return None
+    digest = hashlib.sha256()
+    try:
+        with open(path, "rb") as handle:
+            while True:
+                block = handle.read(1024 * 1024)
+                if not block:
+                    break
+                digest.update(block)
+        return digest.hexdigest()
+    except Exception:
+        return None
+
+
+def _copy_file_atomic(src: str, dst: str) -> None:
+    folder = os.path.dirname(dst)
+    if folder:
+        os.makedirs(folder, exist_ok=True)
+    tmp = dst + ".tmp"
+    shutil.copy2(src, tmp)
+    with open(tmp, "rb") as handle:
+        os.fsync(handle.fileno())
+    os.replace(tmp, dst)
+
+
+def _archive_persistent_state(core: Any, journal: Dict[str, Any], ledger: Dict[str, Any]) -> Dict[str, Any]:
+    os.makedirs(ARCHIVE_ROOT, exist_ok=True)
+    stamp = dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    archive_dir = os.path.join(ARCHIVE_ROOT, f"{stamp}_{DECISION_ID}")
+    os.makedirs(archive_dir, exist_ok=False)
+
+    copied: List[Dict[str, Any]] = []
+    archive_root_abs = os.path.abspath(ARCHIVE_ROOT)
+    for name in sorted(os.listdir(STATE_DIR)):
+        source = os.path.join(STATE_DIR, name)
+        source_abs = os.path.abspath(source)
+        if source_abs == archive_root_abs or source_abs.startswith(archive_root_abs + os.sep):
+            continue
+        destination = os.path.join(archive_dir, name)
+        try:
+            if os.path.isdir(source):
+                shutil.copytree(source, destination)
+                copied.append({"name": name, "type": "directory"})
+            elif os.path.isfile(source):
+                shutil.copy2(source, destination)
+                copied.append({
+                    "name": name,
+                    "type": "file",
+                    "size_bytes": os.path.getsize(destination),
+                    "sha256": _sha256(destination),
+                })
+        except Exception as exc:
+            copied.append({"name": name, "type": "copy_error", "error": f"{type(exc).__name__}: {exc}"})
+
+    pf = _portfolio(core)
+    manifest = {
+        "status": "ok",
+        "type": "clean_accounting_epoch_forensic_archive",
+        "version": VERSION,
+        "decision_id": DECISION_ID,
+        "target_epoch_id": TARGET_EPOCH_ID,
+        "created_local": _now(core),
+        "archive_dir": archive_dir,
+        "pre_cutover_account": {
+            "cash": pf.get("cash"),
+            "equity": pf.get("equity"),
+            "positions": sorted(_d(pf.get("positions")).keys()),
+            "trade_rows": len(_l(pf.get("trades"))),
+            "risk_halted": bool(_d(pf.get("risk_controls")).get("halted", False)),
+            "halt_reason": _d(pf.get("risk_controls")).get("halt_reason"),
+        },
+        "journal_recovery_evidence": {
+            "journal_trade_rows": journal.get("journal_trade_rows"),
+            "deduplicated_execution_rows": journal.get("deduplicated_execution_rows"),
+            "entry_rows": journal.get("entry_rows"),
+            "exit_rows": journal.get("exit_rows"),
+            "coverage_complete": journal.get("coverage_complete"),
+            "coverage_issue_count": journal.get("coverage_issue_count"),
+            "economic_issue_count": journal.get("economic_issue_count"),
+            "trusted_recovery_candidate": journal.get("trusted_recovery_candidate"),
+        },
+        "canonical_ledger_before_cutover": {
+            "chain_valid": ledger.get("chain_valid"),
+            "row_count": ledger.get("row_count"),
+            "current_epoch_id": ledger.get("current_epoch_id"),
+            "authoritative_for_new_executions": ledger.get("authoritative_for_new_executions"),
+        },
+        "copied_entries": copied,
+    }
+    _atomic_json(os.path.join(archive_dir, "clean_epoch_archive_manifest.json"), manifest)
+    return manifest
+
+
+def _base_state(core: Any) -> Dict[str, Any]:
+    fn = getattr(core, "default_state", None)
+    try:
+        value = fn() if callable(fn) else {}
+    except Exception:
+        value = {}
+    return value if isinstance(value, dict) else {}
+
+
+def build_clean_state(core: Any, archive_manifest: Dict[str, Any], journal: Dict[str, Any]) -> Dict[str, Any]:
+    state = _base_state(core)
+    state["initial_cash"] = float(STARTING_CASH)
+    state["starting_cash"] = float(STARTING_CASH)
+    state["initial_equity"] = float(STARTING_CASH)
+    state["cash"] = float(STARTING_CASH)
+    state["equity"] = float(STARTING_CASH)
+    state["peak"] = float(STARTING_CASH)
+    state["history"] = [float(STARTING_CASH)]
+    state["positions"] = {}
+    state["trades"] = []
+    state["last_market"] = {}
+
+    risk_fn = getattr(core, "default_risk_controls", None)
+    try:
+        risk = risk_fn() if callable(risk_fn) else {}
+    except Exception:
+        risk = {}
+    risk = risk if isinstance(risk, dict) else {}
+    risk.update({
+        "day_start_equity": float(STARTING_CASH),
+        "day_peak_equity": float(STARTING_CASH),
+        "day_pnl_pct": 0.0,
+        "daily_loss_pct": 0.0,
+        "daily_drawdown_pct": 0.0,
+        "intraday_drawdown_pct": 0.0,
+        "halted": True,
+        "halt_reason": "clean accounting epoch validation hold",
+        "clean_epoch_validation_hold": True,
+        "clean_epoch_validation_hold_reason": "verify zero-trade baseline and persistence before releasing execution",
+        "profit_guard_active": False,
+        "profit_guard_reason": "",
+        "self_defense_active": False,
+        "self_defense_reason": "",
+        "cooldowns": {},
+    })
+    state["risk_controls"] = risk
+
+    for key, factory_name in (
+        ("auto_runner", "default_auto_runner"),
+        ("realized_pnl", "default_realized_pnl"),
+        ("performance", "default_performance"),
+        ("feedback_loop", "default_feedback_loop"),
+        ("reports", "default_reports"),
+        ("scanner_audit", "default_scanner_audit"),
+    ):
+        factory = getattr(core, factory_name, None)
+        try:
+            value = factory() if callable(factory) else state.get(key, {})
+        except Exception:
+            value = state.get(key, {})
+        state[key] = value if isinstance(value, dict) else {}
+
+    realized = _d(state.get("realized_pnl"))
+    realized.update({"today": 0.0, "total": 0.0, "wins_today": 0, "losses_today": 0, "wins_total": 0, "losses_total": 0})
+    state["realized_pnl"] = realized
+    perf = _d(state.get("performance"))
+    perf.update({
+        "realized_pnl_today": 0.0,
+        "realized_pnl_total": 0.0,
+        "unrealized_pnl": 0.0,
+        "wins_today": 0,
+        "losses_today": 0,
+        "wins_total": 0,
+        "losses_total": 0,
+        "open_positions": {},
+    })
+    state["performance"] = perf
+    state["pullback_watchlist"] = {}
+
+    started = _now(core)
+    state["accounting_epoch_id"] = TARGET_EPOCH_ID
+    state["paper_accounting_epoch"] = {
+        "version": VERSION,
+        "id": TARGET_EPOCH_ID,
+        "decision_id": DECISION_ID,
+        "started_local": started,
+        "starting_cash": float(STARTING_CASH),
+        "clean_start": True,
+        "zero_trade_baseline": True,
+        "historical_recovery_decision": "clean_epoch",
+        "historical_journal_trusted": False,
+        "historical_evidence_archived": True,
+        "forensic_archive_dir": archive_manifest.get("archive_dir"),
+        "journal_coverage_issue_count": int(journal.get("coverage_issue_count") or 0),
+        "journal_economic_issue_count": int(journal.get("economic_issue_count") or 0),
+        "forward_validation_required": True,
+        "valid_path_rows_baseline": 0,
+        "validation_hold": True,
+        "validation_hold_reason": "clean accounting epoch validation hold",
+        "stable_paper_day_count": 0,
+    }
+    return state
+
+
+def _contamination_signature(pf: Dict[str, Any]) -> bool:
+    if _epoch(pf).get("id") == TARGET_EPOCH_ID:
+        return False
+    risk = _d(pf.get("risk_controls"))
+    cash = _f(pf.get("cash"), 0.0)
+    equity = _f(pf.get("equity"), 0.0)
+    trades = _l(pf.get("trades"))
+    return bool(
+        risk.get("halted", False)
+        and len(trades) > 0
+        and (cash < -1000.0 or equity < 0.0)
+    )
+
+
+@contextlib.contextmanager
+def _runtime_locks() -> Iterator[None]:
+    """Match existing journal->state lock order to avoid watcher deadlocks."""
+    journal_lock = None
+    state_lock = None
+    file_lock = None
+    try:
+        try:
+            import trade_journal as tj
+            journal_lock = getattr(tj, "_MIRROR_LOCK", None)
+        except Exception:
+            journal_lock = None
+        try:
+            import state_io_hardening as sio
+            state_lock = getattr(sio, "_THREAD_LOCK", None)
+            file_lock_cls = getattr(sio, "_FileLock", None)
+            file_lock = file_lock_cls(exclusive=True) if callable(file_lock_cls) else None
+        except Exception:
+            state_lock = None
+            file_lock = None
+        if journal_lock is not None:
+            journal_lock.acquire()
+        if state_lock is not None:
+            state_lock.acquire()
+        if file_lock is not None:
+            file_lock.__enter__()
+        yield
+    finally:
+        if file_lock is not None:
+            try:
+                file_lock.__exit__(None, None, None)
+            except Exception:
+                pass
+        if state_lock is not None:
+            try:
+                state_lock.release()
+            except Exception:
+                pass
+        if journal_lock is not None:
+            try:
+                journal_lock.release()
+            except Exception:
+                pass
+
+
+def _write_clean_state_and_backups(core: Any, state: Dict[str, Any]) -> str:
+    state_file = str(getattr(core, "STATE_FILE", os.path.join(STATE_DIR, "state.json")))
+    try:
+        import state_io_hardening as sio
+        sio.atomic_json_write(state_file, state)
+        backups = [
+            getattr(sio, "STATE_BACKUP_LATEST", None),
+            getattr(sio, "STATE_BACKUP_LARGEST", None),
+            getattr(sio, "STATE_BACKUP_PREWRITE", None),
+        ]
+    except Exception:
+        _atomic_json(state_file, state)
+        backups = []
+    app_backup = state_file + ".bak"
+    backups.append(app_backup)
+    for path in backups:
+        if path:
+            _copy_file_atomic(state_file, str(path))
+    return state_file
+
+
+def _rotate_journal(state: Dict[str, Any]) -> None:
+    try:
+        import trade_journal as tj
+    except Exception:
+        return
+    empty_factory = getattr(tj, "_empty_journal", None)
+    try:
+        journal = empty_factory() if callable(empty_factory) else {"trades": [], "recent_trades": [], "snapshots": [], "event_hook_events": []}
+    except Exception:
+        journal = {"trades": [], "recent_trades": [], "snapshots": [], "event_hook_events": []}
+    if not isinstance(journal, dict):
+        journal = {"trades": [], "recent_trades": [], "snapshots": [], "event_hook_events": []}
+    journal["accounting_epoch_id"] = TARGET_EPOCH_ID
+    journal["clean_epoch_started_local"] = _now()
+    for attr in ("TRADE_JOURNAL_FILE", "TRADE_JOURNAL_BACKUP_FILE"):
+        path = str(getattr(tj, attr, "") or "")
+        if path:
+            _atomic_json(path, journal)
+    try:
+        mirror = getattr(tj, "mirror_state", None)
+        if callable(mirror):
+            mirror(state, source="clean_accounting_epoch", source_file=str(getattr(tj, "STATE_FILE", "") or ""))
+    except Exception:
+        pass
+
+
+def _rotate_canonical_ledger() -> None:
+    try:
+        import canonical_execution_ledger as ledger
+        lock = getattr(ledger, "_LOCK", None)
+        if lock is not None:
+            lock.acquire()
+        try:
+            path = str(getattr(ledger, "LEDGER_FILE", "") or "")
+            if path:
+                folder = os.path.dirname(path)
+                if folder:
+                    os.makedirs(folder, exist_ok=True)
+                with open(path, "w", encoding="utf-8") as handle:
+                    handle.flush()
+                    os.fsync(handle.fileno())
+        finally:
+            if lock is not None:
+                lock.release()
+    except Exception:
+        pass
+
+
+def _reset_snapshot_archive(state: Dict[str, Any], state_file: str) -> None:
+    try:
+        import state_snapshot_archive as snapshots
+        directory = str(getattr(snapshots, "SNAPSHOT_DIR", "") or "")
+        if directory:
+            shutil.rmtree(directory, ignore_errors=True)
+            os.makedirs(directory, exist_ok=True)
+        archive = getattr(snapshots, "archive_state", None)
+        if callable(archive):
+            archive(state, state_file)
+    except Exception:
+        pass
+
+
+def _cutover(core: Any, journal: Dict[str, Any], ledger: Dict[str, Any]) -> Dict[str, Any]:
+    global _LAST_STATUS
+    with _runtime_locks():
+        archive = _archive_persistent_state(core, journal, ledger)
+        started_marker = {
+            "status": "cutover_started",
+            "version": VERSION,
+            "decision_id": DECISION_ID,
+            "target_epoch_id": TARGET_EPOCH_ID,
+            "archive_dir": archive.get("archive_dir"),
+            "started_local": _now(core),
+        }
+        _atomic_json(MARKER_FILE, started_marker)
+        clean = build_clean_state(core, archive, journal)
+        state_file = _write_clean_state_and_backups(core, clean)
+        _rotate_canonical_ledger()
+        _rotate_journal(clean)
+        _reset_snapshot_archive(clean, state_file)
+
+        pf = _portfolio(core)
+        pf.clear()
+        pf.update(clean)
+
+        completed = dict(started_marker)
+        completed.update({
+            "status": "completed",
+            "completed_local": _now(core),
+            "starting_cash": float(STARTING_CASH),
+            "validation_hold": True,
+            "state_file": state_file,
+        })
+        _atomic_json(MARKER_FILE, completed)
+        _LAST_STATUS = completed
+        return completed
+
+
+def _decision_evidence(core: Any) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    try:
+        import paper_journal_forensic_recovery as journal_module
+        journal = journal_module.status_payload(core)
+    except Exception as exc:
+        journal = {"status": "error", "trusted_recovery_candidate": None, "error": f"{type(exc).__name__}: {exc}"}
+    try:
+        import canonical_execution_ledger as ledger_module
+        ledger = ledger_module.status_payload(core)
+    except Exception as exc:
+        ledger = {"status": "error", "chain_valid": False, "row_count": None, "error": f"{type(exc).__name__}: {exc}"}
+    return journal, ledger
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _LAST_STATUS
+    if core is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+    if not _paper_only():
+        return {"status": "blocked", "overall": "fail", "version": VERSION, "reason": "paper_runtime_only"}
+
+    with _LOCK:
+        pf = _portfolio(core)
+        existing_epoch = _epoch(pf)
+        marker = _marker()
+        if existing_epoch.get("id") == TARGET_EPOCH_ID:
+            status = {
+                "status": "validation_hold" if bool(_d(pf.get("risk_controls")).get("clean_epoch_validation_hold", False)) else "active",
+                "overall": "warn" if bool(_d(pf.get("risk_controls")).get("clean_epoch_validation_hold", False)) else "pass",
+                "version": VERSION,
+                "decision_id": DECISION_ID,
+                "epoch_id": TARGET_EPOCH_ID,
+                "starting_cash": existing_epoch.get("starting_cash"),
+                "historical_recovery_decision": existing_epoch.get("historical_recovery_decision"),
+                "forensic_archive_dir": existing_epoch.get("forensic_archive_dir") or marker.get("archive_dir"),
+                "archive_complete": bool(existing_epoch.get("historical_evidence_archived", False)),
+                "validation_hold": bool(_d(pf.get("risk_controls")).get("clean_epoch_validation_hold", False)),
+                "zero_trade_baseline": bool(existing_epoch.get("zero_trade_baseline", False)),
+            }
+            _LAST_STATUS = status
+            return status
+
+        journal, ledger = _decision_evidence(core)
+        contamination = _contamination_signature(pf)
+        journal_untrusted = journal.get("trusted_recovery_candidate") is False and int(journal.get("journal_trade_rows") or 0) > 0
+        ledger_ready = bool(ledger.get("chain_valid")) and int(ledger.get("row_count") or 0) == 0 and bool(ledger.get("authoritative_for_new_executions"))
+
+        if marker.get("status") == "completed" and marker.get("target_epoch_id") == TARGET_EPOCH_ID:
+            return {
+                "status": "error",
+                "overall": "fail",
+                "version": VERSION,
+                "reason": "completed_marker_present_but_active_state_epoch_missing",
+                "marker": marker,
+            }
+        if not contamination or not journal_untrusted or not ledger_ready:
+            status = {
+                "status": "blocked",
+                "overall": "warn",
+                "version": VERSION,
+                "decision_id": DECISION_ID,
+                "epoch_id": TARGET_EPOCH_ID,
+                "reason": "clean_epoch_preconditions_not_met",
+                "preconditions": {
+                    "contaminated_halted_state": contamination,
+                    "historical_journal_untrusted": journal_untrusted,
+                    "canonical_ledger_healthy_and_empty": ledger_ready,
+                },
+                "journal": {
+                    "journal_trade_rows": journal.get("journal_trade_rows"),
+                    "coverage_issue_count": journal.get("coverage_issue_count"),
+                    "economic_issue_count": journal.get("economic_issue_count"),
+                    "trusted_recovery_candidate": journal.get("trusted_recovery_candidate"),
+                },
+                "ledger": {
+                    "chain_valid": ledger.get("chain_valid"),
+                    "row_count": ledger.get("row_count"),
+                    "authoritative_for_new_executions": ledger.get("authoritative_for_new_executions"),
+                },
+            }
+            _LAST_STATUS = status
+            return status
+
+        try:
+            result = _cutover(core, journal, ledger)
+            return {
+                "status": "validation_hold",
+                "overall": "warn",
+                "version": VERSION,
+                "decision_id": DECISION_ID,
+                "epoch_id": TARGET_EPOCH_ID,
+                "starting_cash": float(STARTING_CASH),
+                "historical_recovery_decision": "clean_epoch",
+                "forensic_archive_dir": result.get("archive_dir"),
+                "archive_complete": True,
+                "validation_hold": True,
+                "zero_trade_baseline": True,
+            }
+        except Exception as exc:
+            risk = _d(_portfolio(core).setdefault("risk_controls", {}))
+            risk["halted"] = True
+            risk["clean_epoch_cutover_error"] = f"{type(exc).__name__}: {exc}"
+            if not risk.get("halt_reason"):
+                risk["halt_reason"] = "clean accounting epoch cutover failed"
+            status = {"status": "error", "overall": "fail", "version": VERSION, "error": f"{type(exc).__name__}: {exc}"}
+            _LAST_STATUS = status
+            return status
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    pf = _portfolio(core) if core is not None else {}
+    epoch = _epoch(pf)
+    risk = _d(pf.get("risk_controls"))
+    marker = _marker()
+    active = epoch.get("id") == TARGET_EPOCH_ID
+    return {
+        "status": "validation_hold" if active and risk.get("clean_epoch_validation_hold") else "active" if active else _LAST_STATUS.get("status", "pending"),
+        "overall": "warn" if active and risk.get("clean_epoch_validation_hold") else "pass" if active else _LAST_STATUS.get("overall", "warn"),
+        "type": "clean_accounting_epoch_status",
+        "version": VERSION,
+        "decision_id": DECISION_ID,
+        "epoch_id": epoch.get("id") if active else TARGET_EPOCH_ID,
+        "starting_cash": epoch.get("starting_cash") if active else STARTING_CASH,
+        "clean_start": bool(epoch.get("clean_start", False)),
+        "zero_trade_baseline": bool(epoch.get("zero_trade_baseline", False)),
+        "historical_recovery_decision": epoch.get("historical_recovery_decision"),
+        "historical_evidence_archived": bool(epoch.get("historical_evidence_archived", False)),
+        "forensic_archive_dir": epoch.get("forensic_archive_dir") or marker.get("archive_dir"),
+        "validation_hold": bool(risk.get("clean_epoch_validation_hold", False)),
+        "validation_hold_reason": risk.get("clean_epoch_validation_hold_reason"),
+        "marker_status": marker.get("status"),
+        "authority": {
+            "one_time_paper_account_reset": True,
+            "historical_recovery_decision_already_proven": True,
+            "clears_validation_hold": False,
+            "places_orders": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_limits_or_sizing": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    result = apply(core)
+    if flask_app is None:
+        return result
+    app_id = id(flask_app)
+    if app_id not in _REGISTERED_APP_IDS:
+        from flask import jsonify
+        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+        path = "/paper/clean-accounting-epoch-status"
+        if path not in existing:
+            flask_app.add_url_rule(path, "clean_accounting_epoch_status", lambda: jsonify(status_payload(core)))
+        _REGISTERED_APP_IDS.add(app_id)
+    return status_payload(core)

--- a/clean_accounting_epoch_lock_safety.py
+++ b/clean_accounting_epoch_lock_safety.py
@@ -3,8 +3,13 @@
 The cutover already owns the trade-journal mirror lock and state file lock. A
 nested call back into ``trade_journal.mirror_state`` is unnecessary and could
 reacquire the state file lock. The base migration also fsyncs backup copies via a
-read-only descriptor, which is platform-dependent. This shim replaces only those
-two helpers before the cutover module is applied.
+read-only descriptor and writes the primary state before all fallback backups are
+rotated. This shim replaces only those migration helpers before cutover runs.
+
+The clean state is first written to a fully fsynced candidate file, all active
+fallback backups are replaced from that candidate, and only then is the primary
+state path atomically swapped. If backup rotation fails, the contaminated primary
+state remains intact and the hard-halted migration can be retried safely.
 
 This file is intentionally temporary migration plumbing and can be removed once
 the clean epoch has been established and validated.
@@ -15,7 +20,7 @@ import os
 import shutil
 from typing import Any, Dict
 
-VERSION = "clean-accounting-epoch-lock-safety-2026-08-10-v2"
+VERSION = "clean-accounting-epoch-lock-safety-2026-08-10-v3-atomic-final-swap"
 _APPLIED = False
 
 
@@ -50,11 +55,47 @@ def _safe_copy_file_atomic(src: str, dst: str) -> None:
         os.makedirs(folder, exist_ok=True)
     tmp = dst + ".tmp"
     shutil.copy2(src, tmp)
-    # Open writable for a portable fsync before the atomic replace.
     with open(tmp, "rb+") as handle:
         handle.flush()
         os.fsync(handle.fileno())
     os.replace(tmp, dst)
+
+
+def _safe_write_clean_state_and_backups(core: Any, state: Dict[str, Any]) -> str:
+    import clean_accounting_epoch as clean
+
+    state_file = str(getattr(core, "STATE_FILE", os.path.join(clean.STATE_DIR, "state.json")))
+    candidate = state_file + ".clean_epoch_candidate"
+    clean._atomic_json(candidate, state)  # noqa: SLF001 - fully fsynced migration candidate
+
+    backups = []
+    try:
+        import state_io_hardening as sio
+        backups.extend([
+            getattr(sio, "STATE_BACKUP_LATEST", None),
+            getattr(sio, "STATE_BACKUP_LARGEST", None),
+            getattr(sio, "STATE_BACKUP_PREWRITE", None),
+        ])
+    except Exception:
+        pass
+    backups.append(state_file + ".bak")
+
+    for path in backups:
+        if path:
+            _safe_copy_file_atomic(candidate, str(path))
+
+    # Primary state changes only after every fallback copy is clean and durable.
+    os.replace(candidate, state_file)
+    try:
+        folder = os.path.dirname(os.path.abspath(state_file)) or "."
+        directory_fd = os.open(folder, os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except Exception:
+        pass
+    return state_file
 
 
 def apply(core: Any = None) -> Dict[str, Any]:
@@ -62,6 +103,7 @@ def apply(core: Any = None) -> Dict[str, Any]:
     import clean_accounting_epoch as clean
     clean._rotate_journal = _safe_rotate_journal  # type: ignore[attr-defined]  # noqa: SLF001
     clean._copy_file_atomic = _safe_copy_file_atomic  # type: ignore[attr-defined]  # noqa: SLF001
+    clean._write_clean_state_and_backups = _safe_write_clean_state_and_backups  # type: ignore[attr-defined]  # noqa: SLF001
     _APPLIED = True
     return {
         "status": "ok",
@@ -70,6 +112,7 @@ def apply(core: Any = None) -> Dict[str, Any]:
         "applied": True,
         "nested_journal_mirror_disabled": True,
         "portable_backup_fsync": True,
+        "primary_state_swapped_last": True,
         "authority": {
             "changes_strategy": False,
             "changes_thresholds": False,
@@ -88,6 +131,7 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "applied": _APPLIED,
         "nested_journal_mirror_disabled": _APPLIED,
         "portable_backup_fsync": _APPLIED,
+        "primary_state_swapped_last": _APPLIED,
     }
 
 

--- a/clean_accounting_epoch_lock_safety.py
+++ b/clean_accounting_epoch_lock_safety.py
@@ -1,18 +1,21 @@
-"""One-time lock-safety shim for the clean accounting epoch cutover.
+"""One-time lock/persistence safety shim for the clean accounting epoch cutover.
 
-The cutover already owns the trade-journal mirror lock and state file lock.  A
-nested call back into ``trade_journal.mirror_state`` is therefore unnecessary and
-could reacquire the state file lock.  This shim replaces only that helper with a
-direct empty-journal rotation before the cutover module is applied.
+The cutover already owns the trade-journal mirror lock and state file lock. A
+nested call back into ``trade_journal.mirror_state`` is unnecessary and could
+reacquire the state file lock. The base migration also fsyncs backup copies via a
+read-only descriptor, which is platform-dependent. This shim replaces only those
+two helpers before the cutover module is applied.
 
 This file is intentionally temporary migration plumbing and can be removed once
 the clean epoch has been established and validated.
 """
 from __future__ import annotations
 
+import os
+import shutil
 from typing import Any, Dict
 
-VERSION = "clean-accounting-epoch-lock-safety-2026-08-10-v1"
+VERSION = "clean-accounting-epoch-lock-safety-2026-08-10-v2"
 _APPLIED = False
 
 
@@ -41,10 +44,24 @@ def _safe_rotate_journal(_state: Dict[str, Any]) -> None:
             clean._atomic_json(path, journal)  # noqa: SLF001 - same atomic writer as cutover
 
 
+def _safe_copy_file_atomic(src: str, dst: str) -> None:
+    folder = os.path.dirname(dst)
+    if folder:
+        os.makedirs(folder, exist_ok=True)
+    tmp = dst + ".tmp"
+    shutil.copy2(src, tmp)
+    # Open writable for a portable fsync before the atomic replace.
+    with open(tmp, "rb+") as handle:
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, dst)
+
+
 def apply(core: Any = None) -> Dict[str, Any]:
     global _APPLIED
     import clean_accounting_epoch as clean
     clean._rotate_journal = _safe_rotate_journal  # type: ignore[attr-defined]  # noqa: SLF001
+    clean._copy_file_atomic = _safe_copy_file_atomic  # type: ignore[attr-defined]  # noqa: SLF001
     _APPLIED = True
     return {
         "status": "ok",
@@ -52,6 +69,7 @@ def apply(core: Any = None) -> Dict[str, Any]:
         "version": VERSION,
         "applied": True,
         "nested_journal_mirror_disabled": True,
+        "portable_backup_fsync": True,
         "authority": {
             "changes_strategy": False,
             "changes_thresholds": False,
@@ -69,6 +87,7 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "version": VERSION,
         "applied": _APPLIED,
         "nested_journal_mirror_disabled": _APPLIED,
+        "portable_backup_fsync": _APPLIED,
     }
 
 

--- a/clean_accounting_epoch_lock_safety.py
+++ b/clean_accounting_epoch_lock_safety.py
@@ -1,0 +1,76 @@
+"""One-time lock-safety shim for the clean accounting epoch cutover.
+
+The cutover already owns the trade-journal mirror lock and state file lock.  A
+nested call back into ``trade_journal.mirror_state`` is therefore unnecessary and
+could reacquire the state file lock.  This shim replaces only that helper with a
+direct empty-journal rotation before the cutover module is applied.
+
+This file is intentionally temporary migration plumbing and can be removed once
+the clean epoch has been established and validated.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+VERSION = "clean-accounting-epoch-lock-safety-2026-08-10-v1"
+_APPLIED = False
+
+
+def _safe_rotate_journal(_state: Dict[str, Any]) -> None:
+    import clean_accounting_epoch as clean
+    try:
+        import trade_journal as tj
+    except Exception:
+        return
+
+    empty_factory = getattr(tj, "_empty_journal", None)
+    try:
+        journal = empty_factory() if callable(empty_factory) else {
+            "trades": [], "recent_trades": [], "snapshots": [], "event_hook_events": []
+        }
+    except Exception:
+        journal = {"trades": [], "recent_trades": [], "snapshots": [], "event_hook_events": []}
+    if not isinstance(journal, dict):
+        journal = {"trades": [], "recent_trades": [], "snapshots": [], "event_hook_events": []}
+
+    journal["accounting_epoch_id"] = clean.TARGET_EPOCH_ID
+    journal["clean_epoch_started_local"] = clean._now()  # noqa: SLF001 - deliberate one-time migration hook
+    for attr in ("TRADE_JOURNAL_FILE", "TRADE_JOURNAL_BACKUP_FILE"):
+        path = str(getattr(tj, attr, "") or "")
+        if path:
+            clean._atomic_json(path, journal)  # noqa: SLF001 - same atomic writer as cutover
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _APPLIED
+    import clean_accounting_epoch as clean
+    clean._rotate_journal = _safe_rotate_journal  # type: ignore[attr-defined]  # noqa: SLF001
+    _APPLIED = True
+    return {
+        "status": "ok",
+        "overall": "pass",
+        "version": VERSION,
+        "applied": True,
+        "nested_journal_mirror_disabled": True,
+        "authority": {
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "places_orders": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    return {
+        "status": "ok" if _APPLIED else "pending",
+        "overall": "pass" if _APPLIED else "warn",
+        "version": VERSION,
+        "applied": _APPLIED,
+        "nested_journal_mirror_disabled": _APPLIED,
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    return apply(core)

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-10-v12-clean-accounting-epoch"
+VERSION = "data-integrity-startup-bridge-2026-08-10-v13-clean-epoch-lock-safe"
 MODULES = (
     # Registered first so Flask executes its after_request handler last.
     "final_daily_audit_compactor",
@@ -24,6 +24,8 @@ MODULES = (
     "paper_ledger_economic_integrity",
     # Historical recovery evidence is evaluated before the one-time cutover.
     "paper_journal_forensic_recovery",
+    # Disable the unnecessary nested journal mirror while the cutover owns locks.
+    "clean_accounting_epoch_lock_safety",
     "clean_accounting_epoch",
     # All research/path layers run only after the accounting epoch is established.
     "intratrade_path_capture",

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -2,14 +2,15 @@
 
 Imported by the WSGI entry point. This module applies bounded integrity and
 observability modules and registers their status routes. The paper-accounting
-guard is allowed to reconcile paper state from the execution ledger; no module
-here places orders or changes live/ML authority.
+guard is allowed to reconcile paper state from the execution ledger. The one-time
+clean-accounting-epoch module is the explicitly authorized 2026-08-10 migration
+after historical journal recovery was proven incomplete.
 """
 from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-10-v11-canonical-execution-ledger"
+VERSION = "data-integrity-startup-bridge-2026-08-10-v12-clean-accounting-epoch"
 MODULES = (
     # Registered first so Flask executes its after_request handler last.
     "final_daily_audit_compactor",
@@ -21,7 +22,10 @@ MODULES = (
     "paper_accounting_integrity_guard",
     "paper_accounting_readonly_status",
     "paper_ledger_economic_integrity",
+    # Historical recovery evidence is evaluated before the one-time cutover.
     "paper_journal_forensic_recovery",
+    "clean_accounting_epoch",
+    # All research/path layers run only after the accounting epoch is established.
     "intratrade_path_capture",
     "mae_mfe_integration",
     "daily_data_integrity_audit_overlay",

--- a/final_daily_audit_compactor.py
+++ b/final_daily_audit_compactor.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "final-daily-audit-compactor-2026-08-10-v2-canonical-ledger"
+VERSION = "final-daily-audit-compactor-2026-08-10-v3-clean-accounting-epoch"
 _REGISTERED = set()
 
 
@@ -36,11 +36,18 @@ def _ledger_status(core: Any = None) -> Dict[str, Any]:
         return {"status": "warn", "error": f"{type(exc).__name__}: {exc}"}
 
 
+def _epoch_status(core: Any = None) -> Dict[str, Any]:
+    try:
+        import clean_accounting_epoch as module
+        return module.status_payload(core)
+    except Exception as exc:
+        return {"status": "warn", "error": f"{type(exc).__name__}: {exc}"}
+
+
 def compact_payload(payload: Dict[str, Any], core: Any = None) -> Dict[str, Any]:
     sections = _d(payload.get("sections"))
     account = _d(sections.get("01_account_and_open_position_performance"))
     runner = _d(sections.get("02_auto_runner_liveness"))
-    errors = _d(sections.get("03_active_errors_and_recursion"))
     risk = _d(sections.get("04_risk_controls_and_drawdown"))
     scanner = _d(sections.get("05_scanner_signals_entries_rejections"))
     integrity = _d(sections.get("10b_market_data_and_path_integrity"))
@@ -53,6 +60,7 @@ def compact_payload(payload: Dict[str, Any], core: Any = None) -> Dict[str, Any]
     next_action = _d(sections.get("12_next_action"))
     journal = _journal_status(core)
     ledger = _ledger_status(core)
+    epoch = _epoch_status(core)
 
     reasons = []
     for value in _l(risk.get("reasons")) + _l(integrity.get("reasons")):
@@ -79,6 +87,16 @@ def compact_payload(payload: Dict[str, Any], core: Any = None) -> Dict[str, Any]
             "realized_today": account.get("realized_today"),
             "unrealized_pnl": account.get("unrealized_pnl"),
         },
+        "accounting_epoch": {
+            "status": epoch.get("status"),
+            "epoch_id": epoch.get("epoch_id"),
+            "starting_cash": epoch.get("starting_cash"),
+            "clean_start": epoch.get("clean_start"),
+            "zero_trade_baseline": epoch.get("zero_trade_baseline"),
+            "historical_recovery_decision": epoch.get("historical_recovery_decision"),
+            "historical_evidence_archived": epoch.get("historical_evidence_archived"),
+            "validation_hold": epoch.get("validation_hold"),
+        },
         "runner": {
             "status": runner.get("status"),
             "enabled": runner.get("enabled"),
@@ -101,6 +119,7 @@ def compact_payload(payload: Dict[str, Any], core: Any = None) -> Dict[str, Any]
         "accounting_integrity": {
             "status": accounting.get("status"),
             "coverage_complete": accounting.get("coverage_complete"),
+            "baseline_type": rebuilt.get("baseline_type"),
             "ignored_trade_rows": rebuilt.get("ignored_trade_rows"),
             "coverage_issue_count": rebuilt.get("coverage_issue_count"),
             "economic_issue_count": economics.get("economic_issue_count"),
@@ -119,6 +138,8 @@ def compact_payload(payload: Dict[str, Any], core: Any = None) -> Dict[str, Any]
             "candidate_cash": journal.get("candidate_cash"),
             "candidate_equity": journal.get("candidate_equity"),
             "trusted_recovery_candidate": journal.get("trusted_recovery_candidate"),
+            "decision_complete": journal.get("decision_complete"),
+            "historical_recovery_disposition": journal.get("historical_recovery_disposition"),
         },
         "execution_ledger": {
             "status": ledger.get("status"),
@@ -139,6 +160,7 @@ def compact_payload(payload: Dict[str, Any], core: Any = None) -> Dict[str, Any]
             "promotion_block_reason": forward.get("promotion_block_reason"),
             "valid_exact_lifecycle_rows": forward.get("valid_exact_lifecycle_rows_observed"),
             "post_recovery_valid_exact_lifecycle_rows": forward.get("post_recovery_valid_exact_lifecycle_rows"),
+            "post_epoch_valid_exact_lifecycle_rows": forward.get("post_epoch_valid_exact_lifecycle_rows"),
         },
         "next_action": {
             "status": next_action.get("status"),

--- a/paper_journal_forensic_recovery.py
+++ b/paper_journal_forensic_recovery.py
@@ -1,15 +1,19 @@
 """Read-only forensic recovery candidate from the append-only trade journal.
 
-Builds a deduplicated execution candidate from /data/trade_journal.json and
-checks whether it can reconstruct a complete, economically plausible paper
-account. It never mutates portfolio state, clears halts, or places orders.
+Before a clean accounting epoch is established, this builds a deduplicated
+execution candidate from /data/trade_journal.json and checks whether it can
+reconstruct a complete, economically plausible paper account.
+
+After the historical decision is resolved in favor of a clean epoch, the old
+journal is treated as archived forensic evidence rather than an active recovery
+warning.  This module never mutates state, clears halts, or places orders.
 """
 from __future__ import annotations
 
 import json
 from typing import Any, Dict, List, Tuple
 
-VERSION = "paper-journal-forensic-recovery-2026-08-10-v1"
+VERSION = "paper-journal-forensic-recovery-2026-08-10-v2-clean-epoch"
 
 
 def _d(value: Any) -> Dict[str, Any]:
@@ -77,9 +81,54 @@ def _candidate_rows(journal: Dict[str, Any]) -> List[Dict[str, Any]]:
     return out
 
 
+def _clean_epoch_disposition(core: Any) -> Dict[str, Any] | None:
+    pf = _portfolio(core)
+    epoch = _d(pf.get("paper_accounting_epoch"))
+    if not bool(epoch.get("clean_start")) or epoch.get("historical_recovery_decision") != "clean_epoch":
+        return None
+    journal, error = _load_journal()
+    return {
+        "status": "archived",
+        "overall": "pass",
+        "type": "paper_journal_forensic_recovery_status",
+        "version": VERSION,
+        "journal_available": not bool(error),
+        "journal_trade_rows": len(_l(journal.get("trades"))),
+        "deduplicated_execution_rows": len(_candidate_rows(journal)),
+        "entry_rows": sum(1 for row in _candidate_rows(journal) if str(row.get("action") or "").lower() == "entry"),
+        "exit_rows": sum(1 for row in _candidate_rows(journal) if str(row.get("action") or "").lower() in {"exit", "partial_exit"}),
+        "coverage_complete": None,
+        "coverage_issue_count": int(epoch.get("journal_coverage_issue_count") or 0),
+        "economic_issue_count": int(epoch.get("journal_economic_issue_count") or 0),
+        "candidate_cash": None,
+        "candidate_equity": None,
+        "candidate_open_positions": [],
+        "trusted_recovery_candidate": False,
+        "decision_complete": True,
+        "historical_recovery_disposition": "archived_after_incomplete_coverage",
+        "clean_epoch_id": epoch.get("id"),
+        "forensic_archive_dir": epoch.get("forensic_archive_dir"),
+        "error": error,
+        "authority": {
+            "reporting_only": True,
+            "repairs_state": False,
+            "clears_hard_halt": False,
+            "places_orders": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
 def status_payload(core: Any = None) -> Dict[str, Any]:
     if core is None:
         return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+
+    disposition = _clean_epoch_disposition(core)
+    if disposition is not None:
+        return disposition
 
     journal, error = _load_journal()
     rows = _candidate_rows(journal)
@@ -121,6 +170,8 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "candidate_equity": rebuilt.get("equity"),
         "candidate_open_positions": sorted(_d(rebuilt.get("open_positions")).keys()),
         "trusted_recovery_candidate": trustworthy,
+        "decision_complete": False,
+        "historical_recovery_disposition": "pending",
         "authority": {
             "reporting_only": True,
             "repairs_state": False,

--- a/paper_ledger_matched_exit_guard.py
+++ b/paper_ledger_matched_exit_guard.py
@@ -3,13 +3,16 @@
 Prevents unmatched/duplicate exits from creating synthetic cash during ledger
 reconstruction. This module is paper-only and changes accounting reconstruction
 and reporting only; it does not place orders or change strategy/risk authority.
+
+A deliberately created clean accounting epoch is also a valid zero-trade ledger
+baseline when cash/equity/P&L and the canonical execution ledger all agree.
 """
 from __future__ import annotations
 
 import datetime as dt
 from typing import Any, Dict, List
 
-VERSION = "paper-ledger-matched-exit-guard-2026-08-10-v1"
+VERSION = "paper-ledger-matched-exit-guard-2026-08-10-v2-clean-epoch"
 _APPLIED = False
 _REGISTERED_APP_IDS: set[int] = set()
 
@@ -55,12 +58,80 @@ def _initial_cash(accounting: Any, pf: Dict[str, Any]) -> float:
         return _f(history[0], 10000.0) if history else 10000.0
 
 
+def _clean_epoch_zero_trade_baseline(pf: Dict[str, Any], core: Any, accounting: Any) -> Dict[str, Any] | None:
+    epoch = _d(pf.get("paper_accounting_epoch"))
+    if not bool(epoch.get("clean_start")) or not bool(epoch.get("zero_trade_baseline")):
+        return None
+    if _l(pf.get("trades")) or _d(pf.get("positions")):
+        return None
+
+    initial = _f(epoch.get("starting_cash"), _initial_cash(accounting, pf))
+    cash = _f(pf.get("cash"), initial)
+    equity = _f(pf.get("equity"), cash)
+    realized = _d(pf.get("realized_pnl"))
+    performance = _d(pf.get("performance"))
+    issues: List[Dict[str, Any]] = []
+    money_tol = max(0.01, abs(initial) * 1e-8)
+
+    if initial <= 0:
+        issues.append({"reason": "clean_epoch_starting_cash_invalid", "starting_cash": initial})
+    if abs(cash - initial) > money_tol:
+        issues.append({"reason": "clean_epoch_cash_not_at_baseline", "cash": cash, "starting_cash": initial})
+    if abs(equity - initial) > money_tol:
+        issues.append({"reason": "clean_epoch_equity_not_at_baseline", "equity": equity, "starting_cash": initial})
+    if abs(_f(realized.get("today"), 0.0)) > money_tol or abs(_f(realized.get("total"), 0.0)) > money_tol:
+        issues.append({"reason": "clean_epoch_realized_pnl_not_zero"})
+    if abs(_f(performance.get("unrealized_pnl"), 0.0)) > money_tol:
+        issues.append({"reason": "clean_epoch_unrealized_pnl_not_zero"})
+
+    try:
+        import canonical_execution_ledger as ledger
+        ledger_status = ledger.status_payload(core)
+        if not bool(ledger_status.get("chain_valid")):
+            issues.append({"reason": "canonical_execution_ledger_chain_invalid"})
+        if not bool(ledger_status.get("authoritative_for_new_executions")):
+            issues.append({"reason": "canonical_execution_ledger_not_authoritative"})
+        if int(ledger_status.get("row_count") or 0) != 0:
+            issues.append({"reason": "clean_epoch_canonical_ledger_not_empty", "row_count": ledger_status.get("row_count")})
+        if int(ledger_status.get("current_epoch_rows") or 0) != 0:
+            issues.append({"reason": "clean_epoch_current_epoch_ledger_not_empty", "current_epoch_rows": ledger_status.get("current_epoch_rows")})
+        if str(ledger_status.get("current_epoch_id") or "") != str(epoch.get("id") or pf.get("accounting_epoch_id") or ""):
+            issues.append({"reason": "clean_epoch_ledger_epoch_id_mismatch"})
+    except Exception as exc:
+        issues.append({"reason": "canonical_execution_ledger_status_error", "error": f"{type(exc).__name__}: {exc}"})
+
+    complete = not issues
+    return {
+        "status": "ok" if complete else "partial",
+        "reason": "clean_zero_trade_epoch_baseline" if complete else "clean_zero_trade_epoch_baseline_invalid",
+        "baseline_type": "clean_zero_trade_epoch",
+        "coverage_complete": complete,
+        "parsed_trade_rows": 0,
+        "ignored_trade_rows": 0,
+        "initial_cash": round(initial, 6),
+        "cash": round(cash, 6),
+        "equity": round(equity, 6),
+        "market_value": 0.0,
+        "realized_total": 0.0,
+        "realized_today": 0.0,
+        "unrealized_pnl": 0.0,
+        "open_positions": {},
+        "coverage_issues": issues[:50],
+        "coverage_issue_count": len(issues),
+        "economic_issues": [],
+        "economic_issue_count": 0,
+    }
+
+
 def analyze_ledger(pf: Dict[str, Any], core: Any = None) -> Dict[str, Any]:
     import paper_accounting_integrity_guard as accounting
 
     trades = _l(pf.get("trades"))
     positions = _d(pf.get("positions"))
     if not trades:
+        clean = _clean_epoch_zero_trade_baseline(pf, core, accounting)
+        if clean is not None:
+            return clean
         return {
             "status": "unavailable",
             "reason": "trade_ledger_empty",
@@ -130,8 +201,6 @@ def analyze_ledger(pf: Dict[str, Any], core: Any = None) -> Dict[str, Any]:
                 })
             continue
 
-        # Sell only the quantity proven to exist in the lot book. Never credit
-        # proceeds for unmatched/duplicate exit quantity.
         remaining = qty
         matched_qty = 0.0
         matched_proceeds = 0.0
@@ -274,6 +343,7 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "version": VERSION,
         "applied": _APPLIED,
         "coverage_complete": bool(rebuilt.get("coverage_complete")),
+        "baseline_type": rebuilt.get("baseline_type"),
         "parsed_trade_rows": int(rebuilt.get("parsed_trade_rows") or 0),
         "ignored_trade_rows": int(rebuilt.get("ignored_trade_rows") or 0),
         "coverage_issue_count": int(rebuilt.get("coverage_issue_count") or 0),

--- a/paper_trade_action_semantics_recovery.py
+++ b/paper_trade_action_semantics_recovery.py
@@ -4,9 +4,10 @@ The runtime's canonical trade rows contain both ``action`` (entry/exit/partial_e
 and ``side`` (long/short). The accounting incident occurred because reconciliation
 read ``side`` first, causing long exits to be interpreted as additional buys.
 
-This overlay makes ``action`` authoritative, preserves one forensic pre-repair
-snapshot, and invokes the existing paper-only reconciler after semantics are fixed.
-It never clears a hard risk halt and never places orders or changes strategy.
+This overlay makes ``action`` authoritative. Historical recovery behavior remains
+available for the contaminated pre-epoch state, but once a deliberate clean
+accounting epoch exists it installs semantics only and does not create another
+historical-recovery snapshot or replay reconciliation.
 """
 from __future__ import annotations
 
@@ -14,7 +15,7 @@ import copy
 import datetime as dt
 from typing import Any, Dict, Tuple
 
-VERSION = "paper-trade-action-semantics-recovery-2026-08-10-v1"
+VERSION = "paper-trade-action-semantics-recovery-2026-08-10-v2-clean-epoch"
 _REGISTERED_APP_IDS: set[int] = set()
 _APPLIED = False
 
@@ -44,6 +45,12 @@ def _portfolio(core: Any) -> Dict[str, Any]:
     return pf if isinstance(pf, dict) else {}
 
 
+def _clean_epoch(core: Any) -> Dict[str, Any]:
+    pf = _portfolio(core)
+    row = pf.get("paper_accounting_epoch")
+    return row if isinstance(row, dict) and row.get("clean_start") else {}
+
+
 def action_first_trade_fields(row: Dict[str, Any]) -> Tuple[str, str, float, float, str]:
     """Return symbol, economic event, qty, price, timestamp.
 
@@ -71,7 +78,6 @@ def action_first_trade_fields(row: Dict[str, Any]) -> Tuple[str, str, float, flo
     elif direction in {"sell", "s"}:
         event = "sell"
     elif direction in {"long", "entry", "open_long"}:
-        # Backward-compatible fallback only for older rows with no action.
         event = "buy"
     elif direction == "short":
         event = "unsupported_short_entry"
@@ -79,6 +85,17 @@ def action_first_trade_fields(row: Dict[str, Any]) -> Tuple[str, str, float, flo
         event = action or direction
 
     return symbol, event, qty, price, timestamp
+
+
+def _install_action_semantics() -> Dict[str, Any]:
+    try:
+        import paper_accounting_integrity_guard as accounting
+        import paper_ledger_economic_integrity as economics
+        accounting._trade_fields = action_first_trade_fields
+        economics._trade_fields = action_first_trade_fields
+        return {"status": "ok"}
+    except Exception as exc:
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
 
 
 def _archive_before_repair(core: Any) -> Dict[str, Any]:
@@ -123,23 +140,23 @@ def apply(core: Any = None) -> Dict[str, Any]:
     if core is None:
         return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
 
+    semantics = _install_action_semantics()
+    if semantics.get("status") != "ok":
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": semantics.get("error")}
+
+    clean = _clean_epoch(core)
+    if clean:
+        _APPLIED = True
+        return status_payload(core)
+
     archive = _archive_before_repair(core)
 
-    try:
-        import paper_accounting_integrity_guard as accounting
-        import paper_ledger_economic_integrity as economics
-        accounting._trade_fields = action_first_trade_fields
-        economics._trade_fields = action_first_trade_fields
-    except Exception as exc:
-        return {"status": "error", "overall": "fail", "version": VERSION, "error": f"{type(exc).__name__}: {exc}"}
-
-    # Capture the pre-recovery path-evidence baseline once. Existing rows remain
-    # historical evidence but cannot satisfy the post-recovery promotion gate.
     if int(archive.get("recovery_epoch_valid_path_rows_baseline") or 0) <= 0:
         archive["recovery_epoch_valid_path_rows_baseline"] = _current_valid_path_rows()
 
     before_halt = bool((_portfolio(core).get("risk_controls") or {}).get("halted", False)) if isinstance(_portfolio(core).get("risk_controls"), dict) else False
     try:
+        import paper_accounting_integrity_guard as accounting
         result = accounting.reconcile(core, persist=True)
     except Exception as exc:
         result = {"status": "error", "overall": "fail", "error": f"{type(exc).__name__}: {exc}"}
@@ -174,13 +191,39 @@ def apply(core: Any = None) -> Dict[str, Any]:
 
 def status_payload(core: Any = None) -> Dict[str, Any]:
     pf = _portfolio(core) if core is not None else {}
+    clean = _clean_epoch(core) if core is not None else {}
     row = pf.get("paper_accounting_semantics_recovery") if isinstance(pf.get("paper_accounting_semantics_recovery"), dict) else {}
+    if clean:
+        return {
+            "status": "ok" if _APPLIED else "pending",
+            "overall": "pass" if _APPLIED else "warn",
+            "type": "paper_trade_action_semantics_recovery_status",
+            "version": VERSION,
+            "applied": _APPLIED,
+            "mode": "clean_epoch_semantics_only",
+            "clean_epoch_id": clean.get("id"),
+            "historical_recovery_replayed": False,
+            "post_recovery_validation_required": bool(clean.get("forward_validation_required", True)),
+            "hard_halt_preserved": bool((pf.get("risk_controls") or {}).get("halted", False)) if isinstance(pf.get("risk_controls"), dict) else True,
+            "pre_repair_trade_count": 0,
+            "post_repair": {},
+            "authority": {
+                "paper_state_reconciliation_only": True,
+                "places_orders": False,
+                "clears_hard_halt": False,
+                "changes_strategy": False,
+                "changes_thresholds": False,
+                "changes_risk_or_sizing": False,
+                "changes_live_or_ml_authority": False,
+            },
+        }
     return {
         "status": "ok" if _APPLIED and row else "pending",
         "overall": "pass" if _APPLIED and row and row.get("hard_halt_preserved", True) else "warn",
         "type": "paper_trade_action_semantics_recovery_status",
         "version": VERSION,
         "applied": _APPLIED,
+        "mode": "historical_recovery",
         "recovery_epoch_valid_path_rows_baseline": int(row.get("recovery_epoch_valid_path_rows_baseline") or 0),
         "post_recovery_validation_required": bool(row.get("post_recovery_validation_required", True)),
         "hard_halt_preserved": bool(row.get("hard_halt_preserved", True)),

--- a/post_recovery_evidence_epoch_guard.py
+++ b/post_recovery_evidence_epoch_guard.py
@@ -1,10 +1,15 @@
-"""Block MAE/MFE promotion until a new clean lifecycle exists after accounting recovery."""
+"""Block MAE/MFE promotion until new clean lifecycle evidence exists.
+
+Supports both the historical accounting-recovery epoch and the deliberate clean
+accounting epoch.  Old contaminated/recovery-era rows can never satisfy a clean
+epoch promotion gate.
+"""
 from __future__ import annotations
 
 import functools
 from typing import Any, Dict
 
-VERSION = "post-recovery-evidence-epoch-guard-2026-08-10-v1"
+VERSION = "post-recovery-evidence-epoch-guard-2026-08-10-v2-clean-epoch"
 _APPLIED = False
 
 
@@ -15,6 +20,26 @@ def _d(value: Any) -> Dict[str, Any]:
 def _state(core: Any) -> Dict[str, Any]:
     pf = getattr(core, "portfolio", None) if core is not None else None
     return pf if isinstance(pf, dict) else {}
+
+
+def _epoch_gate(state: Dict[str, Any]) -> Dict[str, Any]:
+    clean = _d(state.get("paper_accounting_epoch"))
+    if bool(clean.get("clean_start")):
+        return {
+            "source": "clean_accounting_epoch",
+            "epoch_id": clean.get("id"),
+            "baseline": int(clean.get("valid_path_rows_baseline") or 0),
+            "required": bool(clean.get("forward_validation_required", True)),
+            "reason": "clean_accounting_epoch_forward_validation_required",
+        }
+    recovery = _d(state.get("paper_accounting_semantics_recovery"))
+    return {
+        "source": "historical_accounting_recovery",
+        "epoch_id": None,
+        "baseline": int(recovery.get("recovery_epoch_valid_path_rows_baseline") or 0),
+        "required": bool(recovery.get("post_recovery_validation_required", False)),
+        "reason": "post_accounting_recovery_forward_validation_required",
+    }
 
 
 def apply(core: Any = None) -> Dict[str, Any]:
@@ -41,27 +66,29 @@ def apply(core: Any = None) -> Dict[str, Any]:
             return section
 
         state = _state(active)
-        recovery = _d(state.get("paper_accounting_semantics_recovery"))
-        baseline = int(recovery.get("recovery_epoch_valid_path_rows_baseline") or 0)
+        gate = _epoch_gate(state)
+        baseline = int(gate.get("baseline") or 0)
         forward = _d(section.get("forward_validation"))
         current_valid = int(forward.get("valid_exact_lifecycle_rows_observed") or 0)
-        post_recovery_valid = max(0, current_valid - baseline)
-        required = bool(recovery.get("post_recovery_validation_required", False))
-        eligible = (not required) or post_recovery_valid >= 1
+        post_epoch_valid = max(0, current_valid - baseline)
+        required = bool(gate.get("required", False))
+        eligible = (not required) or post_epoch_valid >= 1
 
         epoch = {
             "version": VERSION,
-            "recovery_active": bool(recovery),
+            "source": gate.get("source"),
+            "epoch_id": gate.get("epoch_id"),
             "baseline_valid_exact_lifecycle_rows": baseline,
             "current_valid_exact_lifecycle_rows": current_valid,
-            "post_recovery_valid_exact_lifecycle_rows": post_recovery_valid,
+            "post_recovery_valid_exact_lifecycle_rows": post_epoch_valid,
+            "post_epoch_valid_exact_lifecycle_rows": post_epoch_valid,
             "minimum_post_recovery_rows_required": 1,
             "promotion_evidence_eligible": eligible,
         }
         section["post_recovery_evidence_epoch"] = epoch
 
         if required and not eligible:
-            reason = "post_accounting_recovery_forward_validation_required"
+            reason = str(gate.get("reason") or "post_accounting_recovery_forward_validation_required")
             reasons = list(section.get("reasons") or [])
             if reason not in reasons:
                 reasons.insert(0, reason)
@@ -70,17 +97,20 @@ def apply(core: Any = None) -> Dict[str, Any]:
 
             forward["promotion_evidence_eligible"] = False
             forward["promotion_block_reason"] = reason
-            forward["post_recovery_valid_exact_lifecycle_rows"] = post_recovery_valid
+            forward["post_recovery_valid_exact_lifecycle_rows"] = post_epoch_valid
+            forward["post_epoch_valid_exact_lifecycle_rows"] = post_epoch_valid
             section["forward_validation"] = forward
 
             mae = _d(section.get("mae_mfe_integrity"))
             mae["promotion_evidence_eligible"] = False
             mae["promotion_block_reason"] = reason
-            mae["post_recovery_training_eligible_rows"] = post_recovery_valid
+            mae["post_recovery_training_eligible_rows"] = post_epoch_valid
+            mae["post_epoch_training_eligible_rows"] = post_epoch_valid
             section["mae_mfe_integrity"] = mae
         elif required and eligible:
             forward["promotion_evidence_eligible"] = True
-            forward["post_recovery_valid_exact_lifecycle_rows"] = post_recovery_valid
+            forward["post_recovery_valid_exact_lifecycle_rows"] = post_epoch_valid
+            forward["post_epoch_valid_exact_lifecycle_rows"] = post_epoch_valid
             section["forward_validation"] = forward
 
         return section
@@ -93,15 +123,19 @@ def apply(core: Any = None) -> Dict[str, Any]:
 
 
 def status_payload(core: Any = None) -> Dict[str, Any]:
-    recovery = _d(_state(core).get("paper_accounting_semantics_recovery")) if core is not None else {}
+    state = _state(core) if core is not None else {}
+    gate = _epoch_gate(state)
     return {
         "status": "ok" if _APPLIED else "pending",
         "overall": "pass" if _APPLIED else "warn",
         "type": "post_recovery_evidence_epoch_guard_status",
         "version": VERSION,
         "applied": _APPLIED,
-        "recovery_epoch_valid_path_rows_baseline": int(recovery.get("recovery_epoch_valid_path_rows_baseline") or 0),
-        "post_recovery_validation_required": bool(recovery.get("post_recovery_validation_required", False)),
+        "epoch_source": gate.get("source"),
+        "epoch_id": gate.get("epoch_id"),
+        "recovery_epoch_valid_path_rows_baseline": int(gate.get("baseline") or 0),
+        "post_recovery_validation_required": bool(gate.get("required", False)),
+        "promotion_block_reason": gate.get("reason") if gate.get("required") else None,
         "authority": {
             "reporting_and_promotion_gate_only": True,
             "places_orders": False,

--- a/test_clean_accounting_epoch.py
+++ b/test_clean_accounting_epoch.py
@@ -1,0 +1,169 @@
+import json
+import sys
+import types
+
+import clean_accounting_epoch as clean
+import final_daily_audit_compactor as compact
+import paper_journal_forensic_recovery as journal_recovery
+import paper_ledger_matched_exit_guard as matched
+import paper_trade_action_semantics_recovery as semantics
+
+
+def _core_with_defaults():
+    def risk():
+        return {"date": "2026-08-10", "halted": False, "halt_reason": "", "cooldowns": {}}
+
+    return types.SimpleNamespace(
+        portfolio={},
+        default_state=lambda: {
+            "cash": 10000.0,
+            "equity": 10000.0,
+            "peak": 10000.0,
+            "positions": {},
+            "history": [],
+            "trades": [],
+            "risk_controls": risk(),
+            "auto_runner": {},
+            "realized_pnl": {},
+            "performance": {},
+            "feedback_loop": {},
+            "reports": {},
+            "scanner_audit": {},
+            "pullback_watchlist": {},
+        },
+        default_risk_controls=risk,
+        default_auto_runner=lambda: {"enabled": True},
+        default_realized_pnl=lambda: {"date": "2026-08-10", "today": 0.0, "total": 0.0},
+        default_performance=lambda: {"realized_pnl_today": 0.0, "realized_pnl_total": 0.0, "unrealized_pnl": 0.0},
+        default_feedback_loop=lambda: {},
+        default_reports=lambda: {},
+        default_scanner_audit=lambda: {},
+        local_ts_text=lambda *args, **kwargs: "2026-08-10 13:20:00 CDT",
+    )
+
+
+def test_build_clean_state_is_zeroed_and_validation_halted():
+    core = _core_with_defaults()
+    state = clean.build_clean_state(
+        core,
+        {"archive_dir": "/data/forensic_archives/example"},
+        {"coverage_issue_count": 23, "economic_issue_count": 0},
+    )
+
+    assert state["accounting_epoch_id"] == clean.TARGET_EPOCH_ID
+    assert state["cash"] == 10000.0
+    assert state["equity"] == 10000.0
+    assert state["positions"] == {}
+    assert state["trades"] == []
+    assert state["realized_pnl"]["today"] == 0.0
+    assert state["realized_pnl"]["total"] == 0.0
+    assert state["risk_controls"]["halted"] is True
+    assert state["risk_controls"]["clean_epoch_validation_hold"] is True
+    assert state["paper_accounting_epoch"]["historical_recovery_decision"] == "clean_epoch"
+    assert state["paper_accounting_epoch"]["journal_coverage_issue_count"] == 23
+
+
+def test_zero_trade_clean_epoch_is_valid_accounting_baseline(monkeypatch):
+    core = _core_with_defaults()
+    state = clean.build_clean_state(core, {"archive_dir": "/archive"}, {"coverage_issue_count": 23, "economic_issue_count": 0})
+    core.portfolio = state
+
+    fake_ledger = types.SimpleNamespace(
+        status_payload=lambda runtime: {
+            "chain_valid": True,
+            "authoritative_for_new_executions": True,
+            "row_count": 0,
+            "current_epoch_rows": 0,
+            "current_epoch_id": clean.TARGET_EPOCH_ID,
+        }
+    )
+    monkeypatch.setitem(sys.modules, "canonical_execution_ledger", fake_ledger)
+
+    rebuilt = matched.analyze_ledger(state, core)
+    assert rebuilt["coverage_complete"] is True
+    assert rebuilt["baseline_type"] == "clean_zero_trade_epoch"
+    assert rebuilt["parsed_trade_rows"] == 0
+    assert rebuilt["cash"] == 10000.0
+    assert rebuilt["equity"] == 10000.0
+    assert rebuilt["coverage_issue_count"] == 0
+
+
+def test_clean_epoch_rejects_nonempty_canonical_ledger(monkeypatch):
+    core = _core_with_defaults()
+    state = clean.build_clean_state(core, {"archive_dir": "/archive"}, {"coverage_issue_count": 23, "economic_issue_count": 0})
+    core.portfolio = state
+    fake_ledger = types.SimpleNamespace(
+        status_payload=lambda runtime: {
+            "chain_valid": True,
+            "authoritative_for_new_executions": True,
+            "row_count": 1,
+            "current_epoch_rows": 1,
+            "current_epoch_id": clean.TARGET_EPOCH_ID,
+        }
+    )
+    monkeypatch.setitem(sys.modules, "canonical_execution_ledger", fake_ledger)
+    rebuilt = matched.analyze_ledger(state, core)
+    assert rebuilt["coverage_complete"] is False
+    assert rebuilt["coverage_issue_count"] >= 1
+
+
+def test_historical_journal_is_archived_after_clean_epoch(monkeypatch, tmp_path):
+    journal_path = tmp_path / "trade_journal.json"
+    journal_path.write_text(json.dumps({"trades": []}), encoding="utf-8")
+    monkeypatch.setitem(sys.modules, "trade_journal", types.SimpleNamespace(TRADE_JOURNAL_FILE=str(journal_path)))
+
+    core = _core_with_defaults()
+    state = clean.build_clean_state(core, {"archive_dir": "/archive"}, {"coverage_issue_count": 23, "economic_issue_count": 0})
+    core.portfolio = state
+    out = journal_recovery.status_payload(core)
+    assert out["status"] == "archived"
+    assert out["overall"] == "pass"
+    assert out["trusted_recovery_candidate"] is False
+    assert out["decision_complete"] is True
+    assert out["historical_recovery_disposition"] == "archived_after_incomplete_coverage"
+
+
+def test_action_semantics_does_not_recreate_historical_recovery_on_clean_epoch():
+    core = _core_with_defaults()
+    state = clean.build_clean_state(core, {"archive_dir": "/archive"}, {"coverage_issue_count": 23, "economic_issue_count": 0})
+    core.portfolio = state
+    out = semantics.apply(core)
+    assert out["mode"] == "clean_epoch_semantics_only"
+    assert "paper_accounting_semantics_recovery" not in core.portfolio
+
+
+def test_compact_audit_exposes_accounting_epoch(monkeypatch):
+    monkeypatch.setattr(compact, "_epoch_status", lambda core=None: {
+        "status": "validation_hold",
+        "epoch_id": clean.TARGET_EPOCH_ID,
+        "starting_cash": 10000.0,
+        "clean_start": True,
+        "zero_trade_baseline": True,
+        "historical_recovery_decision": "clean_epoch",
+        "historical_evidence_archived": True,
+        "validation_hold": True,
+    })
+    monkeypatch.setattr(compact, "_journal_status", lambda core=None: {"status": "archived", "decision_complete": True})
+    monkeypatch.setattr(compact, "_ledger_status", lambda core=None: {"status": "ok", "chain_valid": True, "row_count": 0})
+    payload = {
+        "status": "ok",
+        "overall": "fail",
+        "sections": {
+            "01_account_and_open_position_performance": {"cash": 10000.0, "equity": 10000.0, "positions": []},
+            "02_auto_runner_liveness": {"status": "pass", "enabled": True},
+            "04_risk_controls_and_drawdown": {"status": "fail", "halted": True, "halt_reason": "clean accounting epoch validation hold"},
+            "05_scanner_signals_entries_rejections": {},
+            "10b_market_data_and_path_integrity": {
+                "paper_accounting_integrity": {"status": "ok", "coverage_complete": True, "reconstructed": {"baseline_type": "clean_zero_trade_epoch", "cash": 10000.0, "equity": 10000.0}},
+                "paper_ledger_economic_integrity": {"economic_issue_count": 0},
+                "forward_validation": {},
+                "provider_request_accounting": {},
+            },
+            "11_conclusion": {"pass_count": 10, "warn_count": 0, "fail_count": 1},
+            "12_next_action": {},
+        },
+    }
+    out = compact.compact_payload(payload, None)
+    assert out["accounting_epoch"]["epoch_id"] == clean.TARGET_EPOCH_ID
+    assert out["accounting_epoch"]["validation_hold"] is True
+    assert out["accounting_integrity"]["baseline_type"] == "clean_zero_trade_epoch"


### PR DESCRIPTION
Paper-simulation state-integrity migration only. This PR cannot place real orders, cannot enable live brokerage access, and does not alter scanner logic, strategy rules, thresholds, sizing, or risk limits.

The deployed paper audit proved the old mirrored history is incomplete: the recovery candidate is untrusted with 23 coverage issues, while the new forward-only hash-chained simulation ledger is healthy and empty. Following the project handoff, this archives the contaminated simulation state and begins a clean $10,000 paper-accounting epoch.

The migration archives persistent simulation files before mutation, resets paper cash/equity to $10,000 with no simulated positions or trades, rotates contaminated fallback backups/journal/snapshots, binds future simulated events to a new epoch id, resets research-evidence eligibility, and retains a hard validation hold after migration. It also adds regression coverage and compact daily-audit reporting.

No real-money authority is added or changed. The post-deploy validation hold remains active until a separate paper-integrity review.