### PR TITLE
Fix Stable Paper accounting startup order

### DIFF
--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,22 +10,24 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-11-v17-surge-canonical-execution"
+VERSION = "data-integrity-startup-bridge-2026-08-11-v18-accounting-order"
 MODULES = (
     # Registered first so Flask executes its after_request handler last.
     "final_daily_audit_compactor",
     # Reporting-only fallback for a scanner section that omits latest-cycle
     # entries_count even though auto_runner.last_result.entries is available.
     "daily_audit_entry_count_bridge",
+    # Correctness-critical bootstrap.  It installs canonical execution routing
+    # plus final bidirectional/timestamp semantics before any reconciler runs.
+    "stable_paper_accounting_bootstrap",
     # Stable Core execution truth: durable append-only hash-chained events.
     "canonical_execution_ledger",
-    # Market-surge paper deployment previously bypassed record_trade and wrote
-    # custom state.trades rows. Route all future surge entries through the same
-    # canonical execution boundary before accounting/reconciliation is applied.
     "market_surge_canonical_execution_bridge",
     "orla_hygiene_overlay",
     "paper_ledger_matched_exit_guard",
     "paper_trade_action_semantics_recovery",
+    # Reconciliation now runs only after the bootstrap above has installed the
+    # final clean-epoch event semantics.
     "paper_accounting_integrity_guard",
     "paper_accounting_readonly_status",
     "paper_ledger_economic_integrity",
@@ -34,12 +36,7 @@ MODULES = (
     # Disable the unnecessary nested journal mirror while the cutover owns locks.
     "clean_accounting_epoch_lock_safety",
     "clean_accounting_epoch",
-    # Stable Paper must support the runtime's actual long/short lifecycle before
-    # the administrative clean-epoch hold is eligible for release.
     "paper_bidirectional_accounting_guard",
-    # Canonical record_trade rows use epoch-second timestamps. Normalize them for
-    # session P&L reconstruction, require explicit canonical long/short sides,
-    # and recognize narrowly verified pre-bridge surge entry rows.
     "paper_execution_timestamp_semantics",
     # A validation hold is an administrative execution block, not a loss event.
     "administrative_halt_classification_guard",

--- a/stable_paper_accounting_bootstrap.py
+++ b/stable_paper_accounting_bootstrap.py
@@ -1,0 +1,47 @@
+"""Install Stable Paper accounting semantics before any reconciliation executes.
+
+This bootstrap exists because the legacy integrity module historically ran before
+bidirectional/timestamp compatibility layers. The ordering is correctness-critical:
+execution routing and final event semantics must own the accounting boundary before
+any state reconciliation evaluates persisted clean-epoch rows.
+
+Paper-only accounting/bootstrap. No strategy, sizing, risk-limit, live, or ML
+authority changes.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+VERSION = "stable-paper-accounting-bootstrap-2026-08-11-v1"
+_APPLIED_CORE_IDS: set[int] = set()
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    if core is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+
+    results: Dict[str, Any] = {}
+    ordered = (
+        "canonical_execution_ledger",
+        "market_surge_canonical_execution_bridge",
+        "paper_bidirectional_accounting_guard",
+        "paper_execution_timestamp_semantics",
+    )
+    for name in ordered:
+        try:
+            module = __import__(name)
+            fn = getattr(module, "apply", None)
+            results[name] = fn(core) if callable(fn) else {"status": "no_apply"}
+        except Exception as exc:
+            results[name] = {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
+
+    failed = [name for name, row in results.items() if isinstance(row, dict) and row.get("status") == "error"]
+    if failed:
+        return {"status": "error", "overall": "fail", "version": VERSION, "failed_modules": failed, "modules": results}
+
+    _APPLIED_CORE_IDS.add(id(core))
+    return {"status": "ok", "overall": "pass", "version": VERSION, "ordered_before_reconcile": True, "modules": results}
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    return apply(core)

--- a/test_stable_paper_accounting_bootstrap.py
+++ b/test_stable_paper_accounting_bootstrap.py
@@ -1,0 +1,52 @@
+import types
+
+import paper_bidirectional_accounting_guard as bidirectional
+import paper_execution_timestamp_semantics as timestamp_semantics
+import stable_paper_accounting_bootstrap as bootstrap
+
+
+def _core(state):
+    recorded = []
+
+    def record_trade(action, symbol, side, px, shares, extra=None):
+        recorded.append((action, symbol, side, px, shares, extra or {}))
+
+    return types.SimpleNamespace(
+        portfolio=state,
+        local_ts_text=lambda *args, **kwargs: "2026-08-11 15:00:00 CDT",
+        save_state=lambda *args, **kwargs: None,
+        record_trade=record_trade,
+    )
+
+
+def test_bootstrap_installs_final_event_semantics_before_reconcile():
+    state = {
+        "initial_cash": 10000.0,
+        "cash": 8400.0,
+        "equity": 10000.0,
+        "positions": {
+            "VST": {"shares": 10.0, "entry": 160.0, "last_price": 160.0, "side": "long"},
+        },
+        "trades": [
+            {
+                "time": "2026-08-11 14:30:00 CDT",
+                "symbol": "VST",
+                "side": "buy",
+                "type": "paper_market_surge_deployment",
+                "source": "market_surge_deployment_mode",
+                "entry": 160.0,
+                "shares": 10.0,
+            }
+        ],
+    }
+    core = _core(state)
+    result = bootstrap.apply(core)
+    assert result["status"] == "ok"
+    assert bidirectional._event_fields is timestamp_semantics.normalized_event_fields
+
+    rebuilt = bidirectional.analyze_ledger(state, core)
+    assert rebuilt["coverage_complete"] is True
+    assert rebuilt["ignored_trade_rows"] == 0
+    assert rebuilt["cash"] == 8400.0
+    assert rebuilt["equity"] == 10000.0
+    assert rebuilt["open_positions"]["VST"]["qty"] == 10.0


### PR DESCRIPTION
Correctness-only follow-up to PR #33.

The post-deploy audit showed the persisted surge row was still being evaluated by an early legacy reconciliation pass before the final bidirectional/timestamp compatibility semantics were installed. This PR adds a deterministic Stable Paper accounting bootstrap that installs canonical execution routing plus final event semantics before any reconciliation module runs.

Changes:
- add stable_paper_accounting_bootstrap
- install canonical ledger, surge execution bridge, bidirectional accounting, and timestamp/surge-row semantics before paper_accounting_integrity_guard
- keep later module applications idempotent for route/status registration
- add regression coverage proving a verified pre-bridge surge entry reconstructs correctly after bootstrap ordering

No strategy, sizing, entry criteria, stop/trailing behavior, risk limits, live authority, ML authority, or current hard halt is changed or cleared.