### PR TITLE
Expose unmatched clean-epoch entry evidence

### DIFF
--- a/daily_audit_accounting_issue_bridge.py
+++ b/daily_audit_accounting_issue_bridge.py
@@ -1,9 +1,10 @@
-"""Reporting-only bridge that exposes the first accounting integrity defect.
+"""Reporting-only bridge for bounded Stable Paper accounting defect evidence.
 
-Stable Paper normally keeps /paper/daily-audit compact. During an integrity
-failure, counts alone are insufficient to identify the exact persisted execution
-row. This bridge augments the compact payload with the first coverage issue,
-first economic issue, and reconstructed open-position symbols.
+When accounting coverage fails, the compact daily audit needs enough evidence to
+identify whether an unmatched exit has a real pre-existing entry row without
+mutating state or inventing executions.  This bridge exposes all bounded coverage
+issues plus a few earlier same-symbol entry-like rows from the persisted trade
+mirror for forensic comparison.
 
 No state repair, execution, strategy, sizing, risk, live, or ML authority is
 changed.
@@ -11,10 +12,12 @@ changed.
 from __future__ import annotations
 
 import functools
-from typing import Any, Dict
+from typing import Any, Dict, List
 
-VERSION = "daily-audit-accounting-issue-bridge-2026-08-11-v1"
+VERSION = "daily-audit-accounting-issue-bridge-2026-08-12-v2-entry-evidence"
 _APPLIED = False
+_MAX_ISSUES = 10
+_MAX_CANDIDATES_PER_ISSUE = 3
 
 
 def _d(value: Any) -> Dict[str, Any]:
@@ -28,6 +31,58 @@ def _l(value: Any) -> list:
 def _first_safe(value: Any) -> Any:
     rows = _l(value)
     return rows[0] if rows else None
+
+
+def _portfolio(core: Any = None) -> Dict[str, Any]:
+    pf = getattr(core, "portfolio", None) if core is not None else None
+    return pf if isinstance(pf, dict) else {}
+
+
+def _entry_like(row: Dict[str, Any]) -> bool:
+    action = str(row.get("action") or "").lower().strip()
+    side = str(row.get("side") or "").lower().strip()
+    row_type = str(row.get("type") or "").lower().strip()
+    return (
+        action in {"entry", "buy", "open", "open_long", "open_short"}
+        or side in {"buy", "b"}
+        or row_type == "paper_market_surge_deployment"
+    )
+
+
+def _safe_trade_evidence(index: int, row: Dict[str, Any]) -> Dict[str, Any]:
+    keys = (
+        "action", "side", "source", "type", "symbol", "ticker", "qty", "shares",
+        "quantity", "price", "entry", "entry_price", "fill_price", "time",
+        "timestamp", "ts_local", "execution_id", "accounting_epoch_id",
+        "canonical_ledger_version", "entry_tag", "trade_authority",
+    )
+    out = {"trade_index": index}
+    for key in keys:
+        if key in row:
+            out[key] = row.get(key)
+    return out
+
+
+def _candidate_entries(core: Any, issue: Dict[str, Any]) -> List[Dict[str, Any]]:
+    symbol = str(issue.get("symbol") or "").upper().strip()
+    issue_index = issue.get("trade_index")
+    try:
+        before = int(issue_index)
+    except Exception:
+        before = 10**9
+    if not symbol:
+        return []
+
+    trades = _l(_portfolio(core).get("trades"))
+    found: List[Dict[str, Any]] = []
+    for index, raw in enumerate(trades):
+        if index >= before or not isinstance(raw, dict):
+            continue
+        raw_symbol = str(raw.get("symbol") or raw.get("ticker") or "").upper().strip()
+        if raw_symbol != symbol or not _entry_like(raw):
+            continue
+        found.append(_safe_trade_evidence(index, raw))
+    return found[-_MAX_CANDIDATES_PER_ISSUE:]
 
 
 def apply(core: Any = None) -> Dict[str, Any]:
@@ -59,11 +114,23 @@ def apply(core: Any = None) -> Dict[str, Any]:
         rebuilt = _d(accounting.get("reconstructed"))
         economics = _d(integrity.get("paper_ledger_economic_integrity"))
 
+        coverage_issues = _l(rebuilt.get("coverage_issues"))[:_MAX_ISSUES]
+        evidence = []
+        for issue in coverage_issues:
+            if not isinstance(issue, dict):
+                continue
+            evidence.append({
+                "issue": issue,
+                "prior_same_symbol_entry_candidates": _candidate_entries(runtime_core or core, issue),
+            })
+
         target = _d(out.get("accounting_integrity"))
-        target["first_coverage_issue"] = _first_safe(rebuilt.get("coverage_issues"))
+        target["first_coverage_issue"] = _first_safe(coverage_issues)
         target["first_economic_issue"] = _first_safe(
             economics.get("economic_issues") or rebuilt.get("economic_issues")
         )
+        target["coverage_issues"] = coverage_issues
+        target["unmatched_exit_entry_evidence"] = evidence
         target["reconstructed_open_positions"] = sorted(
             str(symbol) for symbol in _d(rebuilt.get("open_positions")).keys()
         )
@@ -84,9 +151,10 @@ def status_payload() -> Dict[str, Any]:
         "overall": "pass" if _APPLIED else "warn",
         "version": VERSION,
         "reporting_only": True,
-        "surfaces_first_coverage_issue": True,
-        "surfaces_first_economic_issue": True,
-        "surfaces_reconstructed_open_positions": True,
+        "surfaces_bounded_coverage_issues": True,
+        "surfaces_prior_same_symbol_entry_candidates": True,
+        "max_issues": _MAX_ISSUES,
+        "max_candidates_per_issue": _MAX_CANDIDATES_PER_ISSUE,
     }
 
 

--- a/test_daily_audit_accounting_issue_bridge.py
+++ b/test_daily_audit_accounting_issue_bridge.py
@@ -4,37 +4,75 @@ import daily_audit_accounting_issue_bridge as bridge
 import final_daily_audit_compactor as compactor
 
 
-def test_compact_audit_surfaces_first_accounting_issue(monkeypatch):
+def test_compact_audit_surfaces_bounded_accounting_evidence(monkeypatch):
     def base(payload, core=None):
         return {"accounting_integrity": {"coverage_complete": False}}
 
     monkeypatch.setattr(compactor, "compact_payload", base)
     bridge._APPLIED = False
-    result = bridge.apply(types.SimpleNamespace())
+    state = {
+        "trades": [
+            {
+                "time": "2026-08-11 14:50:00 CDT",
+                "symbol": "CLSK",
+                "side": "buy",
+                "type": "paper_market_surge_deployment",
+                "source": "market_surge_deployment_mode",
+                "entry": 12.25,
+                "shares": 134.680133,
+            },
+            {
+                "time": 1786460578,
+                "action": "exit",
+                "symbol": "CLSK",
+                "side": "long",
+                "price": 11.5223,
+                "shares": 134.680133,
+                "execution_id": "exit-1",
+            },
+        ]
+    }
+    core = types.SimpleNamespace(portfolio=state)
+    result = bridge.apply(core)
     assert result["status"] == "ok"
 
+    issue = {
+        "trade_index": 1,
+        "reason": "exit_exceeds_reconstructed_position",
+        "symbol": "CLSK",
+        "action": "exit",
+        "side": "long",
+        "requested_qty": 134.680133,
+        "matched_qty": 0.0,
+    }
     payload = {
         "sections": {
             "10b_market_data_and_path_integrity": {
                 "paper_accounting_integrity": {
                     "reconstructed": {
-                        "parsed_trade_rows": 6,
-                        "coverage_issues": [{"trade_index": 6, "reason": "unsupported_or_incomplete_trade_row", "symbol": "VST"}],
-                        "economic_issues": [{"trade_index": 6, "reason": "entry_exceeds_available_cash", "symbol": "VST"}],
-                        "open_positions": {"LRCX": {"qty": 1}},
+                        "parsed_trade_rows": 1,
+                        "coverage_issues": [issue],
+                        "economic_issues": [issue],
+                        "open_positions": {},
                     }
                 },
                 "paper_ledger_economic_integrity": {
-                    "economic_issues": [{"trade_index": 6, "reason": "entry_exceeds_available_cash", "symbol": "VST"}]
+                    "economic_issues": [issue]
                 },
             }
         }
     }
 
-    out = compactor.compact_payload(payload, None)
+    out = compactor.compact_payload(payload, core)
     acct = out["accounting_integrity"]
-    assert acct["parsed_trade_rows"] == 6
-    assert acct["first_coverage_issue"]["trade_index"] == 6
-    assert acct["first_coverage_issue"]["symbol"] == "VST"
-    assert acct["first_economic_issue"]["reason"] == "entry_exceeds_available_cash"
-    assert acct["reconstructed_open_positions"] == ["LRCX"]
+    assert acct["parsed_trade_rows"] == 1
+    assert acct["first_coverage_issue"]["symbol"] == "CLSK"
+    assert acct["coverage_issues"] == [issue]
+    evidence = acct["unmatched_exit_entry_evidence"][0]
+    assert evidence["issue"]["trade_index"] == 1
+    candidates = evidence["prior_same_symbol_entry_candidates"]
+    assert len(candidates) == 1
+    assert candidates[0]["trade_index"] == 0
+    assert candidates[0]["source"] == "market_surge_deployment_mode"
+    assert candidates[0]["entry"] == 12.25
+    assert candidates[0]["shares"] == 134.680133


### PR DESCRIPTION
Reporting-only Stable Paper forensic enhancement.

The deployed audit now shows five unmatched exits while the canonical ledger is healthy. Each new canonical exit is increasing the unmatched count, which suggests some positions were opened by a pre-canonical paper path that mutated positions/cash without recording an authoritative entry.

This PR does not repair or reinterpret any trade. It exposes, in the compact daily audit, all bounded coverage issues plus up to three earlier same-symbol entry-like rows from the persisted trade mirror for each issue. That provides the exact evidence needed to distinguish a provable pre-bridge entry from a genuinely unmatched/duplicate exit.

No state mutation, cash/equity change, halt clearing, execution, strategy/sizing/risk change, live authority, or ML authority. Regression coverage verifies a CLSK unmatched exit surfaces its prior legacy market-surge entry evidence.