### PR TITLE
Fix Stable Paper audit entry-count reporting

### DIFF
--- a/daily_audit_entry_count_bridge.py
+++ b/daily_audit_entry_count_bridge.py
@@ -1,0 +1,104 @@
+"""Reporting-only bridge for the compact Stable Paper daily audit.
+
+The scanner section can omit ``entries_count`` even when the latest auto-runner
+cycle persisted an ``entries`` list.  This bridge fills only that missing report
+field from ``portfolio.auto_runner.last_result.entries`` and clears the obsolete
+``entry_count_missing`` next-action when the fallback is available.
+
+It does not alter scanner decisions, signals, execution, sizing, risk controls,
+strategy thresholds, live authority, or ML authority.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+VERSION = "daily-audit-entry-count-bridge-2026-08-11-v1"
+_REGISTERED: set[int] = set()
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> list:
+    return value if isinstance(value, list) else []
+
+
+def _portfolio(core: Any) -> Dict[str, Any]:
+    state = getattr(core, "portfolio", None) if core is not None else None
+    return state if isinstance(state, dict) else {}
+
+
+def _latest_cycle_entry_count(core: Any) -> int | None:
+    state = _portfolio(core)
+    auto = _d(state.get("auto_runner"))
+    last = _d(auto.get("last_result"))
+    entries = last.get("entries")
+    if isinstance(entries, list):
+        return len(entries)
+    return None
+
+
+def patch_payload(payload: Dict[str, Any], core: Any = None) -> Dict[str, Any]:
+    sections = _d(payload.get("sections"))
+    scanner = _d(sections.get("05_scanner_signals_entries_rejections"))
+    if scanner.get("entries_count") is not None:
+        return payload
+
+    fallback = _latest_cycle_entry_count(core)
+    if fallback is None:
+        return payload
+
+    scanner["entries_count"] = fallback
+    scanner["entries_count_source"] = "auto_runner.last_result.entries"
+    sections["05_scanner_signals_entries_rejections"] = scanner
+
+    next_action = _d(sections.get("12_next_action"))
+    if next_action.get("reason") == "entry_count_missing":
+        next_action.update({
+            "status": "ok",
+            "priority": "normal",
+            "reason": "latest_cycle_entry_count_available",
+            "action": "Continue normal Stable Paper validation; latest-cycle entry count is available from the auto-runner result.",
+        })
+        sections["12_next_action"] = next_action
+
+    payload["sections"] = sections
+    return payload
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    return {
+        "status": "ok",
+        "overall": "pass",
+        "version": VERSION,
+        "reporting_only": True,
+        "latest_cycle_entry_count": _latest_cycle_entry_count(core),
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    if flask_app is None:
+        return {"status": "warn", "overall": "warn", "version": VERSION}
+    app_id = id(flask_app)
+    if app_id not in _REGISTERED:
+        from flask import request
+
+        @flask_app.after_request
+        def _fill_missing_entry_count(response):
+            try:
+                if request.path != "/paper/daily-audit" or request.args.get("full") == "1":
+                    return response
+                payload = response.get_json(silent=True)
+                if not isinstance(payload, dict):
+                    return response
+                patched = patch_payload(payload, core)
+                response.set_data(flask_app.json.dumps(patched))
+                response.content_type = "application/json"
+                response.content_length = len(response.get_data())
+            except Exception:
+                return response
+            return response
+
+        _REGISTERED.add(app_id)
+    return apply(core)

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,10 +10,13 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-10-v15-stable-paper-release-timestamp-safe"
+VERSION = "data-integrity-startup-bridge-2026-08-11-v16-entry-count-reporting"
 MODULES = (
     # Registered first so Flask executes its after_request handler last.
     "final_daily_audit_compactor",
+    # Reporting-only fallback for a scanner section that omits latest-cycle
+    # entries_count even though auto_runner.last_result.entries is available.
+    "daily_audit_entry_count_bridge",
     # Stable Core execution truth: durable append-only hash-chained events.
     "canonical_execution_ledger",
     "orla_hygiene_overlay",

--- a/test_daily_audit_entry_count_bridge.py
+++ b/test_daily_audit_entry_count_bridge.py
@@ -1,0 +1,69 @@
+import types
+
+import daily_audit_entry_count_bridge as bridge
+
+
+def _core(entries):
+    return types.SimpleNamespace(
+        portfolio={
+            "auto_runner": {
+                "last_result": {
+                    "entries": entries,
+                }
+            }
+        }
+    )
+
+
+def test_fills_missing_entry_count_from_latest_runner_cycle():
+    payload = {
+        "sections": {
+            "05_scanner_signals_entries_rejections": {
+                "signals_found": 38,
+                "entries_count": None,
+                "rejected_signals_count": 40,
+            },
+            "12_next_action": {
+                "status": "required",
+                "priority": "normal",
+                "reason": "entry_count_missing",
+                "action": "Compare scanner and decision-audit counts for the latest completed cycle.",
+            },
+        }
+    }
+    out = bridge.patch_payload(payload, _core([{"symbol": "CLSK"}]))
+    scanner = out["sections"]["05_scanner_signals_entries_rejections"]
+    assert scanner["entries_count"] == 1
+    assert scanner["entries_count_source"] == "auto_runner.last_result.entries"
+    assert out["sections"]["12_next_action"]["reason"] == "latest_cycle_entry_count_available"
+
+
+def test_preserves_explicit_scanner_entry_count():
+    payload = {
+        "sections": {
+            "05_scanner_signals_entries_rejections": {
+                "signals_found": 10,
+                "entries_count": 2,
+                "rejected_signals_count": 8,
+            },
+            "12_next_action": {
+                "reason": "entry_count_missing",
+            },
+        }
+    }
+    out = bridge.patch_payload(payload, _core([{"symbol": "A"}]))
+    assert out["sections"]["05_scanner_signals_entries_rejections"]["entries_count"] == 2
+    assert out["sections"]["12_next_action"]["reason"] == "entry_count_missing"
+
+
+def test_does_not_fabricate_count_when_runner_entries_missing():
+    core = types.SimpleNamespace(portfolio={"auto_runner": {"last_result": {}}})
+    payload = {
+        "sections": {
+            "05_scanner_signals_entries_rejections": {"entries_count": None},
+            "12_next_action": {"reason": "entry_count_missing"},
+        }
+    }
+    out = bridge.patch_payload(payload, core)
+    assert out["sections"]["05_scanner_signals_entries_rejections"]["entries_count"] is None
+    assert out["sections"]["12_next_action"]["reason"] == "entry_count_missing"


### PR DESCRIPTION
Reporting-only Stable Paper observability fix.

- fills missing scanner `entries_count` from persisted `auto_runner.last_result.entries` when available
- clears the obsolete `entry_count_missing` next-action only when that fallback is proven available
- preserves any explicit scanner-provided entry count
- fails closed and leaves the warning in place if no fallback exists
- adds focused regression tests

No scanner logic, signal selection, thresholds, sizing, risk limits, execution behavior, live authority, or ML authority are changed.