### PR TITLE
Block catastrophic paper exit bad ticks

### DIFF
--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-12-v22-final-accounting-bootstrap-order"
+VERSION = "data-integrity-startup-bridge-2026-08-12-v23-paper-exit-price-integrity"
 MODULES = (
     # Registered first so Flask executes its after_request handler last.
     "final_daily_audit_compactor",
@@ -25,6 +25,9 @@ MODULES = (
     "canonical_execution_ledger",
     "market_surge_canonical_execution_bridge",
     "market_surge_queue_canonical_execution_bridge",
+    # Fail closed on catastrophic paper exit quote anomalies before they can
+    # mutate cash/positions or become canonical execution records.
+    "paper_exit_price_integrity_guard",
     "orla_hygiene_overlay",
     # Legacy compatibility layers may replace accounting functions/parsers. Keep
     # them before the final bootstrap so they cannot clobber canonical semantics

--- a/paper_exit_price_integrity_guard.py
+++ b/paper_exit_price_integrity_guard.py
@@ -1,0 +1,190 @@
+"""Fail-closed quote-integrity guard for paper exits.
+
+A paper position should never jump from the normal stop regime to a catastrophic
+single-tick exit without quote-integrity review. This module wraps the core full
+and partial exit boundaries and blocks only extreme adverse prices that are far
+outside the position's entry/peak context.
+
+Paper-only safety control. It does not change signals, sizing, normal stops,
+profit taking, live authority, or ML authority.
+"""
+from __future__ import annotations
+
+import functools
+import math
+import os
+from typing import Any, Dict
+
+VERSION = "paper-exit-price-integrity-2026-08-12-v1"
+LONG_MIN_PRICE_RATIO = 0.40
+SHORT_MAX_PRICE_RATIO = 2.50
+_APPLIED_CORE_IDS: set[int] = set()
+_REGISTERED_APP_IDS: set[int] = set()
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        out = float(value)
+        return out if math.isfinite(out) else default
+    except Exception:
+        return default
+
+
+def _paper_only() -> bool:
+    live = os.environ.get("LIVE_TRADING_ENABLED", "false").lower() in {"1", "true", "yes", "on"}
+    broker_live = os.environ.get("BROKER_MODE", "").lower() in {"live", "real", "production"}
+    return not live and not broker_live
+
+
+def _portfolio(core: Any) -> Dict[str, Any]:
+    pf = getattr(core, "portfolio", None) if core is not None else None
+    return pf if isinstance(pf, dict) else {}
+
+
+def _position(core: Any, symbol: str) -> Dict[str, Any]:
+    return _d(_d(_portfolio(core).get("positions")).get(str(symbol or "").upper().strip()))
+
+
+def _entry_anchor(pos: Dict[str, Any]) -> float:
+    return _f(pos.get("entry", pos.get("entry_price")), 0.0)
+
+
+def anomaly(pos: Dict[str, Any], px: Any) -> Dict[str, Any] | None:
+    price = _f(px, 0.0)
+    entry = _entry_anchor(pos)
+    side = str(pos.get("side") or "long").lower().strip()
+    if price <= 0.0:
+        return {"reason": "nonpositive_or_nonfinite_exit_price", "price": price, "entry": entry, "side": side}
+    if entry <= 0.0:
+        return None
+
+    ratio = price / entry
+    if side == "short":
+        if ratio >= SHORT_MAX_PRICE_RATIO:
+            return {
+                "reason": "catastrophic_short_exit_price_outlier",
+                "price": price,
+                "entry": entry,
+                "price_to_entry_ratio": ratio,
+                "side": side,
+            }
+        return None
+
+    if ratio <= LONG_MIN_PRICE_RATIO:
+        return {
+            "reason": "catastrophic_long_exit_price_outlier",
+            "price": price,
+            "entry": entry,
+            "price_to_entry_ratio": ratio,
+            "side": "long",
+        }
+    return None
+
+
+def _mark(core: Any, symbol: str, row: Dict[str, Any], boundary: str) -> None:
+    pf = _portfolio(core)
+    risk = _d(pf.setdefault("risk_controls", {}))
+    diagnostic = {
+        **row,
+        "symbol": str(symbol or "").upper().strip(),
+        "boundary": boundary,
+        "version": VERSION,
+    }
+    risk["paper_exit_price_integrity_block"] = diagnostic
+    risk["paper_exit_price_integrity_active"] = True
+    if not bool(risk.get("halted", False)):
+        risk["halted"] = True
+        risk["halt_reason"] = "paper exit quote integrity halt"
+    risk["self_defense_active"] = True
+    existing = str(risk.get("self_defense_reason") or "").strip()
+    marker = "paper exit quote integrity halt"
+    if marker not in existing.lower():
+        risk["self_defense_reason"] = f"{existing}; {marker}".strip("; ") if existing else marker
+    pf["risk_controls"] = risk
+    save = getattr(core, "save_state", None)
+    if callable(save):
+        try:
+            save(pf)
+        except TypeError:
+            save()
+        except Exception:
+            pass
+
+
+def _wrap_boundary(core: Any, name: str) -> bool:
+    current = getattr(core, name, None)
+    if not callable(current):
+        return False
+    marker = f"_{name}_paper_exit_price_integrity_version"
+    if getattr(current, marker, None) == VERSION:
+        return True
+    prior = getattr(current, f"_{name}_paper_exit_price_integrity_prior", current)
+
+    @functools.wraps(prior)
+    def wrapped(symbol, px, *args, **kwargs):
+        pos = _position(core, symbol)
+        issue = anomaly(pos, px) if pos else None
+        if issue is not None:
+            _mark(core, symbol, issue, name)
+            return None
+        return prior(symbol, px, *args, **kwargs)
+
+    setattr(wrapped, marker, VERSION)
+    setattr(wrapped, f"_{name}_paper_exit_price_integrity_prior", prior)
+    setattr(core, name, wrapped)
+    return True
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    if core is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+    if not _paper_only():
+        return {"status": "skipped", "overall": "pass", "version": VERSION, "reason": "paper_only"}
+
+    full = _wrap_boundary(core, "exit_position")
+    partial = _wrap_boundary(core, "reduce_position")
+    if full or partial:
+        _APPLIED_CORE_IDS.add(id(core))
+    return status_payload(core)
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    pf = _portfolio(core) if core is not None else {}
+    risk = _d(pf.get("risk_controls"))
+    return {
+        "status": "ok" if core is not None and id(core) in _APPLIED_CORE_IDS else "pending",
+        "overall": "pass" if core is not None and id(core) in _APPLIED_CORE_IDS else "warn",
+        "type": "paper_exit_price_integrity_guard_status",
+        "version": VERSION,
+        "paper_only": True,
+        "long_min_price_ratio": LONG_MIN_PRICE_RATIO,
+        "short_max_price_ratio": SHORT_MAX_PRICE_RATIO,
+        "active_block": risk.get("paper_exit_price_integrity_block"),
+        "authority": {
+            "fail_closed_quote_integrity_only": True,
+            "changes_normal_stop_thresholds": False,
+            "changes_strategy": False,
+            "changes_sizing": False,
+            "places_orders": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    result = apply(core)
+    if flask_app is None:
+        return result
+    app_id = id(flask_app)
+    if app_id not in _REGISTERED_APP_IDS:
+        from flask import jsonify
+        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+        path = "/paper/exit-price-integrity-status"
+        if path not in existing:
+            flask_app.add_url_rule(path, "paper_exit_price_integrity_status", lambda: jsonify(status_payload(core)))
+        _REGISTERED_APP_IDS.add(app_id)
+    return status_payload(core)

--- a/test_paper_exit_price_integrity_guard.py
+++ b/test_paper_exit_price_integrity_guard.py
@@ -1,0 +1,88 @@
+import types
+
+import paper_exit_price_integrity_guard as guard
+
+
+def _core():
+    calls = []
+    state = {
+        "positions": {
+            "LRCX": {
+                "symbol": "LRCX",
+                "side": "long",
+                "entry": 312.9,
+                "shares": 3.42486,
+                "last_price": 326.0,
+            }
+        },
+        "risk_controls": {
+            "halted": False,
+            "halt_reason": "",
+            "self_defense_active": False,
+            "self_defense_reason": "",
+        },
+    }
+
+    def exit_position(symbol, px, *args, **kwargs):
+        calls.append(("exit", symbol, px))
+        return {"symbol": symbol, "price": px}
+
+    def reduce_position(symbol, px, *args, **kwargs):
+        calls.append(("partial", symbol, px))
+        return {"symbol": symbol, "price": px}
+
+    return types.SimpleNamespace(
+        portfolio=state,
+        exit_position=exit_position,
+        reduce_position=reduce_position,
+        save_state=lambda *args, **kwargs: None,
+        calls=calls,
+    )
+
+
+def test_catastrophic_long_bad_tick_is_blocked_and_halts():
+    core = _core()
+    result = guard.apply(core)
+    assert result["status"] == "ok"
+
+    before = dict(core.portfolio["positions"]["LRCX"])
+    out = core.exit_position("LRCX", 36.26, "stop_loss")
+    assert out is None
+    assert core.calls == []
+    assert core.portfolio["positions"]["LRCX"] == before
+
+    risk = core.portfolio["risk_controls"]
+    assert risk["halted"] is True
+    assert risk["self_defense_active"] is True
+    block = risk["paper_exit_price_integrity_block"]
+    assert block["symbol"] == "LRCX"
+    assert block["reason"] == "catastrophic_long_exit_price_outlier"
+    assert block["price"] == 36.26
+    assert block["entry"] == 312.9
+
+
+def test_normal_full_and_partial_exits_are_unchanged():
+    core = _core()
+    guard.apply(core)
+
+    full = core.exit_position("LRCX", 305.0, "normal_stop")
+    partial = core.reduce_position("LRCX", 327.1188, 0.33, "partial_profit")
+
+    assert full == {"symbol": "LRCX", "price": 305.0}
+    assert partial == {"symbol": "LRCX", "price": 327.1188}
+    assert core.calls == [
+        ("exit", "LRCX", 305.0),
+        ("partial", "LRCX", 327.1188),
+    ]
+
+
+def test_existing_halt_reason_is_preserved_when_bad_tick_is_blocked():
+    core = _core()
+    core.portfolio["risk_controls"]["halted"] = True
+    core.portfolio["risk_controls"]["halt_reason"] = "absolute daily equity loss halt (3.00%)"
+    guard.apply(core)
+
+    assert core.exit_position("LRCX", 36.26, "stop_loss") is None
+    risk = core.portfolio["risk_controls"]
+    assert risk["halt_reason"] == "absolute daily equity loss halt (3.00%)"
+    assert risk["paper_exit_price_integrity_active"] is True


### PR DESCRIPTION
Paper-only safety fix for the LRCX bad-tick failure observed in the afternoon audit.

Evidence:
- LRCX entry was 312.90 and a partial exit printed at 327.1188.
- A later exit was recorded at 36.26, a catastrophic discontinuity inconsistent with contemporaneous LRCX market prices and far outside the bot's normal stop regime.

Changes:
- wrap only the core full/partial paper exit boundaries;
- fail closed on nonpositive/nonfinite prices or extreme adverse prices (long <= 40% of entry; short >= 250% of entry);
- preserve the position and prevent cash/P&L/execution-ledger mutation when blocked;
- raise an explicit paper quote-integrity self-defense marker/halt without overwriting any existing hard halt reason;
- leave normal stops, partial profits, strategy, sizing, live authority, and ML authority unchanged;
- register the guard during deterministic startup and add regression tests reproducing LRCX 312.90 -> 36.26.

This PR does not repair the already-recorded afternoon state; that remains fail-closed until the exact trade-row duplication evidence is reviewed.