### PR TITLE
Stable Paper post-cutover release guards

### DIFF
--- a/administrative_halt_classification_guard.py
+++ b/administrative_halt_classification_guard.py
@@ -1,0 +1,157 @@
+"""Keep administrative paper holds distinct from performance self-defense.
+
+A clean-accounting validation hold blocks execution through ``risk.halted`` but
+is not a loss event.  The performance-risk calibration layer historically treated
+any halt as a hard performance halt, which caused a zero-loss clean epoch to be
+reported as self-defense.
+
+This guard preserves the administrative halt itself while preventing it from
+being mislabeled as loss-driven self-defense.  It changes no thresholds, sizing,
+entry rules, order behavior, live authority, or ML authority.
+"""
+from __future__ import annotations
+
+import functools
+from typing import Any, Dict
+
+VERSION = "administrative-halt-classification-2026-08-10-v1"
+_APPLIED_CORE_IDS: set[int] = set()
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or isinstance(value, bool):
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def _portfolio(core: Any) -> Dict[str, Any]:
+    value = getattr(core, "portfolio", None) if core is not None else None
+    return value if isinstance(value, dict) else {}
+
+
+def _is_clean_epoch_admin_hold(risk: Dict[str, Any]) -> bool:
+    reason = str(risk.get("halt_reason") or "").strip().lower()
+    return bool(
+        risk.get("halted")
+        and risk.get("clean_epoch_validation_hold")
+        and reason == "clean accounting epoch validation hold"
+    )
+
+
+def _loss_metrics_clear(risk: Dict[str, Any]) -> bool:
+    return all(
+        abs(_f(risk.get(key), 0.0)) < 1e-9
+        for key in (
+            "daily_loss_pct",
+            "daily_drawdown_pct",
+            "intraday_drawdown_pct",
+            "realized_loss_pct",
+            "daily_loss_fraction",
+            "intraday_drawdown_fraction",
+            "realized_loss_fraction",
+        )
+    )
+
+
+def _normalize(core: Any, feedback: Dict[str, Any], persist: bool) -> Dict[str, Any]:
+    state = _portfolio(core)
+    risk = _d(state.get("risk_controls"))
+    if not (_is_clean_epoch_admin_hold(risk) and _loss_metrics_clear(risk)):
+        return feedback
+
+    controlled = _d(feedback.get("controlled_restart"))
+    if controlled:
+        controlled["hard_halt_active"] = False
+        controlled["soft_pause_active"] = False
+        controlled["realized_soft_triggered"] = False
+        controlled["loss_streak_soft_triggered"] = False
+        controlled["active"] = False
+        controlled["administrative_hold_active"] = True
+        feedback["controlled_restart"] = controlled
+
+    feedback["self_defense_mode"] = False
+    feedback["hard_halt"] = False
+    # The administrative hold is already enforced by risk.halted in the canonical
+    # entry gate. Do not duplicate it as a self-defense loss block.
+    feedback["block_new_entries"] = False
+    feedback["reasons"] = ["clean accounting epoch validation hold (administrative, zero-loss)"]
+    feedback["administrative_hold_active"] = True
+    feedback["administrative_hold_reason"] = "clean accounting epoch validation hold"
+
+    if persist:
+        risk["self_defense_active"] = False
+        risk["self_defense_reason"] = ""
+        risk["administrative_hold_active"] = True
+        risk["administrative_hold_reason"] = "clean accounting epoch validation hold"
+        state["risk_controls"] = risk
+        state["feedback_loop"] = feedback
+    return feedback
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    if core is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+    if id(core) in _APPLIED_CORE_IDS:
+        return status_payload(core)
+
+    current = getattr(core, "feedback_loop_status", None)
+    if not callable(current):
+        return {"status": "error", "overall": "fail", "version": VERSION, "reason": "feedback_loop_status_missing"}
+    if getattr(current, "_administrative_halt_classification_version", None) == VERSION:
+        _APPLIED_CORE_IDS.add(id(core))
+        return status_payload(core)
+
+    prior = getattr(current, "_administrative_halt_classification_prior", current)
+
+    @functools.wraps(prior)
+    def wrapped(*args, **kwargs):
+        result = prior(*args, **kwargs)
+        feedback = result if isinstance(result, dict) else {}
+        persist = bool(kwargs.get("persist", args[4] if len(args) >= 5 else True))
+        return _normalize(core, feedback, persist)
+
+    wrapped._administrative_halt_classification_version = VERSION  # type: ignore[attr-defined]
+    wrapped._administrative_halt_classification_prior = prior  # type: ignore[attr-defined]
+    core.feedback_loop_status = wrapped
+    _APPLIED_CORE_IDS.add(id(core))
+
+    # Normalize the persisted diagnostic immediately; the halt remains active.
+    state = _portfolio(core)
+    feedback = _d(state.get("feedback_loop"))
+    if feedback:
+        _normalize(core, feedback, True)
+    return status_payload(core)
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    state = _portfolio(core) if core is not None else {}
+    risk = _d(state.get("risk_controls"))
+    return {
+        "status": "ok" if core is not None and id(core) in _APPLIED_CORE_IDS else "pending",
+        "overall": "pass" if core is not None and id(core) in _APPLIED_CORE_IDS else "warn",
+        "type": "administrative_halt_classification_status",
+        "version": VERSION,
+        "applied": bool(core is not None and id(core) in _APPLIED_CORE_IDS),
+        "clean_epoch_administrative_hold": _is_clean_epoch_admin_hold(risk),
+        "loss_metrics_clear": _loss_metrics_clear(risk),
+        "authority": {
+            "classification_only": True,
+            "clears_halt": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "places_orders": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    return apply(core)

--- a/clean_epoch_validation_release.py
+++ b/clean_epoch_validation_release.py
@@ -1,0 +1,294 @@
+"""One-time release of the clean-accounting validation hold.
+
+The clean epoch was intentionally deployed halted so its zero-trade baseline
+could be verified from Railway before paper execution resumed.  The operator's
+post-cutover audit established that baseline.  This module re-verifies the same
+facts in-process on the next deployment and clears *only* the administrative
+clean-epoch hold when every invariant still agrees.
+
+It cannot clear any other risk halt and cannot run outside paper mode.  It does
+not change strategy logic, thresholds, sizing, live authority, or ML authority.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import os
+from typing import Any, Dict, List
+
+VERSION = "clean-epoch-validation-release-2026-08-10-v1"
+TARGET_EPOCH_ID = "stable-paper-v1-20260810-clean01"
+EXPECTED_STARTING_CASH = float(os.environ.get("CLEAN_EPOCH_STARTING_CASH", "10000"))
+_RELEASED_CORE_IDS: set[int] = set()
+_LAST: Dict[str, Any] = {}
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or isinstance(value, bool):
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def _now(core: Any = None) -> str:
+    try:
+        return str(core.local_ts_text())
+    except Exception:
+        return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _paper_only() -> bool:
+    live = os.environ.get("LIVE_TRADING_ENABLED", "false").lower() in {"1", "true", "yes", "on"}
+    broker_live = os.environ.get("BROKER_MODE", "").lower() in {"live", "real", "production"}
+    return not live and not broker_live
+
+
+def _portfolio(core: Any) -> Dict[str, Any]:
+    pf = getattr(core, "portfolio", None) if core is not None else None
+    return pf if isinstance(pf, dict) else {}
+
+
+def _risk_metrics_zero(risk: Dict[str, Any]) -> bool:
+    return all(
+        abs(_f(risk.get(key), 0.0)) < 1e-9
+        for key in (
+            "daily_loss_pct",
+            "daily_drawdown_pct",
+            "intraday_drawdown_pct",
+            "realized_loss_pct",
+            "daily_loss_fraction",
+            "intraday_drawdown_fraction",
+            "realized_loss_fraction",
+        )
+    )
+
+
+def _evidence(core: Any) -> Dict[str, Any]:
+    state = _portfolio(core)
+    epoch = _d(state.get("paper_accounting_epoch"))
+    risk = _d(state.get("risk_controls"))
+    realized = _d(state.get("realized_pnl"))
+    perf = _d(state.get("performance"))
+
+    try:
+        import canonical_execution_ledger as ledger_module
+        ledger = ledger_module.status_payload(core)
+    except Exception as exc:
+        ledger = {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
+    try:
+        import paper_bidirectional_accounting_guard as bidirectional
+        bidir = bidirectional.status_payload(core)
+    except Exception as exc:
+        bidir = {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
+    try:
+        import paper_accounting_integrity_guard as accounting
+        integrity = accounting.status_payload(core)
+    except Exception as exc:
+        integrity = {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
+    try:
+        import paper_journal_forensic_recovery as journal_module
+        journal = journal_module.status_payload(core)
+    except Exception as exc:
+        journal = {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
+
+    return {
+        "state": state,
+        "epoch": epoch,
+        "risk": risk,
+        "realized": realized,
+        "performance": perf,
+        "ledger": ledger,
+        "bidirectional": bidir,
+        "integrity": integrity,
+        "journal": journal,
+    }
+
+
+def _preconditions(core: Any) -> Dict[str, Any]:
+    e = _evidence(core)
+    state = e["state"]
+    epoch = e["epoch"]
+    risk = e["risk"]
+    realized = e["realized"]
+    perf = e["performance"]
+    ledger = e["ledger"]
+    bidir = e["bidirectional"]
+    integrity = e["integrity"]
+    journal = e["journal"]
+    rebuilt = _d(integrity.get("reconstructed"))
+
+    money_tol = max(0.01, EXPECTED_STARTING_CASH * 1e-8)
+    checks = {
+        "paper_runtime": _paper_only(),
+        "target_epoch": str(epoch.get("id") or state.get("accounting_epoch_id") or "") == TARGET_EPOCH_ID,
+        "clean_start": bool(epoch.get("clean_start")),
+        "zero_trade_baseline": bool(epoch.get("zero_trade_baseline")),
+        "historical_evidence_archived": bool(epoch.get("historical_evidence_archived")),
+        "validation_hold_active": bool(risk.get("clean_epoch_validation_hold")),
+        "validation_halt_reason_exact": str(risk.get("halt_reason") or "") == "clean accounting epoch validation hold",
+        "cash_at_baseline": abs(_f(state.get("cash")) - EXPECTED_STARTING_CASH) <= money_tol,
+        "equity_at_baseline": abs(_f(state.get("equity")) - EXPECTED_STARTING_CASH) <= money_tol,
+        "no_positions": not _d(state.get("positions")),
+        "no_state_trades": not _l(state.get("trades")),
+        "realized_zero": abs(_f(realized.get("today"))) <= money_tol and abs(_f(realized.get("total"))) <= money_tol,
+        "unrealized_zero": abs(_f(perf.get("unrealized_pnl"))) <= money_tol,
+        "risk_metrics_zero": _risk_metrics_zero(risk),
+        "canonical_ledger_chain_valid": bool(ledger.get("chain_valid")),
+        "canonical_ledger_authoritative": bool(ledger.get("authoritative_for_new_executions")),
+        "canonical_ledger_empty": int(ledger.get("row_count") or 0) == 0,
+        "canonical_epoch_empty": int(ledger.get("current_epoch_rows") or 0) == 0,
+        "canonical_epoch_matches": str(ledger.get("current_epoch_id") or "") == TARGET_EPOCH_ID,
+        "bidirectional_accounting_installed": bidir.get("status") == "ok" and bool(bidir.get("supports_long_short")),
+        "accounting_coverage_complete": bool(integrity.get("coverage_complete")),
+        "accounting_clean_zero_trade_baseline": rebuilt.get("baseline_type") == "clean_zero_trade_epoch",
+        "accounting_no_coverage_issues": int(rebuilt.get("coverage_issue_count") or 0) == 0,
+        "accounting_no_economic_issues": int(rebuilt.get("economic_issue_count") or 0) == 0,
+        "journal_decision_complete": bool(journal.get("decision_complete")),
+        "journal_archived": str(journal.get("status") or "") == "archived",
+        "journal_remains_untrusted": journal.get("trusted_recovery_candidate") is False,
+    }
+    failed = [name for name, ok in checks.items() if not ok]
+    return {"checks": checks, "failed": failed, "evidence": e}
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _LAST
+    if core is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+    if not _paper_only():
+        return {"status": "blocked", "overall": "fail", "version": VERSION, "reason": "paper_runtime_only"}
+
+    state = _portfolio(core)
+    epoch = _d(state.get("paper_accounting_epoch"))
+    risk = _d(state.get("risk_controls"))
+
+    if str(epoch.get("id") or state.get("accounting_epoch_id") or "") == TARGET_EPOCH_ID and not risk.get("clean_epoch_validation_hold"):
+        result = {
+            "status": "released",
+            "overall": "pass",
+            "version": VERSION,
+            "epoch_id": TARGET_EPOCH_ID,
+            "already_released": True,
+            "released_local": epoch.get("validation_released_local"),
+        }
+        _RELEASED_CORE_IDS.add(id(core))
+        _LAST = result
+        return result
+
+    pre = _preconditions(core)
+    if pre["failed"]:
+        result = {
+            "status": "blocked",
+            "overall": "warn",
+            "version": VERSION,
+            "epoch_id": TARGET_EPOCH_ID,
+            "reason": "clean_epoch_release_preconditions_not_met",
+            "failed_checks": pre["failed"],
+            "checks": pre["checks"],
+        }
+        _LAST = result
+        return result
+
+    # Clear only the explicitly named administrative hold.  Any other halt reason
+    # fails the precondition above and is preserved.
+    risk["halted"] = False
+    risk["halt_reason"] = ""
+    risk["clean_epoch_validation_hold"] = False
+    risk["clean_epoch_validation_hold_reason"] = ""
+    risk["administrative_hold_active"] = False
+    risk["administrative_hold_reason"] = ""
+    risk["self_defense_active"] = False
+    risk["self_defense_reason"] = ""
+    risk["clean_epoch_validation_released_local"] = _now(core)
+    risk["clean_epoch_validation_release_version"] = VERSION
+    state["risk_controls"] = risk
+
+    feedback = _d(state.get("feedback_loop"))
+    feedback["self_defense_mode"] = False
+    feedback["block_new_entries"] = False
+    feedback["hard_halt"] = False
+    feedback["reasons"] = ["clean accounting epoch validated; normal risk controls active"]
+    feedback["administrative_hold_active"] = False
+    state["feedback_loop"] = feedback
+
+    epoch["validation_hold"] = False
+    epoch["validation_hold_reason"] = ""
+    epoch["validation_released_local"] = _now(core)
+    epoch["validation_release_version"] = VERSION
+    epoch["stable_paper_day_count"] = int(epoch.get("stable_paper_day_count") or 0)
+    state["paper_accounting_epoch"] = epoch
+
+    save = getattr(core, "save_state", None)
+    if not callable(save):
+        result = {"status": "error", "overall": "fail", "version": VERSION, "reason": "save_state_missing"}
+        _LAST = result
+        return result
+    try:
+        save(state)
+    except TypeError:
+        save()
+
+    _RELEASED_CORE_IDS.add(id(core))
+    result = {
+        "status": "released",
+        "overall": "pass",
+        "version": VERSION,
+        "epoch_id": TARGET_EPOCH_ID,
+        "already_released": False,
+        "released_local": epoch.get("validation_released_local"),
+        "checks": pre["checks"],
+    }
+    _LAST = result
+    return result
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    state = _portfolio(core) if core is not None else {}
+    epoch = _d(state.get("paper_accounting_epoch"))
+    risk = _d(state.get("risk_controls"))
+    active_epoch = str(epoch.get("id") or state.get("accounting_epoch_id") or "") == TARGET_EPOCH_ID
+    released = bool(active_epoch and not risk.get("clean_epoch_validation_hold") and not risk.get("halted"))
+    return {
+        "status": "released" if released else _LAST.get("status", "pending"),
+        "overall": "pass" if released else _LAST.get("overall", "warn"),
+        "type": "clean_epoch_validation_release_status",
+        "version": VERSION,
+        "epoch_id": TARGET_EPOCH_ID,
+        "released": released,
+        "validation_hold": bool(risk.get("clean_epoch_validation_hold")),
+        "risk_halted": bool(risk.get("halted")),
+        "halt_reason": risk.get("halt_reason"),
+        "released_local": epoch.get("validation_released_local"),
+        "last_result": dict(_LAST),
+        "authority": {
+            "paper_only": True,
+            "clears_only_clean_epoch_validation_hold": True,
+            "clears_other_risk_halts": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_limits_or_sizing": False,
+            "places_orders": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    result = apply(core)
+    if flask_app is None:
+        return result
+    from flask import jsonify
+    existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+    path = "/paper/clean-epoch-validation-release-status"
+    if path not in existing:
+        flask_app.add_url_rule(path, "clean_epoch_validation_release_status", lambda: jsonify(status_payload(core)))
+    return status_payload(core)

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-10-v13-clean-epoch-lock-safe"
+VERSION = "data-integrity-startup-bridge-2026-08-10-v14-stable-paper-release"
 MODULES = (
     # Registered first so Flask executes its after_request handler last.
     "final_daily_audit_compactor",
@@ -27,6 +27,14 @@ MODULES = (
     # Disable the unnecessary nested journal mirror while the cutover owns locks.
     "clean_accounting_epoch_lock_safety",
     "clean_accounting_epoch",
+    # Stable Paper must support the runtime's actual long/short lifecycle before
+    # the administrative clean-epoch hold is eligible for release.
+    "paper_bidirectional_accounting_guard",
+    # A validation hold is an administrative execution block, not a loss event.
+    "administrative_halt_classification_guard",
+    # Re-verifies the deployed zero-trade baseline and clears only that exact
+    # administrative hold. Any other risk halt remains untouched.
+    "clean_epoch_validation_release",
     # All research/path layers run only after the accounting epoch is established.
     "intratrade_path_capture",
     "mae_mfe_integration",

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-10-v14-stable-paper-release"
+VERSION = "data-integrity-startup-bridge-2026-08-10-v15-stable-paper-release-timestamp-safe"
 MODULES = (
     # Registered first so Flask executes its after_request handler last.
     "final_daily_audit_compactor",
@@ -30,6 +30,9 @@ MODULES = (
     # Stable Paper must support the runtime's actual long/short lifecycle before
     # the administrative clean-epoch hold is eligible for release.
     "paper_bidirectional_accounting_guard",
+    # Canonical record_trade rows use epoch-second timestamps. Normalize them for
+    # session P&L reconstruction and require explicit canonical long/short sides.
+    "paper_execution_timestamp_semantics",
     # A validation hold is an administrative execution block, not a loss event.
     "administrative_halt_classification_guard",
     # Re-verifies the deployed zero-trade baseline and clears only that exact

--- a/final_daily_audit_compactor.py
+++ b/final_daily_audit_compactor.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "final-daily-audit-compactor-2026-08-10-v3-clean-accounting-epoch"
+VERSION = "final-daily-audit-compactor-2026-08-10-v4-stable-paper-release"
 _REGISTERED = set()
 
 
@@ -18,6 +18,15 @@ def _d(value: Any) -> Dict[str, Any]:
 
 def _l(value: Any) -> list:
     return value if isinstance(value, list) else []
+
+
+def _i(value: Any) -> int:
+    try:
+        if value is None or isinstance(value, bool):
+            return 0
+        return max(0, int(value))
+    except Exception:
+        return 0
 
 
 def _journal_status(core: Any = None) -> Dict[str, Any]:
@@ -44,6 +53,39 @@ def _epoch_status(core: Any = None) -> Dict[str, Any]:
         return {"status": "warn", "error": f"{type(exc).__name__}: {exc}"}
 
 
+def _release_status(core: Any = None) -> Dict[str, Any]:
+    try:
+        import clean_epoch_validation_release as module
+        return module.status_payload(core)
+    except Exception as exc:
+        return {"status": "warn", "error": f"{type(exc).__name__}: {exc}"}
+
+
+def _bidirectional_status(core: Any = None) -> Dict[str, Any]:
+    try:
+        import paper_bidirectional_accounting_guard as module
+        return module.status_payload(core)
+    except Exception as exc:
+        return {"status": "warn", "error": f"{type(exc).__name__}: {exc}"}
+
+
+def _market_data_status(integrity: Dict[str, Any], provider: Dict[str, Any]) -> str:
+    requests = _i(provider.get("requests"))
+    classified = _i(provider.get("classified_terminal_outcomes"))
+    gap = _i(provider.get("in_flight_or_unclassified_requests"))
+    if not gap and requests > classified:
+        gap = requests - classified
+    over = _i(provider.get("provider_outcomes_over_request_count"))
+    protected_blocked = _l(integrity.get("protected_symbols_blocked"))
+    if bool(integrity.get("provider_circuit_open")) or protected_blocked or over > 0:
+        return "fail"
+    # One open request is an expected concurrent snapshot state because the
+    # request counter increments before its terminal outcome is recorded.
+    if gap > 1:
+        return "warn"
+    return "pass"
+
+
 def compact_payload(payload: Dict[str, Any], core: Any = None) -> Dict[str, Any]:
     sections = _d(payload.get("sections"))
     account = _d(sections.get("01_account_and_open_position_performance"))
@@ -61,11 +103,26 @@ def compact_payload(payload: Dict[str, Any], core: Any = None) -> Dict[str, Any]
     journal = _journal_status(core)
     ledger = _ledger_status(core)
     epoch = _epoch_status(core)
+    release = _release_status(core)
+    bidirectional = _bidirectional_status(core)
 
     reasons = []
     for value in _l(risk.get("reasons")) + _l(integrity.get("reasons")):
         if value and value not in reasons:
             reasons.append(value)
+
+    next_reason = next_action.get("reason")
+    next_action_text = next_action.get("action")
+    next_priority = next_action.get("priority")
+    if next_reason == "clean_accounting_epoch_forward_validation_required":
+        next_action_text = "Continue normal paper operation and collect the first clean exact lifecycle before any ML/MAE-MFE promotion."
+        next_priority = "normal"
+
+    requests = _i(provider.get("requests"))
+    classified = _i(provider.get("classified_terminal_outcomes"))
+    gap = _i(provider.get("in_flight_or_unclassified_requests"))
+    if not gap and requests > classified:
+        gap = requests - classified
 
     return {
         "status": payload.get("status"),
@@ -96,6 +153,9 @@ def compact_payload(payload: Dict[str, Any], core: Any = None) -> Dict[str, Any]
             "historical_recovery_decision": epoch.get("historical_recovery_decision"),
             "historical_evidence_archived": epoch.get("historical_evidence_archived"),
             "validation_hold": epoch.get("validation_hold"),
+            "validation_release_status": release.get("status"),
+            "validation_released": release.get("released"),
+            "validation_released_local": release.get("released_local"),
         },
         "runner": {
             "status": runner.get("status"),
@@ -108,6 +168,7 @@ def compact_payload(payload: Dict[str, Any], core: Any = None) -> Dict[str, Any]
             "halted": risk.get("halted"),
             "halt_reason": risk.get("halt_reason"),
             "self_defense_active": risk.get("self_defense_active"),
+            "self_defense_reason": risk.get("self_defense_reason"),
             "net_daily_loss_pct": risk.get("net_daily_loss_pct", risk.get("realized_loss_pct")),
             "intraday_drawdown_pct": risk.get("intraday_drawdown_pct"),
         },
@@ -120,6 +181,8 @@ def compact_payload(payload: Dict[str, Any], core: Any = None) -> Dict[str, Any]
             "status": accounting.get("status"),
             "coverage_complete": accounting.get("coverage_complete"),
             "baseline_type": rebuilt.get("baseline_type"),
+            "supports_long_short": bidirectional.get("supports_long_short"),
+            "accounting_model": "bidirectional_margin_v1" if bidirectional.get("supports_long_short") else None,
             "ignored_trade_rows": rebuilt.get("ignored_trade_rows"),
             "coverage_issue_count": rebuilt.get("coverage_issue_count"),
             "economic_issue_count": economics.get("economic_issue_count"),
@@ -150,12 +213,15 @@ def compact_payload(payload: Dict[str, Any], core: Any = None) -> Dict[str, Any]
             "authoritative_for_new_executions": ledger.get("authoritative_for_new_executions"),
         },
         "market_data": {
-            "status": integrity.get("status"),
-            "requests": provider.get("requests"),
-            "classified_terminal_outcomes": provider.get("classified_terminal_outcomes"),
+            "status": _market_data_status(integrity, provider),
+            "requests": requests,
+            "classified_terminal_outcomes": classified,
+            "in_flight_or_unclassified_requests": gap,
+            "accounting_complete_at_snapshot": provider.get("accounting_complete_at_snapshot"),
             "provider_circuit_open": integrity.get("provider_circuit_open"),
         },
         "ml_evidence": {
+            "status": "pass" if forward.get("promotion_evidence_eligible") else "warn",
             "promotion_evidence_eligible": forward.get("promotion_evidence_eligible"),
             "promotion_block_reason": forward.get("promotion_block_reason"),
             "valid_exact_lifecycle_rows": forward.get("valid_exact_lifecycle_rows_observed"),
@@ -164,9 +230,9 @@ def compact_payload(payload: Dict[str, Any], core: Any = None) -> Dict[str, Any]
         },
         "next_action": {
             "status": next_action.get("status"),
-            "priority": next_action.get("priority"),
-            "reason": next_action.get("reason"),
-            "action": next_action.get("action"),
+            "priority": next_priority,
+            "reason": next_reason,
+            "action": next_action_text,
         },
         "full_audit": "https://web-production-e1796.up.railway.app/paper/daily-audit?full=1",
         "compactor_version": VERSION,

--- a/paper_bidirectional_accounting_guard.py
+++ b/paper_bidirectional_accounting_guard.py
@@ -1,0 +1,453 @@
+"""Bidirectional long/short accounting for the clean Stable Paper epoch.
+
+The legacy reconciliation path was long-lot only.  This module makes the
+paper-accounting source of truth understand the runtime's actual execution
+semantics:
+
+- long entry: reserve cash equal to entry notional
+- long exit/partial exit: release matched sale proceeds
+- short entry: reserve cash equal to short margin/notional
+- short exit/partial exit: release matched margin plus realized P&L
+
+Only quantities proven by reconstructed lots can be closed.  Unmatched exits
+remain coverage failures and never create synthetic cash.
+
+Paper-only accounting/reconciliation.  No signal, threshold, sizing, order,
+live-authority, or ML-authority behavior is changed.
+"""
+from __future__ import annotations
+
+import copy
+import datetime as dt
+from typing import Any, Dict, List, Tuple
+
+VERSION = "paper-bidirectional-accounting-2026-08-10-v1"
+_APPLIED = False
+_REGISTERED_APP_IDS: set[int] = set()
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or isinstance(value, bool):
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def _now(core: Any = None) -> str:
+    try:
+        return str(core.local_ts_text())
+    except Exception:
+        return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _today(core: Any = None) -> str:
+    return _now(core)[:10]
+
+
+def _portfolio(core: Any) -> Dict[str, Any]:
+    pf = getattr(core, "portfolio", None) if core is not None else None
+    return pf if isinstance(pf, dict) else {}
+
+
+def _initial_cash(accounting: Any, pf: Dict[str, Any]) -> float:
+    try:
+        return float(accounting._initial_cash(pf))
+    except Exception:
+        for key in ("initial_cash", "starting_cash", "starting_equity", "initial_equity"):
+            value = _f(pf.get(key), 0.0)
+            if value > 0:
+                return value
+        history = _l(pf.get("history"))
+        return _f(history[0], 10000.0) if history else 10000.0
+
+
+def _event_fields(row: Dict[str, Any]) -> Tuple[str, str, str, float, float, str]:
+    symbol = str(row.get("symbol") or row.get("ticker") or "").upper().strip()
+    action = str(row.get("action") or "").lower().strip()
+    side = str(row.get("side") or row.get("direction") or "").lower().strip()
+    qty = _f(row.get("qty", row.get("shares", row.get("quantity"))), 0.0)
+    price = _f(row.get("price", row.get("fill_price", row.get("entry_price", row.get("exit_price")))), 0.0)
+    timestamp = str(row.get("timestamp") or row.get("time") or row.get("ts_local") or row.get("created_at") or "")
+
+    if side in {"buy", "b", "open_long"}:
+        side = "long"
+    elif side in {"sell", "s", "close_long"} and not action:
+        side = "long"
+    if side not in {"long", "short"}:
+        side = "long"
+
+    if action in {"entry", "buy", "open", "open_long", "open_short"}:
+        event = "entry"
+    elif action in {"exit", "partial_exit", "sell", "close", "close_long", "close_short", "cover"}:
+        event = "exit"
+    elif str(row.get("side") or "").lower().strip() in {"buy", "b"}:
+        event, side = "entry", "long"
+    elif str(row.get("side") or "").lower().strip() in {"sell", "s"}:
+        event, side = "exit", "long"
+    else:
+        event = action
+    return symbol, event, side, qty, price, timestamp
+
+
+def _clean_zero_trade_baseline(pf: Dict[str, Any], core: Any, accounting: Any) -> Dict[str, Any] | None:
+    try:
+        import paper_ledger_matched_exit_guard as matched
+        fn = getattr(matched, "_clean_epoch_zero_trade_baseline", None)
+        if callable(fn):
+            return fn(pf, core, accounting)
+    except Exception:
+        pass
+    return None
+
+
+def analyze_ledger(pf: Dict[str, Any], core: Any = None) -> Dict[str, Any]:
+    import paper_accounting_integrity_guard as accounting
+
+    trades = _l(pf.get("trades"))
+    positions = _d(pf.get("positions"))
+    if not trades:
+        clean = _clean_zero_trade_baseline(pf, core, accounting)
+        if clean is not None:
+            clean = dict(clean)
+            clean["accounting_model"] = "bidirectional_margin_v1"
+            clean["supports_long_short"] = True
+            return clean
+        return {
+            "status": "unavailable",
+            "reason": "trade_ledger_empty",
+            "coverage_complete": False,
+            "parsed_trade_rows": 0,
+            "ignored_trade_rows": 0,
+            "coverage_issues": [],
+            "coverage_issue_count": 0,
+            "economic_issues": [],
+            "economic_issue_count": 0,
+            "accounting_model": "bidirectional_margin_v1",
+            "supports_long_short": True,
+        }
+
+    initial = _initial_cash(accounting, pf)
+    cash = initial
+    books: Dict[str, Dict[str, List[List[float]]]] = {}
+    parsed = 0
+    ignored = 0
+    coverage_issues: List[Dict[str, Any]] = []
+    economic_issues: List[Dict[str, Any]] = []
+    realized_total = 0.0
+    realized_today = 0.0
+    today = _today(core)
+
+    for index, raw in enumerate(trades):
+        if not isinstance(raw, dict):
+            ignored += 1
+            coverage_issues.append({"trade_index": index, "reason": "non_dict_trade_row"})
+            continue
+
+        symbol, event, side, qty, price, timestamp = _event_fields(raw)
+        if not symbol or event not in {"entry", "exit"} or side not in {"long", "short"} or qty <= 0 or price <= 0:
+            ignored += 1
+            coverage_issues.append({
+                "trade_index": index,
+                "reason": "unsupported_or_incomplete_trade_row",
+                "symbol": symbol,
+                "event": event,
+                "action": raw.get("action"),
+                "side": raw.get("side"),
+                "qty": qty,
+                "price": price,
+                "timestamp": timestamp,
+            })
+            continue
+
+        parsed += 1
+        side_books = books.setdefault(symbol, {"long": [], "short": []})
+        book = side_books[side]
+
+        if event == "entry":
+            notional = qty * price
+            tolerance = max(2.0, abs(cash) * 0.0025)
+            if notional > cash + tolerance:
+                economic_issues.append({
+                    "trade_index": index,
+                    "reason": "entry_exceeds_available_cash",
+                    "symbol": symbol,
+                    "side": side,
+                    "timestamp": timestamp,
+                    "cash_before": round(cash, 6),
+                    "entry_notional": round(notional, 6),
+                    "overspend": round(notional - cash, 6),
+                })
+            cash -= notional
+            # [remaining qty, entry price].  For shorts, entry notional is also
+            # the reserved margin released pro-rata on exits.
+            book.append([qty, price])
+            if cash < -max(2.0, initial * 0.0025):
+                economic_issues.append({
+                    "trade_index": index,
+                    "reason": "negative_cash_after_entry",
+                    "symbol": symbol,
+                    "side": side,
+                    "timestamp": timestamp,
+                    "cash_after": round(cash, 6),
+                })
+            continue
+
+        remaining = qty
+        matched_qty = 0.0
+        cash_release = 0.0
+        trade_realized = 0.0
+        while remaining > 1e-9 and book:
+            lot_qty, lot_price = book[0]
+            used = min(remaining, lot_qty)
+            matched_qty += used
+            if side == "long":
+                cash_release += used * price
+                trade_realized += (price - lot_price) * used
+            else:
+                pnl = (lot_price - price) * used
+                trade_realized += pnl
+                cash_release += (lot_price * used) + pnl
+            lot_qty -= used
+            remaining -= used
+            if lot_qty <= 1e-9:
+                book.pop(0)
+            else:
+                book[0][0] = lot_qty
+
+        cash += cash_release
+        realized_total += trade_realized
+        if timestamp[:10] == today:
+            realized_today += trade_realized
+
+        if remaining > 1e-6:
+            ignored += 1
+            coverage_issues.append({
+                "trade_index": index,
+                "reason": "exit_exceeds_reconstructed_position",
+                "symbol": symbol,
+                "side": side,
+                "timestamp": timestamp,
+                "requested_qty": round(qty, 9),
+                "matched_qty": round(matched_qty, 9),
+                "unmatched_qty": round(remaining, 9),
+                "price": round(price, 6),
+                "action": raw.get("action"),
+            })
+
+    open_rows: Dict[str, Dict[str, Any]] = {}
+    position_value_total = 0.0
+    unrealized = 0.0
+    for symbol, side_books in books.items():
+        open_sides = [side for side in ("long", "short") if sum(row[0] for row in side_books[side]) > 1e-9]
+        if len(open_sides) > 1:
+            economic_issues.append({"reason": "opposing_open_books_same_symbol", "symbol": symbol, "open_sides": open_sides})
+        for side in open_sides:
+            book = side_books[side]
+            qty = sum(row[0] for row in book)
+            basis = sum(row[0] * row[1] for row in book)
+            entry = basis / qty if qty else 0.0
+            pos = _d(positions.get(symbol))
+            last = _f(pos.get("last_price", pos.get("mark", pos.get("price"))), entry)
+            if last <= 0:
+                last = entry
+            if side == "short":
+                upnl = (entry - last) * qty
+                value = basis + upnl
+                pnl_pct = ((entry - last) / entry * 100.0) if entry else 0.0
+            else:
+                upnl = (last - entry) * qty
+                value = qty * last
+                pnl_pct = ((last - entry) / entry * 100.0) if entry else 0.0
+            position_value_total += value
+            unrealized += upnl
+            open_rows[symbol] = {
+                "side": side,
+                "qty": qty,
+                "entry_price": entry,
+                "last_price": last,
+                "market_value": value,
+                "position_value": value,
+                "cost_basis": basis,
+                "margin": basis if side == "short" else 0.0,
+                "unrealized_pnl": upnl,
+                "unrealized_pnl_pct": pnl_pct,
+            }
+
+    coverage_complete = parsed > 0 and ignored == 0 and not coverage_issues
+    equity = cash + position_value_total
+    return {
+        "status": "ok" if coverage_complete else "partial",
+        "coverage_complete": coverage_complete,
+        "parsed_trade_rows": parsed,
+        "ignored_trade_rows": ignored,
+        "initial_cash": round(initial, 6),
+        "cash": round(cash, 6),
+        "equity": round(equity, 6),
+        "market_value": round(position_value_total, 6),
+        "realized_total": round(realized_total, 6),
+        "realized_today": round(realized_today, 6),
+        "unrealized_pnl": round(unrealized, 6),
+        "open_positions": open_rows,
+        "coverage_issues": coverage_issues[:50],
+        "coverage_issue_count": len(coverage_issues),
+        "economic_issues": economic_issues[:50],
+        "economic_issue_count": len(economic_issues),
+        "accounting_model": "bidirectional_margin_v1",
+        "supports_long_short": True,
+    }
+
+
+def _economic_status(core: Any = None) -> Dict[str, Any]:
+    rebuilt = analyze_ledger(_portfolio(core), core)
+    coverage_complete = bool(rebuilt.get("coverage_complete"))
+    issues = _l(rebuilt.get("economic_issues")) + _l(rebuilt.get("coverage_issues"))
+    ok = coverage_complete and not issues
+    return {
+        "status": "ok" if ok else "fail",
+        "overall": "pass" if ok else "fail",
+        "type": "paper_ledger_economic_integrity_status",
+        "version": VERSION,
+        "generated_local": _now(core),
+        "cash_only_assumption": True,
+        "short_margin_model": "entry_notional_reserved_and_released_with_pnl",
+        "supports_long_short": True,
+        "parsed_trade_rows": int(rebuilt.get("parsed_trade_rows") or 0),
+        "ignored_trade_rows": int(rebuilt.get("ignored_trade_rows") or 0),
+        "coverage_complete": coverage_complete,
+        "selected_initial_cash": rebuilt.get("initial_cash"),
+        "reconstructed_cash_after_ledger": rebuilt.get("cash"),
+        "economic_issue_count": len(issues),
+        "economic_issues": issues[:20],
+        "promotion_evidence_eligible": bool(ok),
+        "authority": {
+            "reporting_only": True,
+            "repairs_state": False,
+            "places_orders": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def _repair_position_metadata(core: Any, rebuilt: Dict[str, Any], persist: bool) -> bool:
+    state = _portfolio(core)
+    positions = _d(state.get("positions"))
+    changed = False
+    for symbol, expected in _d(rebuilt.get("open_positions")).items():
+        pos = _d(positions.get(symbol))
+        if not pos:
+            continue
+        side = str(expected.get("side") or "long")
+        if str(pos.get("side") or "long") != side:
+            pos["side"] = side
+            changed = True
+        if side == "short":
+            margin = _f(expected.get("margin"))
+            if abs(_f(pos.get("margin")) - margin) > 0.01:
+                pos["margin"] = round(margin, 6)
+                changed = True
+        positions[symbol] = pos
+    if changed:
+        state["positions"] = positions
+        if persist:
+            save = getattr(core, "save_state", None)
+            if callable(save):
+                try:
+                    save(state)
+                except TypeError:
+                    save()
+    return changed
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _APPLIED
+    try:
+        import paper_accounting_integrity_guard as accounting
+        import paper_ledger_economic_integrity as economics
+        import paper_ledger_matched_exit_guard as matched
+    except Exception as exc:
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": f"{type(exc).__name__}: {exc}"}
+
+    accounting.reconstruct_from_ledger = analyze_ledger
+    matched.analyze_ledger = analyze_ledger
+    economics.status_payload = _economic_status
+    economics.apply = _economic_status
+
+    current_reconcile = getattr(accounting, "reconcile", None)
+    if callable(current_reconcile) and getattr(current_reconcile, "_bidirectional_accounting_version", None) != VERSION:
+        prior = getattr(current_reconcile, "_bidirectional_accounting_prior", current_reconcile)
+
+        def wrapped_reconcile(runtime: Any = None, *, persist: bool = True):
+            result = prior(runtime, persist=persist)
+            active = runtime or core
+            if active is not None:
+                rebuilt = analyze_ledger(_portfolio(active), active)
+                if rebuilt.get("coverage_complete"):
+                    changed = _repair_position_metadata(active, rebuilt, persist)
+                    if changed and isinstance(result, dict):
+                        result = copy.deepcopy(result)
+                        result["position_side_metadata_repaired"] = True
+                        result["reconstructed"] = rebuilt
+            return result
+
+        wrapped_reconcile._bidirectional_accounting_version = VERSION  # type: ignore[attr-defined]
+        wrapped_reconcile._bidirectional_accounting_prior = prior  # type: ignore[attr-defined]
+        accounting.reconcile = wrapped_reconcile
+
+    _APPLIED = True
+    return status_payload(core)
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    rebuilt = analyze_ledger(_portfolio(core), core) if core is not None else {}
+    return {
+        "status": "ok" if _APPLIED else "pending",
+        "overall": "pass" if _APPLIED else "warn",
+        "type": "paper_bidirectional_accounting_status",
+        "version": VERSION,
+        "applied": _APPLIED,
+        "supports_long_short": True,
+        "short_margin_model": "entry_notional_reserved_and_released_with_pnl",
+        "coverage_complete": bool(rebuilt.get("coverage_complete")),
+        "baseline_type": rebuilt.get("baseline_type"),
+        "parsed_trade_rows": int(rebuilt.get("parsed_trade_rows") or 0),
+        "ignored_trade_rows": int(rebuilt.get("ignored_trade_rows") or 0),
+        "coverage_issue_count": int(rebuilt.get("coverage_issue_count") or 0),
+        "economic_issue_count": int(rebuilt.get("economic_issue_count") or 0),
+        "reconstructed_cash": rebuilt.get("cash"),
+        "reconstructed_equity": rebuilt.get("equity"),
+        "authority": {
+            "paper_accounting_reconstruction_only": True,
+            "places_orders": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    result = apply(core)
+    if flask_app is None:
+        return result
+    if id(flask_app) not in _REGISTERED_APP_IDS:
+        from flask import jsonify
+        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+        path = "/paper/bidirectional-accounting-status"
+        if path not in existing:
+            flask_app.add_url_rule(path, "paper_bidirectional_accounting_status", lambda: jsonify(status_payload(core)))
+        _REGISTERED_APP_IDS.add(id(flask_app))
+    return status_payload(core)

--- a/paper_execution_timestamp_semantics.py
+++ b/paper_execution_timestamp_semantics.py
@@ -1,0 +1,138 @@
+"""Normalize execution timestamp and side semantics for Stable Paper accounting.
+
+Canonical ``record_trade`` rows store ``time`` as epoch seconds, while historical
+rows may carry ISO/local timestamp strings.  The bidirectional reconciler needs a
+calendar-day string so realized P&L for the current session is reconstructed
+correctly.  This compatibility shim also refuses to silently coerce an unknown
+canonical side to ``long``.
+
+Paper-accounting compatibility only.  No strategy, threshold, sizing, order,
+risk-limit, live-authority, or ML-authority behavior is changed.
+"""
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Dict, Tuple
+
+VERSION = "paper-execution-timestamp-semantics-2026-08-10-v1"
+_APPLIED = False
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or isinstance(value, bool):
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def _timestamp_text(row: Dict[str, Any]) -> str:
+    raw = row.get("timestamp")
+    if raw in (None, ""):
+        raw = row.get("time")
+    if raw in (None, ""):
+        raw = row.get("ts_local")
+    if raw in (None, ""):
+        raw = row.get("created_at")
+    if raw in (None, ""):
+        return ""
+
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        try:
+            return dt.datetime.fromtimestamp(float(raw), tz=dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+        except Exception:
+            return str(raw)
+
+    text = str(raw).strip()
+    if text:
+        try:
+            numeric = float(text)
+            # Epoch seconds are currently ~1.8e9.  Bound the conversion so a
+            # YYYYMMDD-like identifier is not mistaken for a timestamp.
+            if 946684800 <= numeric <= 4102444800:
+                return dt.datetime.fromtimestamp(numeric, tz=dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+        except Exception:
+            pass
+    return text
+
+
+def normalized_event_fields(row: Dict[str, Any]) -> Tuple[str, str, str, float, float, str]:
+    symbol = str(row.get("symbol") or row.get("ticker") or "").upper().strip()
+    action = str(row.get("action") or "").lower().strip()
+    raw_side = str(row.get("side") or row.get("direction") or "").lower().strip()
+    qty = _f(row.get("qty", row.get("shares", row.get("quantity"))), 0.0)
+    price = _f(row.get("price", row.get("fill_price", row.get("entry_price", row.get("exit_price")))), 0.0)
+    timestamp = _timestamp_text(row)
+
+    long_aliases = {"long", "buy", "b", "open_long", "close_long", "sell", "s"}
+    short_aliases = {"short", "open_short", "close_short", "cover"}
+
+    if raw_side in short_aliases:
+        side = "short"
+    elif raw_side in long_aliases:
+        side = "long"
+    elif action in {"open_short", "close_short", "cover"}:
+        side = "short"
+    elif action in {"open_long", "close_long"}:
+        side = "long"
+    else:
+        # Canonical entry/exit rows are required to declare long/short.  Leaving
+        # this empty makes the reconciler flag incomplete coverage instead of
+        # fabricating a long lot.
+        side = ""
+
+    if action in {"entry", "buy", "open", "open_long", "open_short"}:
+        event = "entry"
+    elif action in {"exit", "partial_exit", "sell", "close", "close_long", "close_short", "cover"}:
+        event = "exit"
+    elif raw_side in {"buy", "b"}:
+        event, side = "entry", "long"
+    elif raw_side in {"sell", "s"}:
+        event, side = "exit", "long"
+    else:
+        event = action
+
+    return symbol, event, side, qty, price, timestamp
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _APPLIED
+    try:
+        import paper_bidirectional_accounting_guard as bidirectional
+    except Exception as exc:
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": f"{type(exc).__name__}: {exc}"}
+
+    bidirectional._event_fields = normalized_event_fields
+    _APPLIED = True
+    return status_payload(core)
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    return {
+        "status": "ok" if _APPLIED else "pending",
+        "overall": "pass" if _APPLIED else "warn",
+        "type": "paper_execution_timestamp_semantics_status",
+        "version": VERSION,
+        "applied": _APPLIED,
+        "epoch_seconds_normalized": True,
+        "unknown_side_fails_coverage": True,
+        "authority": {
+            "paper_accounting_compatibility_only": True,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "places_orders": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    return apply(core)
+
+
+try:
+    apply(None)
+except Exception:
+    pass

--- a/post_recovery_evidence_epoch_guard.py
+++ b/post_recovery_evidence_epoch_guard.py
@@ -1,15 +1,20 @@
 """Block MAE/MFE promotion until new clean lifecycle evidence exists.
 
 Supports both the historical accounting-recovery epoch and the deliberate clean
-accounting epoch.  Old contaminated/recovery-era rows can never satisfy a clean
+accounting epoch. Old contaminated/recovery-era rows can never satisfy a clean
 epoch promotion gate.
+
+A clean zero-trade epoch with no forward lifecycle rows is an expected research
+readiness state, not an operational market-data failure. It therefore remains a
+hard promotion block while surfacing as an operational warning unless another
+integrity defect already makes the section fail.
 """
 from __future__ import annotations
 
 import functools
 from typing import Any, Dict
 
-VERSION = "post-recovery-evidence-epoch-guard-2026-08-10-v2-clean-epoch"
+VERSION = "post-recovery-evidence-epoch-guard-2026-08-10-v3-clean-warning"
 _APPLIED = False
 
 
@@ -93,12 +98,24 @@ def apply(core: Any = None) -> Dict[str, Any]:
             if reason not in reasons:
                 reasons.insert(0, reason)
             section["reasons"] = reasons
-            section["status"] = "fail"
+
+            # Historical recovery uncertainty remains an operational failure.
+            # A deliberately established clean epoch is different: the account is
+            # operationally valid, but research promotion must wait for a forward
+            # exact lifecycle. Preserve any unrelated existing failure.
+            if gate.get("source") == "clean_accounting_epoch":
+                if str(section.get("status") or "pass").lower() != "fail":
+                    section["status"] = "warn"
+                section["promotion_gate_operational_severity"] = "warn"
+            else:
+                section["status"] = "fail"
+                section["promotion_gate_operational_severity"] = "fail"
 
             forward["promotion_evidence_eligible"] = False
             forward["promotion_block_reason"] = reason
             forward["post_recovery_valid_exact_lifecycle_rows"] = post_epoch_valid
             forward["post_epoch_valid_exact_lifecycle_rows"] = post_epoch_valid
+            forward["promotion_gate_blocks_execution"] = False
             section["forward_validation"] = forward
 
             mae = _d(section.get("mae_mfe_integrity"))
@@ -106,11 +123,13 @@ def apply(core: Any = None) -> Dict[str, Any]:
             mae["promotion_block_reason"] = reason
             mae["post_recovery_training_eligible_rows"] = post_epoch_valid
             mae["post_epoch_training_eligible_rows"] = post_epoch_valid
+            mae["promotion_gate_blocks_execution"] = False
             section["mae_mfe_integrity"] = mae
         elif required and eligible:
             forward["promotion_evidence_eligible"] = True
             forward["post_recovery_valid_exact_lifecycle_rows"] = post_epoch_valid
             forward["post_epoch_valid_exact_lifecycle_rows"] = post_epoch_valid
+            forward["promotion_gate_blocks_execution"] = False
             section["forward_validation"] = forward
 
         return section
@@ -136,6 +155,7 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "recovery_epoch_valid_path_rows_baseline": int(gate.get("baseline") or 0),
         "post_recovery_validation_required": bool(gate.get("required", False)),
         "promotion_block_reason": gate.get("reason") if gate.get("required") else None,
+        "clean_epoch_operational_severity": "warn" if gate.get("source") == "clean_accounting_epoch" and gate.get("required") else None,
         "authority": {
             "reporting_and_promotion_gate_only": True,
             "places_orders": False,

--- a/test_stable_paper_post_cutover_release.py
+++ b/test_stable_paper_post_cutover_release.py
@@ -1,0 +1,124 @@
+import datetime as dt
+import types
+
+import administrative_halt_classification_guard as admin_guard
+import clean_epoch_validation_release as release
+import paper_bidirectional_accounting_guard as bidirectional
+import paper_execution_timestamp_semantics as timestamp_semantics
+
+
+def _core(state=None):
+    state = state or {}
+    return types.SimpleNamespace(
+        portfolio=state,
+        local_ts_text=lambda *args, **kwargs: "2026-08-10 13:45:00 CDT",
+        save_state=lambda *args, **kwargs: None,
+    )
+
+
+def test_epoch_seconds_are_normalized_to_calendar_timestamp():
+    epoch = dt.datetime(2026, 8, 10, 18, 30, tzinfo=dt.timezone.utc).timestamp()
+    row = {
+        "action": "exit",
+        "symbol": "AMD",
+        "side": "long",
+        "shares": 2,
+        "price": 150,
+        "time": epoch,
+    }
+    symbol, event, side, qty, price, timestamp = timestamp_semantics.normalized_event_fields(row)
+    assert symbol == "AMD"
+    assert event == "exit"
+    assert side == "long"
+    assert qty == 2
+    assert price == 150
+    assert timestamp.startswith("2026-08-10 ")
+
+
+def test_unknown_canonical_side_fails_closed():
+    row = {
+        "action": "entry",
+        "symbol": "AMD",
+        "side": "mystery",
+        "shares": 1,
+        "price": 100,
+        "timestamp": "2026-08-10 13:00:00",
+    }
+    _, event, side, _, _, _ = timestamp_semantics.normalized_event_fields(row)
+    assert event == "entry"
+    assert side == ""
+
+
+def test_bidirectional_accounting_reconstructs_long_and_short_round_trips(monkeypatch):
+    # Make the reconciler use the normalized Stable Paper semantics directly.
+    monkeypatch.setattr(bidirectional, "_event_fields", timestamp_semantics.normalized_event_fields)
+    epoch = dt.datetime(2026, 8, 10, 18, 30, tzinfo=dt.timezone.utc).timestamp()
+    state = {
+        "initial_cash": 10000.0,
+        "cash": 10200.0,
+        "equity": 10200.0,
+        "positions": {},
+        "trades": [
+            {"action": "entry", "symbol": "AMD", "side": "long", "shares": 10, "price": 100, "time": epoch},
+            {"action": "exit", "symbol": "AMD", "side": "long", "shares": 10, "price": 110, "time": epoch},
+            {"action": "entry", "symbol": "CRWD", "side": "short", "shares": 5, "price": 200, "time": epoch},
+            {"action": "exit", "symbol": "CRWD", "side": "short", "shares": 5, "price": 180, "time": epoch},
+        ],
+    }
+    rebuilt = bidirectional.analyze_ledger(state, _core(state))
+    assert rebuilt["coverage_complete"] is True
+    assert rebuilt["ignored_trade_rows"] == 0
+    assert rebuilt["economic_issue_count"] == 0
+    assert rebuilt["cash"] == 10200.0
+    assert rebuilt["equity"] == 10200.0
+    assert rebuilt["realized_total"] == 200.0
+    assert rebuilt["realized_today"] == 200.0
+    assert rebuilt["open_positions"] == {}
+
+
+def test_administrative_hold_is_not_mislabeled_as_loss_self_defense():
+    state = {
+        "risk_controls": {
+            "halted": True,
+            "halt_reason": "clean accounting epoch validation hold",
+            "clean_epoch_validation_hold": True,
+            "daily_loss_pct": 0.0,
+            "daily_drawdown_pct": 0.0,
+            "intraday_drawdown_pct": 0.0,
+            "realized_loss_pct": 0.0,
+        },
+        "feedback_loop": {},
+    }
+    feedback = {
+        "self_defense_mode": True,
+        "block_new_entries": True,
+        "hard_halt": True,
+        "reasons": ["hard risk halt active"],
+    }
+    out = admin_guard._normalize(_core(state), feedback, True)
+    assert out["self_defense_mode"] is False
+    assert out["hard_halt"] is False
+    assert state["risk_controls"]["halted"] is True
+    assert state["risk_controls"]["halt_reason"] == "clean accounting epoch validation hold"
+    assert state["risk_controls"]["self_defense_active"] is False
+
+
+def test_release_module_never_clears_unrelated_risk_halt():
+    state = {
+        "accounting_epoch_id": release.TARGET_EPOCH_ID,
+        "paper_accounting_epoch": {
+            "id": release.TARGET_EPOCH_ID,
+            "clean_start": True,
+            "zero_trade_baseline": True,
+            "historical_evidence_archived": True,
+        },
+        "risk_controls": {
+            "halted": True,
+            "halt_reason": "performance risk hard intraday drawdown halt (2.50%)",
+            "clean_epoch_validation_hold": False,
+        },
+    }
+    out = release.apply(_core(state))
+    assert out["status"] != "released"
+    assert state["risk_controls"]["halted"] is True
+    assert state["risk_controls"]["halt_reason"].startswith("performance risk hard")


### PR DESCRIPTION
Post-clean-epoch Stable Paper release package. Paper runtime only.

Scope:
- add bidirectional long/short accounting reconstruction matching the runtime cash/margin semantics
- normalize epoch-second execution timestamps for realized-today accounting
- fail coverage on unknown execution side instead of silently assuming long
- distinguish the clean accounting validation hold from loss-driven self-defense
- clear only the exact clean-epoch administrative validation hold after re-verifying the deployed zero-trade baseline, archived history, canonical empty ledger, and accounting integrity
- keep any unrelated performance/risk halt untouched
- separate provider-health reporting from post-epoch ML/MAE-MFE evidence readiness in the compact daily audit
- add focused regression tests for the release-sensitive behaviors

No strategy rules, scanner thresholds, risk limits, sizing rules, order semantics, live authority, or ML execution authority are expanded by this PR.