### PR TITLE
Surface exact accounting defect in routine audit

### DIFF
--- a/daily_audit_accounting_issue_bridge.py
+++ b/daily_audit_accounting_issue_bridge.py
@@ -1,0 +1,94 @@
+"""Reporting-only bridge that exposes the first accounting integrity defect.
+
+Stable Paper normally keeps /paper/daily-audit compact. During an integrity
+failure, counts alone are insufficient to identify the exact persisted execution
+row. This bridge augments the compact payload with the first coverage issue,
+first economic issue, and reconstructed open-position symbols.
+
+No state repair, execution, strategy, sizing, risk, live, or ML authority is
+changed.
+"""
+from __future__ import annotations
+
+import functools
+from typing import Any, Dict
+
+VERSION = "daily-audit-accounting-issue-bridge-2026-08-11-v1"
+_APPLIED = False
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> list:
+    return value if isinstance(value, list) else []
+
+
+def _first_safe(value: Any) -> Any:
+    rows = _l(value)
+    return rows[0] if rows else None
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _APPLIED
+    try:
+        import final_daily_audit_compactor as compactor
+    except Exception as exc:
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": f"{type(exc).__name__}: {exc}"}
+
+    current = getattr(compactor, "compact_payload", None)
+    if not callable(current):
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": "compact_payload_missing"}
+
+    if getattr(current, "_accounting_issue_bridge_version", None) == VERSION:
+        _APPLIED = True
+        return status_payload()
+
+    prior = getattr(current, "_accounting_issue_bridge_prior", current)
+
+    @functools.wraps(prior)
+    def wrapped(payload: Dict[str, Any], runtime_core: Any = None) -> Dict[str, Any]:
+        out = prior(payload, runtime_core)
+        if not isinstance(out, dict):
+            return out
+
+        sections = _d(payload.get("sections"))
+        integrity = _d(sections.get("10b_market_data_and_path_integrity"))
+        accounting = _d(integrity.get("paper_accounting_integrity"))
+        rebuilt = _d(accounting.get("reconstructed"))
+        economics = _d(integrity.get("paper_ledger_economic_integrity"))
+
+        target = _d(out.get("accounting_integrity"))
+        target["first_coverage_issue"] = _first_safe(rebuilt.get("coverage_issues"))
+        target["first_economic_issue"] = _first_safe(
+            economics.get("economic_issues") or rebuilt.get("economic_issues")
+        )
+        target["reconstructed_open_positions"] = sorted(
+            str(symbol) for symbol in _d(rebuilt.get("open_positions")).keys()
+        )
+        target["parsed_trade_rows"] = rebuilt.get("parsed_trade_rows")
+        out["accounting_integrity"] = target
+        return out
+
+    wrapped._accounting_issue_bridge_version = VERSION  # type: ignore[attr-defined]
+    wrapped._accounting_issue_bridge_prior = prior  # type: ignore[attr-defined]
+    compactor.compact_payload = wrapped
+    _APPLIED = True
+    return status_payload()
+
+
+def status_payload() -> Dict[str, Any]:
+    return {
+        "status": "ok" if _APPLIED else "pending",
+        "overall": "pass" if _APPLIED else "warn",
+        "version": VERSION,
+        "reporting_only": True,
+        "surfaces_first_coverage_issue": True,
+        "surfaces_first_economic_issue": True,
+        "surfaces_reconstructed_open_positions": True,
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    return apply(core)

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,14 +10,17 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-11-v18-accounting-order"
+VERSION = "data-integrity-startup-bridge-2026-08-11-v19-accounting-issue-diagnostics"
 MODULES = (
     # Registered first so Flask executes its after_request handler last.
     "final_daily_audit_compactor",
     # Reporting-only fallback for a scanner section that omits latest-cycle
     # entries_count even though auto_runner.last_result.entries is available.
     "daily_audit_entry_count_bridge",
-    # Correctness-critical bootstrap.  It installs canonical execution routing
+    # Reporting-only integrity detail so one compact audit identifies the exact
+    # persisted row/reason when accounting coverage fails.
+    "daily_audit_accounting_issue_bridge",
+    # Correctness-critical bootstrap. It installs canonical execution routing
     # plus final bidirectional/timestamp semantics before any reconciler runs.
     "stable_paper_accounting_bootstrap",
     # Stable Core execution truth: durable append-only hash-chained events.

--- a/test_daily_audit_accounting_issue_bridge.py
+++ b/test_daily_audit_accounting_issue_bridge.py
@@ -1,0 +1,40 @@
+import types
+
+import daily_audit_accounting_issue_bridge as bridge
+import final_daily_audit_compactor as compactor
+
+
+def test_compact_audit_surfaces_first_accounting_issue(monkeypatch):
+    def base(payload, core=None):
+        return {"accounting_integrity": {"coverage_complete": False}}
+
+    monkeypatch.setattr(compactor, "compact_payload", base)
+    bridge._APPLIED = False
+    result = bridge.apply(types.SimpleNamespace())
+    assert result["status"] == "ok"
+
+    payload = {
+        "sections": {
+            "10b_market_data_and_path_integrity": {
+                "paper_accounting_integrity": {
+                    "reconstructed": {
+                        "parsed_trade_rows": 6,
+                        "coverage_issues": [{"trade_index": 6, "reason": "unsupported_or_incomplete_trade_row", "symbol": "VST"}],
+                        "economic_issues": [{"trade_index": 6, "reason": "entry_exceeds_available_cash", "symbol": "VST"}],
+                        "open_positions": {"LRCX": {"qty": 1}},
+                    }
+                },
+                "paper_ledger_economic_integrity": {
+                    "economic_issues": [{"trade_index": 6, "reason": "entry_exceeds_available_cash", "symbol": "VST"}]
+                },
+            }
+        }
+    }
+
+    out = compactor.compact_payload(payload, None)
+    acct = out["accounting_integrity"]
+    assert acct["parsed_trade_rows"] == 6
+    assert acct["first_coverage_issue"]["trade_index"] == 6
+    assert acct["first_coverage_issue"]["symbol"] == "VST"
+    assert acct["first_economic_issue"]["reason"] == "entry_exceeds_available_cash"
+    assert acct["reconstructed_open_positions"] == ["LRCX"]


### PR DESCRIPTION
Reporting-only Stable Paper observability change.

The current compact audit reports one ignored trade row and one economic issue but does not expose the exact row/reason. This PR keeps the one-link operator workflow and adds only:
- first_coverage_issue
- first_economic_issue
- reconstructed_open_positions
- parsed_trade_rows

No state repair, execution behavior, strategy, sizing, risk limits, live authority, or ML authority changes. The current hard halt remains untouched.