### PR TITLE
Fix final Stable Paper accounting startup order

### DIFF
--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-12-v21-surge-queue-canonical-execution"
+VERSION = "data-integrity-startup-bridge-2026-08-12-v22-final-accounting-bootstrap-order"
 MODULES = (
     # Registered first so Flask executes its after_request handler last.
     "final_daily_audit_compactor",
@@ -20,21 +20,21 @@ MODULES = (
     # Reporting-only integrity detail so one compact audit identifies the exact
     # persisted row/reason when accounting coverage fails.
     "daily_audit_accounting_issue_bridge",
-    # Correctness-critical bootstrap. It installs canonical execution routing
-    # plus final bidirectional/timestamp semantics before any reconciler runs.
-    "stable_paper_accounting_bootstrap",
-    # Stable Core execution truth: durable append-only hash-chained events.
+    # Stable Core execution truth and paper-only execution bridges are installed
+    # before any accounting compatibility modules are loaded.
     "canonical_execution_ledger",
     "market_surge_canonical_execution_bridge",
-    # The older surge queue executor also predates the canonical execution
-    # boundary. Replace only newly appended queue rows through record_trade while
-    # preserving its selection, sizing, cash mutation, and risk gates.
     "market_surge_queue_canonical_execution_bridge",
     "orla_hygiene_overlay",
+    # Legacy compatibility layers may replace accounting functions/parsers. Keep
+    # them before the final bootstrap so they cannot clobber canonical semantics
+    # immediately before reconciliation.
     "paper_ledger_matched_exit_guard",
     "paper_trade_action_semantics_recovery",
-    # Reconciliation now runs only after the bootstrap above has installed the
-    # final clean-epoch event semantics.
+    # Correctness-critical final bootstrap. Reassert canonical execution routing,
+    # bidirectional accounting, and final timestamp/surge-row semantics after all
+    # legacy compatibility overlays and immediately before reconciliation.
+    "stable_paper_accounting_bootstrap",
     "paper_accounting_integrity_guard",
     "paper_accounting_readonly_status",
     "paper_ledger_economic_integrity",

--- a/test_stable_paper_accounting_bootstrap.py
+++ b/test_stable_paper_accounting_bootstrap.py
@@ -1,7 +1,11 @@
 import types
 
+import data_integrity_startup_bridge as startup
+import paper_accounting_integrity_guard as accounting
 import paper_bidirectional_accounting_guard as bidirectional
 import paper_execution_timestamp_semantics as timestamp_semantics
+import paper_ledger_matched_exit_guard as matched
+import paper_trade_action_semantics_recovery as action_semantics
 import stable_paper_accounting_bootstrap as bootstrap
 
 
@@ -13,7 +17,7 @@ def _core(state):
 
     return types.SimpleNamespace(
         portfolio=state,
-        local_ts_text=lambda *args, **kwargs: "2026-08-11 15:00:00 CDT",
+        local_ts_text=lambda *args, **kwargs: "2026-08-12 10:45:00 CDT",
         save_state=lambda *args, **kwargs: None,
         record_trade=record_trade,
     )
@@ -50,3 +54,60 @@ def test_bootstrap_installs_final_event_semantics_before_reconcile():
     assert rebuilt["cash"] == 8400.0
     assert rebuilt["equity"] == 10000.0
     assert rebuilt["open_positions"]["VST"]["qty"] == 10.0
+
+
+def test_startup_places_final_bootstrap_after_legacy_overlays_before_reconcile():
+    modules = startup.MODULES
+    assert modules.index("paper_ledger_matched_exit_guard") < modules.index("stable_paper_accounting_bootstrap")
+    assert modules.index("paper_trade_action_semantics_recovery") < modules.index("stable_paper_accounting_bootstrap")
+    assert modules.index("stable_paper_accounting_bootstrap") < modules.index("paper_accounting_integrity_guard")
+
+
+def test_final_bootstrap_restores_surge_entry_semantics_before_exit_reconcile():
+    state = {
+        "initial_cash": 10000.0,
+        "cash": 10010.0,
+        "equity": 10010.0,
+        "paper_accounting_epoch": {
+            "id": "stable-paper-v1-20260810-clean01",
+            "clean_start": True,
+            "zero_trade_baseline": True,
+        },
+        "positions": {},
+        "trades": [
+            {
+                "time": "2026-08-11 14:45:00 CDT",
+                "symbol": "CLSK",
+                "side": "buy",
+                "type": "paper_market_surge_deployment",
+                "source": "market_surge_deployment_mode",
+                "entry": 10.0,
+                "shares": 100.0,
+            },
+            {
+                "time": 1786456978,
+                "action": "exit",
+                "symbol": "CLSK",
+                "side": "long",
+                "price": 10.1,
+                "shares": 100.0,
+            },
+        ],
+    }
+    core = _core(state)
+
+    matched.apply(core)
+    action_semantics.apply(core)
+    result = bootstrap.apply(core)
+
+    assert result["status"] == "ok"
+    assert accounting.reconstruct_from_ledger is bidirectional.analyze_ledger
+    assert bidirectional._event_fields is timestamp_semantics.normalized_event_fields
+
+    rebuilt = accounting.reconstruct_from_ledger(state, core)
+    assert rebuilt["coverage_complete"] is True
+    assert rebuilt["ignored_trade_rows"] == 0
+    assert rebuilt["coverage_issue_count"] == 0
+    assert rebuilt["realized_total"] == 10.0
+    assert rebuilt["cash"] == 10010.0
+    assert rebuilt["open_positions"] == {}


### PR DESCRIPTION
Correctness-only Stable Paper accounting fix.

The deployed audit showed four unmatched exits even though the canonical execution ledger is healthy and current risk metrics are clean. Root cause: deterministic startup installed the final Stable Paper bootstrap early, then later legacy compatibility modules replaced the accounting reconstruction function and trade parser before `paper_accounting_integrity_guard` reconciled state.

This PR moves the final `stable_paper_accounting_bootstrap` application after `paper_ledger_matched_exit_guard` and `paper_trade_action_semantics_recovery`, immediately before reconciliation. That reasserts:
- bidirectional long/short accounting;
- normalized timestamp semantics;
- narrowly verified pre-bridge surge-entry support;
- canonical execution routing.

Regression coverage reproduces the legacy overwrite sequence with a verified CLSK surge entry followed by a legitimate exit and proves the final bootstrap restores complete reconciliation with zero ignored rows.

No persisted trade rows are deleted, rewritten, or fabricated. No cash/equity is manually changed. No scanner/strategy thresholds, sizing, risk limits, stop/trailing behavior, live authority, or ML authority are changed.