### PR TITLE
Expose trade row window for accounting forensics

### DIFF
--- a/daily_audit_accounting_issue_bridge.py
+++ b/daily_audit_accounting_issue_bridge.py
@@ -2,9 +2,9 @@
 
 When accounting coverage fails, the compact daily audit needs enough evidence to
 identify whether an unmatched exit has a real pre-existing entry row without
-mutating state or inventing executions.  This bridge exposes all bounded coverage
-issues plus a few earlier same-symbol entry-like rows from the persisted trade
-mirror for forensic comparison.
+mutating state or inventing executions. This bridge exposes bounded coverage
+issues, prior same-symbol entry-like rows, and a compact first-row trade window
+for forensic comparison.
 
 No state repair, execution, strategy, sizing, risk, live, or ML authority is
 changed.
@@ -14,10 +14,11 @@ from __future__ import annotations
 import functools
 from typing import Any, Dict, List
 
-VERSION = "daily-audit-accounting-issue-bridge-2026-08-12-v2-entry-evidence"
+VERSION = "daily-audit-accounting-issue-bridge-2026-08-12-v3-trade-window"
 _APPLIED = False
 _MAX_ISSUES = 10
 _MAX_CANDIDATES_PER_ISSUE = 3
+_MAX_TRADE_ROWS = 12
 
 
 def _d(value: Any) -> Dict[str, Any]:
@@ -52,9 +53,10 @@ def _entry_like(row: Dict[str, Any]) -> bool:
 def _safe_trade_evidence(index: int, row: Dict[str, Any]) -> Dict[str, Any]:
     keys = (
         "action", "side", "source", "type", "symbol", "ticker", "qty", "shares",
-        "quantity", "price", "entry", "entry_price", "fill_price", "time",
-        "timestamp", "ts_local", "execution_id", "accounting_epoch_id",
-        "canonical_ledger_version", "entry_tag", "trade_authority",
+        "quantity", "price", "entry", "entry_price", "exit_price", "fill_price",
+        "value", "pnl", "realized_pnl", "reason", "time", "timestamp", "ts_local",
+        "execution_id", "accounting_epoch_id", "canonical_ledger_version",
+        "canonical_ledger_event_hash", "entry_tag", "trade_authority",
     )
     out = {"trade_index": index}
     for key in keys:
@@ -85,6 +87,16 @@ def _candidate_entries(core: Any, issue: Dict[str, Any]) -> List[Dict[str, Any]]
     return found[-_MAX_CANDIDATES_PER_ISSUE:]
 
 
+def _trade_row_window(core: Any) -> List[Dict[str, Any]]:
+    rows = []
+    for index, raw in enumerate(_l(_portfolio(core).get("trades"))[:_MAX_TRADE_ROWS]):
+        if isinstance(raw, dict):
+            rows.append(_safe_trade_evidence(index, raw))
+        else:
+            rows.append({"trade_index": index, "row_type": type(raw).__name__})
+    return rows
+
+
 def apply(core: Any = None) -> Dict[str, Any]:
     global _APPLIED
     try:
@@ -108,6 +120,7 @@ def apply(core: Any = None) -> Dict[str, Any]:
         if not isinstance(out, dict):
             return out
 
+        active_core = runtime_core or core
         sections = _d(payload.get("sections"))
         integrity = _d(sections.get("10b_market_data_and_path_integrity"))
         accounting = _d(integrity.get("paper_accounting_integrity"))
@@ -121,7 +134,7 @@ def apply(core: Any = None) -> Dict[str, Any]:
                 continue
             evidence.append({
                 "issue": issue,
-                "prior_same_symbol_entry_candidates": _candidate_entries(runtime_core or core, issue),
+                "prior_same_symbol_entry_candidates": _candidate_entries(active_core, issue),
             })
 
         target = _d(out.get("accounting_integrity"))
@@ -131,6 +144,7 @@ def apply(core: Any = None) -> Dict[str, Any]:
         )
         target["coverage_issues"] = coverage_issues
         target["unmatched_exit_entry_evidence"] = evidence
+        target["trade_row_window"] = _trade_row_window(active_core)
         target["reconstructed_open_positions"] = sorted(
             str(symbol) for symbol in _d(rebuilt.get("open_positions")).keys()
         )
@@ -153,8 +167,10 @@ def status_payload() -> Dict[str, Any]:
         "reporting_only": True,
         "surfaces_bounded_coverage_issues": True,
         "surfaces_prior_same_symbol_entry_candidates": True,
+        "surfaces_trade_row_window": True,
         "max_issues": _MAX_ISSUES,
         "max_candidates_per_issue": _MAX_CANDIDATES_PER_ISSUE,
+        "max_trade_rows": _MAX_TRADE_ROWS,
     }
 
 

--- a/test_daily_audit_accounting_issue_bridge.py
+++ b/test_daily_audit_accounting_issue_bridge.py
@@ -20,6 +20,16 @@ def test_compact_audit_surfaces_bounded_accounting_evidence(monkeypatch):
                 "source": "market_surge_deployment_mode",
                 "entry": 12.25,
                 "shares": 134.680133,
+                "execution_id": "entry-1",
+            },
+            {
+                "time": 1786460500,
+                "action": "exit",
+                "symbol": "CLSK",
+                "side": "long",
+                "price": 11.5223,
+                "shares": 134.680133,
+                "source": "legacy_exit_mirror",
             },
             {
                 "time": 1786460578,
@@ -29,6 +39,7 @@ def test_compact_audit_surfaces_bounded_accounting_evidence(monkeypatch):
                 "price": 11.5223,
                 "shares": 134.680133,
                 "execution_id": "exit-1",
+                "canonical_ledger_version": "canonical-execution-ledger-2026-08-10-v1",
             },
         ]
     }
@@ -37,7 +48,7 @@ def test_compact_audit_surfaces_bounded_accounting_evidence(monkeypatch):
     assert result["status"] == "ok"
 
     issue = {
-        "trade_index": 1,
+        "trade_index": 2,
         "reason": "exit_exceeds_reconstructed_position",
         "symbol": "CLSK",
         "action": "exit",
@@ -50,7 +61,7 @@ def test_compact_audit_surfaces_bounded_accounting_evidence(monkeypatch):
             "10b_market_data_and_path_integrity": {
                 "paper_accounting_integrity": {
                     "reconstructed": {
-                        "parsed_trade_rows": 1,
+                        "parsed_trade_rows": 2,
                         "coverage_issues": [issue],
                         "economic_issues": [issue],
                         "open_positions": {},
@@ -65,14 +76,20 @@ def test_compact_audit_surfaces_bounded_accounting_evidence(monkeypatch):
 
     out = compactor.compact_payload(payload, core)
     acct = out["accounting_integrity"]
-    assert acct["parsed_trade_rows"] == 1
+    assert acct["parsed_trade_rows"] == 2
     assert acct["first_coverage_issue"]["symbol"] == "CLSK"
     assert acct["coverage_issues"] == [issue]
     evidence = acct["unmatched_exit_entry_evidence"][0]
-    assert evidence["issue"]["trade_index"] == 1
+    assert evidence["issue"]["trade_index"] == 2
     candidates = evidence["prior_same_symbol_entry_candidates"]
     assert len(candidates) == 1
     assert candidates[0]["trade_index"] == 0
     assert candidates[0]["source"] == "market_surge_deployment_mode"
     assert candidates[0]["entry"] == 12.25
     assert candidates[0]["shares"] == 134.680133
+
+    window = acct["trade_row_window"]
+    assert [row["trade_index"] for row in window] == [0, 1, 2]
+    assert window[1]["source"] == "legacy_exit_mirror"
+    assert window[2]["execution_id"] == "exit-1"
+    assert window[2]["canonical_ledger_version"] == "canonical-execution-ledger-2026-08-10-v1"


### PR DESCRIPTION
Reporting-only Stable Paper forensic enhancement.

The afternoon audit proved all five unmatched exits have exact same-epoch canonical entries with quantities that fully reconcile. The remaining question is which earlier trade-mirror rows consumed those lots before the later canonical exits were evaluated.

This PR adds a bounded `trade_row_window` (first 12 persisted trade rows) to the compact daily audit, exposing only execution-relevant fields such as index, action, symbol, side, qty/shares, price, source/type, execution id, epoch id, canonical markers, P&L, and reason.

No state mutation, cash/equity change, halt clearing, execution behavior, strategy/sizing/risk change, live authority, or ML authority. Regression coverage verifies the window can distinguish a legacy exit mirror from a later canonical exit.