### PR TITLE
Fix surge deployment canonical accounting defect

### DIFF
--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-11-v16-entry-count-reporting"
+VERSION = "data-integrity-startup-bridge-2026-08-11-v17-surge-canonical-execution"
 MODULES = (
     # Registered first so Flask executes its after_request handler last.
     "final_daily_audit_compactor",
@@ -19,6 +19,10 @@ MODULES = (
     "daily_audit_entry_count_bridge",
     # Stable Core execution truth: durable append-only hash-chained events.
     "canonical_execution_ledger",
+    # Market-surge paper deployment previously bypassed record_trade and wrote
+    # custom state.trades rows. Route all future surge entries through the same
+    # canonical execution boundary before accounting/reconciliation is applied.
+    "market_surge_canonical_execution_bridge",
     "orla_hygiene_overlay",
     "paper_ledger_matched_exit_guard",
     "paper_trade_action_semantics_recovery",
@@ -34,7 +38,8 @@ MODULES = (
     # the administrative clean-epoch hold is eligible for release.
     "paper_bidirectional_accounting_guard",
     # Canonical record_trade rows use epoch-second timestamps. Normalize them for
-    # session P&L reconstruction and require explicit canonical long/short sides.
+    # session P&L reconstruction, require explicit canonical long/short sides,
+    # and recognize narrowly verified pre-bridge surge entry rows.
     "paper_execution_timestamp_semantics",
     # A validation hold is an administrative execution block, not a loss event.
     "administrative_halt_classification_guard",

--- a/market_surge_canonical_execution_bridge.py
+++ b/market_surge_canonical_execution_bridge.py
@@ -1,0 +1,122 @@
+"""Route market-surge paper entries through the canonical execution boundary.
+
+The original market-surge deployment path mutated paper positions/cash and then
+appended custom rows directly to ``state.trades``.  That bypassed ``core.record_trade``
+and therefore bypassed the canonical append-only execution ledger.
+
+This bridge replaces only that custom trade-row append function.  Position
+selection, sizing, surge eligibility, stop/trailing behavior, risk limits, and
+paper-only authority are unchanged.
+"""
+from __future__ import annotations
+
+import functools
+from typing import Any, Dict, List
+
+VERSION = "market-surge-canonical-execution-bridge-2026-08-11-v1"
+_APPLIED_CORE_IDS: set[int] = set()
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or isinstance(value, bool):
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    if core is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+
+    try:
+        import market_surge_deployment_mode as surge
+    except Exception as exc:
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": f"{type(exc).__name__}: {exc}"}
+
+    record_trade = getattr(core, "record_trade", None)
+    if not callable(record_trade):
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": "core.record_trade_missing"}
+
+    current = getattr(surge, "_append_trade_rows", None)
+    if not callable(current):
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": "market_surge._append_trade_rows_missing"}
+
+    if getattr(current, "_canonical_execution_bridge_version", None) == VERSION:
+        _APPLIED_CORE_IDS.add(id(core))
+        return status_payload(core)
+
+    prior = getattr(current, "_canonical_execution_bridge_prior", current)
+
+    @functools.wraps(prior)
+    def canonical_append_trade_rows(pf: Dict[str, Any], executed_entries: List[Dict[str, Any]], now_text: str) -> None:
+        if not executed_entries:
+            return
+
+        for row in executed_entries:
+            symbol = str(row.get("symbol") or "").upper().strip()
+            price = _f(row.get("entry"), 0.0)
+            shares = _f(row.get("shares"), 0.0)
+            if not symbol or price <= 0.0 or shares <= 0.0:
+                # Fail closed: do not fabricate a malformed execution row.  The
+                # surrounding surge executor will preserve its paper state and
+                # the normal integrity audit will surface the mismatch.
+                continue
+
+            extra = {
+                "source": "market_surge_deployment_mode",
+                "type": "paper_market_surge_deployment",
+                "original_execution_time": now_text,
+                "bucket": row.get("bucket"),
+                "selection_reason": row.get("selection_reason"),
+                "allocation_dollars": row.get("allocation_dollars"),
+                "allocation_pct": row.get("allocation_pct"),
+                "account_risk_pct": row.get("account_risk_pct"),
+                "planned_stop": row.get("planned_stop"),
+                "trade_authority": "paper_only_state_entry",
+                "live_trade_authority": "none",
+                "ml_authority": "shadow_only",
+                "market_surge_version": getattr(surge, "VERSION", None),
+                "canonical_surge_bridge_version": VERSION,
+            }
+            record_trade("entry", symbol, "long", price, shares, extra)
+
+    canonical_append_trade_rows._canonical_execution_bridge_version = VERSION  # type: ignore[attr-defined]
+    canonical_append_trade_rows._canonical_execution_bridge_prior = prior  # type: ignore[attr-defined]
+    surge._append_trade_rows = canonical_append_trade_rows
+    _APPLIED_CORE_IDS.add(id(core))
+    return status_payload(core)
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    try:
+        import market_surge_deployment_mode as surge
+        fn = getattr(surge, "_append_trade_rows", None)
+        hooked = getattr(fn, "_canonical_execution_bridge_version", None) == VERSION
+    except Exception:
+        hooked = False
+    return {
+        "status": "ok" if hooked else "pending",
+        "overall": "pass" if hooked else "warn",
+        "type": "market_surge_canonical_execution_bridge_status",
+        "version": VERSION,
+        "hook_applied": bool(hooked),
+        "routes_entries_through_record_trade": bool(hooked),
+        "authority": {
+            "paper_execution_boundary_only": True,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_sizing": False,
+            "changes_risk_limits": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    return apply(core)

--- a/paper_execution_timestamp_semantics.py
+++ b/paper_execution_timestamp_semantics.py
@@ -6,6 +6,13 @@ calendar-day string so realized P&L for the current session is reconstructed
 correctly.  This compatibility shim also refuses to silently coerce an unknown
 canonical side to ``long``.
 
+The pre-bridge market-surge paper path wrote verified entry rows directly to
+``state.trades`` using ``entry`` for the fill price, ``side=buy``, and explicit
+``source/type`` markers.  Those narrowly identified rows are accepted so the
+clean epoch can reconcile them without fabricating executions.  Future surge
+entries are routed through the canonical ``record_trade`` boundary by the surge
+canonical-execution bridge.
+
 Paper-accounting compatibility only.  No strategy, threshold, sizing, order,
 risk-limit, live-authority, or ML-authority behavior is changed.
 """
@@ -14,7 +21,7 @@ from __future__ import annotations
 import datetime as dt
 from typing import Any, Dict, Tuple
 
-VERSION = "paper-execution-timestamp-semantics-2026-08-10-v1"
+VERSION = "paper-execution-timestamp-semantics-2026-08-11-v2-surge-entry"
 _APPLIED = False
 
 
@@ -48,13 +55,25 @@ def _timestamp_text(row: Dict[str, Any]) -> str:
     if text:
         try:
             numeric = float(text)
-            # Epoch seconds are currently ~1.8e9.  Bound the conversion so a
-            # YYYYMMDD-like identifier is not mistaken for a timestamp.
             if 946684800 <= numeric <= 4102444800:
                 return dt.datetime.fromtimestamp(numeric, tz=dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
         except Exception:
             pass
     return text
+
+
+def _verified_legacy_surge_entry(row: Dict[str, Any]) -> bool:
+    source = str(row.get("source") or "").strip().lower()
+    row_type = str(row.get("type") or "").strip().lower()
+    side = str(row.get("side") or "").strip().lower()
+    return (
+        source == "market_surge_deployment_mode"
+        and row_type == "paper_market_surge_deployment"
+        and side in {"buy", "b", "long"}
+        and _f(row.get("entry"), 0.0) > 0.0
+        and _f(row.get("shares", row.get("qty", row.get("quantity"))), 0.0) > 0.0
+        and bool(str(row.get("symbol") or row.get("ticker") or "").strip())
+    )
 
 
 def normalized_event_fields(row: Dict[str, Any]) -> Tuple[str, str, str, float, float, str]:
@@ -64,6 +83,10 @@ def normalized_event_fields(row: Dict[str, Any]) -> Tuple[str, str, str, float, 
     qty = _f(row.get("qty", row.get("shares", row.get("quantity"))), 0.0)
     price = _f(row.get("price", row.get("fill_price", row.get("entry_price", row.get("exit_price")))), 0.0)
     timestamp = _timestamp_text(row)
+
+    legacy_surge_entry = _verified_legacy_surge_entry(row)
+    if price <= 0.0 and legacy_surge_entry:
+        price = _f(row.get("entry"), 0.0)
 
     long_aliases = {"long", "buy", "b", "open_long", "close_long", "sell", "s"}
     short_aliases = {"short", "open_short", "close_short", "cover"}
@@ -77,15 +100,14 @@ def normalized_event_fields(row: Dict[str, Any]) -> Tuple[str, str, str, float, 
     elif action in {"open_long", "close_long"}:
         side = "long"
     else:
-        # Canonical entry/exit rows are required to declare long/short.  Leaving
-        # this empty makes the reconciler flag incomplete coverage instead of
-        # fabricating a long lot.
         side = ""
 
     if action in {"entry", "buy", "open", "open_long", "open_short"}:
         event = "entry"
     elif action in {"exit", "partial_exit", "sell", "close", "close_long", "close_short", "cover"}:
         event = "exit"
+    elif legacy_surge_entry:
+        event, side = "entry", "long"
     elif raw_side in {"buy", "b"}:
         event, side = "entry", "long"
     elif raw_side in {"sell", "s"}:
@@ -117,6 +139,7 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "applied": _APPLIED,
         "epoch_seconds_normalized": True,
         "unknown_side_fails_coverage": True,
+        "verified_legacy_surge_entry_supported": True,
         "authority": {
             "paper_accounting_compatibility_only": True,
             "changes_strategy": False,

--- a/test_market_surge_canonical_execution_bridge.py
+++ b/test_market_surge_canonical_execution_bridge.py
@@ -1,0 +1,117 @@
+import types
+
+import market_surge_canonical_execution_bridge as bridge
+import market_surge_deployment_mode as surge
+import paper_bidirectional_accounting_guard as bidirectional
+import paper_execution_timestamp_semantics as semantics
+
+
+def test_verified_legacy_surge_entry_row_reconciles():
+    row = {
+        "time": "2026-08-11 14:45:00 CDT",
+        "symbol": "VST",
+        "side": "buy",
+        "type": "paper_market_surge_deployment",
+        "source": "market_surge_deployment_mode",
+        "entry": 150.0,
+        "shares": 10.0,
+    }
+    symbol, event, side, qty, price, timestamp = semantics.normalized_event_fields(row)
+    assert symbol == "VST"
+    assert event == "entry"
+    assert side == "long"
+    assert qty == 10.0
+    assert price == 150.0
+    assert timestamp.startswith("2026-08-11")
+
+
+def test_unmarked_row_does_not_use_entry_field_as_fill():
+    row = {
+        "time": "2026-08-11 14:45:00 CDT",
+        "symbol": "VST",
+        "side": "buy",
+        "entry": 150.0,
+        "shares": 10.0,
+    }
+    _, event, side, qty, price, _ = semantics.normalized_event_fields(row)
+    assert event == "entry"
+    assert side == "long"
+    assert qty == 10.0
+    assert price == 0.0
+
+
+def test_legacy_surge_entry_restores_open_position_accounting(monkeypatch):
+    monkeypatch.setattr(bidirectional, "_event_fields", semantics.normalized_event_fields)
+    state = {
+        "initial_cash": 10000.0,
+        "cash": 8500.0,
+        "equity": 10000.0,
+        "positions": {
+            "VST": {
+                "side": "long",
+                "shares": 10.0,
+                "entry": 150.0,
+                "last_price": 151.0,
+            }
+        },
+        "trades": [
+            {
+                "time": "2026-08-11 14:45:00 CDT",
+                "symbol": "VST",
+                "side": "buy",
+                "type": "paper_market_surge_deployment",
+                "source": "market_surge_deployment_mode",
+                "entry": 150.0,
+                "shares": 10.0,
+            }
+        ],
+    }
+    core = types.SimpleNamespace(
+        portfolio=state,
+        local_ts_text=lambda *args, **kwargs: "2026-08-11 15:00:00 CDT",
+    )
+    rebuilt = bidirectional.analyze_ledger(state, core)
+    assert rebuilt["coverage_complete"] is True
+    assert rebuilt["ignored_trade_rows"] == 0
+    assert rebuilt["economic_issue_count"] == 0
+    assert rebuilt["cash"] == 8500.0
+    assert rebuilt["equity"] == 10010.0
+    assert rebuilt["open_positions"]["VST"]["qty"] == 10.0
+
+
+def test_surge_bridge_routes_entries_through_record_trade(monkeypatch):
+    captured = []
+
+    def record_trade(action, symbol, side, px, shares, extra=None):
+        captured.append((action, symbol, side, px, shares, extra or {}))
+
+    core = types.SimpleNamespace(record_trade=record_trade, portfolio={})
+    original = surge._append_trade_rows
+    try:
+        result = bridge.apply(core)
+        assert result["status"] == "ok"
+        surge._append_trade_rows(
+            {},
+            [{
+                "symbol": "LRCX",
+                "entry": 120.0,
+                "shares": 5.0,
+                "allocation_dollars": 600.0,
+                "allocation_pct": 6.0,
+                "account_risk_pct": 0.2,
+                "bucket": "semi_leaders",
+                "selection_reason": "test",
+            }],
+            "2026-08-11 14:55:00 CDT",
+        )
+        assert len(captured) == 1
+        action, symbol, side, px, shares, extra = captured[0]
+        assert action == "entry"
+        assert symbol == "LRCX"
+        assert side == "long"
+        assert px == 120.0
+        assert shares == 5.0
+        assert extra["source"] == "market_surge_deployment_mode"
+        assert extra["type"] == "paper_market_surge_deployment"
+    finally:
+        surge._append_trade_rows = original


### PR DESCRIPTION
Correctness-only Stable Paper repair for the 2026-08-11 accounting failure.

Root cause: market_surge_deployment_mode mutated paper positions/cash and appended custom state.trades rows directly, bypassing core.record_trade and therefore the canonical execution ledger. Those rows also stored the fill under `entry` instead of canonical `price`, causing the bidirectional reconciler to ignore a legitimate clean-epoch surge entry.

Changes:
- add market_surge_canonical_execution_bridge so future surge entries go through core.record_trade and the canonical append-only ledger
- accept only narrowly verified pre-bridge surge rows (`source=market_surge_deployment_mode`, `type=paper_market_surge_deployment`) using their stored `entry` fill for reconciliation
- keep unknown/unmarked rows fail-closed
- wire the bridge before accounting modules at startup
- add focused regression tests for legacy surge-row reconciliation and canonical future execution routing

No strategy logic, signal thresholds, sizing rules, stop/trailing behavior, risk limits, live authority, or ML authority are changed. The current hard risk halt is intentionally preserved and is not cleared by this PR.