### PR TITLE
Fix stale absolute daily loss halt lifecycle

### DIFF
--- a/absolute_daily_halt_lifecycle_guard.py
+++ b/absolute_daily_halt_lifecycle_guard.py
@@ -1,0 +1,72 @@
+"""Allow a recovered absolute-daily-loss halt to follow the normal risk lifecycle.
+
+The 3% absolute daily equity-loss ceiling remains unchanged and authoritative.
+`performance_risk_calibration` already reasserts that halt whenever the current
+metric is at or above the ceiling, and clears managed performance halts only after
+the triggering metric has recovered below its threshold.
+
+The absolute-daily-loss reason was accidentally omitted from the helper that
+classifies managed performance halts. That made this one reason permanently
+sticky even after the current daily-loss metric recovered. This compatibility
+guard adds only that exact reason to the existing managed-halt classifier.
+
+It does not clear state directly, change thresholds, bypass self-defense, alter
+accounting, place orders, or change live/ML authority.
+"""
+from __future__ import annotations
+
+import functools
+from typing import Any, Dict
+
+VERSION = "absolute-daily-halt-lifecycle-2026-08-12-v1"
+_APPLIED = False
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _APPLIED
+    try:
+        import performance_risk_calibration as calibration
+    except Exception as exc:
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": f"{type(exc).__name__}: {exc}"}
+
+    current = getattr(calibration, "_managed_halt", None)
+    if not callable(current):
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": "managed_halt_classifier_missing"}
+    if getattr(current, "_absolute_daily_halt_lifecycle_version", None) == VERSION:
+        _APPLIED = True
+        return status_payload()
+
+    prior = getattr(current, "_absolute_daily_halt_lifecycle_prior", current)
+
+    @functools.wraps(prior)
+    def managed_halt(reason: Any) -> bool:
+        text = str(reason or "").strip().lower()
+        return bool(prior(reason) or text.startswith("absolute daily equity loss halt"))
+
+    managed_halt._absolute_daily_halt_lifecycle_version = VERSION  # type: ignore[attr-defined]
+    managed_halt._absolute_daily_halt_lifecycle_prior = prior  # type: ignore[attr-defined]
+    calibration._managed_halt = managed_halt
+    _APPLIED = True
+    return status_payload()
+
+
+def status_payload() -> Dict[str, Any]:
+    return {
+        "status": "ok" if _APPLIED else "pending",
+        "overall": "pass" if _APPLIED else "warn",
+        "type": "absolute_daily_halt_lifecycle_guard_status",
+        "version": VERSION,
+        "absolute_daily_loss_threshold_changed": False,
+        "direct_state_clear": False,
+        "authority": {
+            "risk_correctness_only": True,
+            "changes_risk_thresholds": False,
+            "places_orders": False,
+            "changes_strategy": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    return apply(core)

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-11-v19-accounting-issue-diagnostics"
+VERSION = "data-integrity-startup-bridge-2026-08-12-v20-absolute-daily-halt-lifecycle"
 MODULES = (
     # Registered first so Flask executes its after_request handler last.
     "final_daily_audit_compactor",
@@ -41,6 +41,10 @@ MODULES = (
     "clean_accounting_epoch",
     "paper_bidirectional_accounting_guard",
     "paper_execution_timestamp_semantics",
+    # The absolute 3% daily-loss ceiling remains unchanged. This guard only lets
+    # its stale persisted reason use the normal managed-halt recovery lifecycle
+    # after the current metric has recovered below the ceiling.
+    "absolute_daily_halt_lifecycle_guard",
     # A validation hold is an administrative execution block, not a loss event.
     "administrative_halt_classification_guard",
     # Re-verifies the deployed zero-trade baseline and clears only that exact

--- a/test_absolute_daily_halt_lifecycle_guard.py
+++ b/test_absolute_daily_halt_lifecycle_guard.py
@@ -1,0 +1,56 @@
+import types
+
+import absolute_daily_halt_lifecycle_guard as guard
+import performance_risk_calibration as calibration
+
+
+def _core(equity, start=10000.0, peak=10010.0):
+    state = {
+        "equity": equity,
+        "cash": equity,
+        "performance": {"realized_pnl_today": 0.0},
+        "risk_controls": {
+            "day_start_equity": start,
+            "day_peak_equity": peak,
+            "halted": True,
+            "halt_reason": "absolute daily equity loss halt (3.00%)",
+        },
+    }
+    return types.SimpleNamespace(
+        portfolio=state,
+        local_ts_text=lambda: "2026-08-12 10:30:00 CDT",
+        today_key=lambda: "2026-08-12",
+        get_realized_pnl=lambda: {"today": 0.0},
+    )
+
+
+def test_recovered_absolute_daily_halt_is_managed_and_can_clear():
+    core = _core(10000.0)
+    guard._APPLIED = False
+    assert guard.apply(core)["status"] == "ok"
+
+    risk = calibration._decorate_risk(core, core.portfolio["risk_controls"])
+
+    assert risk["daily_loss_pct"] == 0.0
+    assert risk["halted"] is False
+    assert risk["halt_reason"] == ""
+    assert calibration.ABSOLUTE_DAILY == 0.03
+
+
+def test_active_absolute_daily_loss_is_reasserted_at_same_threshold():
+    core = _core(9600.0, start=10000.0, peak=10000.0)
+    guard._APPLIED = False
+    assert guard.apply(core)["status"] == "ok"
+
+    risk = calibration._decorate_risk(core, core.portfolio["risk_controls"])
+
+    assert risk["daily_loss_pct"] == 4.0
+    assert risk["halted"] is True
+    assert risk["halt_reason"] == "absolute daily equity loss halt (3.00%)"
+    assert calibration.ABSOLUTE_DAILY == 0.03
+
+
+def test_unrelated_halt_reason_is_not_reclassified():
+    guard._APPLIED = False
+    assert guard.apply(None)["status"] == "ok"
+    assert calibration._managed_halt("canonical execution ledger write failed") is False


### PR DESCRIPTION
Correctness-only Stable Paper risk fix.

Root cause:
- `performance_risk_calibration._decorate_risk()` correctly reasserts the 3.00% absolute daily equity-loss halt while the current daily-loss metric is at/above the ceiling.
- However, the persisted reason `absolute daily equity loss halt (...)` was omitted from `_managed_halt()`, so after the metric recovered below 3.00% that specific halt could remain permanently sticky.

Changes:
- add a narrow compatibility guard that classifies only the existing absolute-daily-loss reason as a managed performance halt;
- preserve the existing 3.00% threshold and existing reassertion logic;
- do not clear state directly and do not reclassify unrelated safety halts;
- add regression tests proving a recovered stale reason can clear, an active >3% loss remains halted, and a canonical-ledger failure remains unmanaged;
- register the guard in deterministic startup.

This does not weaken risk limits, bypass self-defense, repair accounting state, change strategy/sizing/order behavior, enable live trading, or grant ML authority. The separate paper-accounting integrity failure remains fail-closed until its exact persisted rows are identified and repaired.