### PR TITLE
Recover verified snapshot epoch after bad ticks

### DIFF
--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,54 +10,37 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-12-v23-paper-exit-price-integrity"
+VERSION = "data-integrity-startup-bridge-2026-08-12-v24-verified-snapshot-recovery"
 MODULES = (
-    # Registered first so Flask executes its after_request handler last.
     "final_daily_audit_compactor",
-    # Reporting-only fallback for a scanner section that omits latest-cycle
-    # entries_count even though auto_runner.last_result.entries is available.
     "daily_audit_entry_count_bridge",
-    # Reporting-only integrity detail so one compact audit identifies the exact
-    # persisted row/reason when accounting coverage fails.
     "daily_audit_accounting_issue_bridge",
-    # Stable Core execution truth and paper-only execution bridges are installed
-    # before any accounting compatibility modules are loaded.
     "canonical_execution_ledger",
     "market_surge_canonical_execution_bridge",
     "market_surge_queue_canonical_execution_bridge",
-    # Fail closed on catastrophic paper exit quote anomalies before they can
-    # mutate cash/positions or become canonical execution records.
     "paper_exit_price_integrity_guard",
     "orla_hygiene_overlay",
-    # Legacy compatibility layers may replace accounting functions/parsers. Keep
-    # them before the final bootstrap so they cannot clobber canonical semantics
-    # immediately before reconciliation.
     "paper_ledger_matched_exit_guard",
     "paper_trade_action_semantics_recovery",
-    # Correctness-critical final bootstrap. Reassert canonical execution routing,
-    # bidirectional accounting, and final timestamp/surge-row semantics after all
-    # legacy compatibility overlays and immediately before reconciliation.
     "stable_paper_accounting_bootstrap",
     "paper_accounting_integrity_guard",
     "paper_accounting_readonly_status",
     "paper_ledger_economic_integrity",
-    # Historical recovery evidence is evaluated before the one-time cutover.
     "paper_journal_forensic_recovery",
-    # Disable the unnecessary nested journal mirror while the cutover owns locks.
     "clean_accounting_epoch_lock_safety",
     "clean_accounting_epoch",
     "paper_bidirectional_accounting_guard",
     "paper_execution_timestamp_semantics",
-    # The absolute 3% daily-loss ceiling remains unchanged. This guard only lets
-    # its stale persisted reason use the normal managed-halt recovery lifecycle
-    # after the current metric has recovered below the ceiling.
+    # Exact-signature one-time recovery for the proven 2026-08-12 bad-tick
+    # incident. It archives the contaminated epoch and starts a verified snapshot
+    # epoch under a validation hold; it is not a generic loss reset.
+    "verified_snapshot_epoch_recovery",
+    # Final accounting adapter so the new epoch can begin from verified cash plus
+    # the restored open LRCX lot and all future executions remain canonical.
+    "verified_snapshot_accounting_baseline",
     "absolute_daily_halt_lifecycle_guard",
-    # A validation hold is an administrative execution block, not a loss event.
     "administrative_halt_classification_guard",
-    # Re-verifies the deployed zero-trade baseline and clears only that exact
-    # administrative hold. Any other risk halt remains untouched.
     "clean_epoch_validation_release",
-    # All research/path layers run only after the accounting epoch is established.
     "intratrade_path_capture",
     "mae_mfe_integration",
     "daily_data_integrity_audit_overlay",

--- a/paper_exit_bad_tick_guard.py
+++ b/paper_exit_bad_tick_guard.py
@@ -1,0 +1,20 @@
+"""Compatibility status alias for the paper exit price-integrity guard."""
+from __future__ import annotations
+from typing import Any, Dict
+import paper_exit_price_integrity_guard as _impl
+
+VERSION = _impl.VERSION
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    return _impl.apply(core)
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    out = dict(_impl.status_payload(core))
+    out["hook_applied"] = out.get("status") == "ok"
+    return out
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    return _impl.register_routes(flask_app, core)

--- a/test_verified_snapshot_recovery.py
+++ b/test_verified_snapshot_recovery.py
@@ -1,0 +1,121 @@
+import math
+import types
+
+import paper_bidirectional_accounting_guard as bidirectional
+import verified_snapshot_accounting_baseline as baseline
+import verified_snapshot_epoch_recovery as recovery
+
+
+def test_exact_contamination_signature_requires_known_bad_tick_rows():
+    trades = [{} for _ in range(11)]
+    trades[4] = {
+        "execution_id": recovery.BAD_VST_EXECUTION_ID,
+        "symbol": "VST",
+        "action": "exit",
+        "price": 20.16,
+        "shares": 11.014993,
+    }
+    trades[10] = {
+        "execution_id": recovery.BAD_EXECUTION_ID,
+        "symbol": "LRCX",
+        "action": "exit",
+        "price": 36.26,
+        "shares": 3.42486,
+    }
+    pf = {
+        "cash": recovery.EXPECTED_CURRENT_CASH,
+        "positions": {},
+        "trades": trades,
+        "paper_accounting_epoch": {"id": recovery.OLD_EPOCH_ID},
+        "risk_controls": {"halted": True, "halt_reason": "absolute daily equity loss halt (3.00%)"},
+    }
+    assert recovery.contamination_signature(pf) is True
+    pf["cash"] += 100.0
+    assert recovery.contamination_signature(pf) is False
+
+
+def test_recovery_reverses_only_lrcx_bad_tick_and_restores_lot():
+    pf = {
+        "cash": recovery.EXPECTED_CURRENT_CASH,
+        "equity": recovery.EXPECTED_CURRENT_CASH,
+        "positions": {},
+        "trades": [{"x": 1}],
+        "history": [],
+        "realized_pnl": {"today": -914.64, "total": -800.0, "losses_today": 1, "losses_total": 1},
+        "performance": {"realized_pnl_today": -914.64, "realized_pnl_total": -800.0, "losses_today": 1, "losses_total": 1},
+        "risk_controls": {"halted": True, "halt_reason": "absolute daily equity loss halt (3.00%)"},
+    }
+    out = recovery.build_recovered_state(pf, "/tmp/archive", "2026-08-12 15:50:00 CDT")
+    expected_cash = recovery.EXPECTED_CURRENT_CASH - recovery.BAD_PROCEEDS
+    assert math.isclose(out["cash"], expected_cash, abs_tol=1e-9)
+    assert list(out["positions"]) == ["LRCX"]
+    pos = out["positions"]["LRCX"]
+    assert math.isclose(pos["shares"], 3.42486, abs_tol=1e-9)
+    assert math.isclose(pos["entry"], 312.90, abs_tol=1e-9)
+    assert math.isclose(pos["last_price"], 326.24, abs_tol=1e-9)
+    assert out["trades"] == []
+    assert out["paper_accounting_epoch"]["baseline_type"] == "verified_snapshot_with_open_position"
+    assert out["risk_controls"]["verified_snapshot_validation_hold"] is True
+    assert math.isclose(out["realized_pnl"]["today"], -914.64 - recovery.BAD_REALIZED, abs_tol=1e-9)
+
+
+def test_snapshot_baseline_reconstructs_open_position_without_trade_rows(monkeypatch):
+    # Use the real bidirectional reconciler as the wrapped prior.
+    monkeypatch.setattr(bidirectional, "analyze_ledger", getattr(bidirectional.analyze_ledger, "_verified_snapshot_baseline_prior", bidirectional.analyze_ledger))
+    baseline._APPLIED = False
+    core = types.SimpleNamespace()
+    assert baseline.apply(core)["status"] == "ok"
+
+    pf = {
+        "cash": 10768.497731,
+        "equity": 11885.824057,
+        "positions": {
+            "LRCX": {"side": "long", "shares": 3.42486, "entry": 312.90, "last_price": 326.24}
+        },
+        "trades": [],
+        "paper_accounting_epoch": {
+            "baseline_type": "verified_snapshot_with_open_position",
+            "verified_snapshot_baseline": {
+                "verified": True,
+                "cash": 10768.497731,
+                "equity": 11885.824057,
+                "realized_today": 32.81327,
+                "realized_total": 32.81327,
+                "positions": {"LRCX": {"side": "long", "qty": 3.42486, "entry_price": 312.90, "mark": 326.24}},
+            },
+        },
+    }
+    rebuilt = bidirectional.analyze_ledger(pf, core)
+    assert rebuilt["coverage_complete"] is True
+    assert rebuilt["parsed_trade_rows"] == 0
+    assert rebuilt["baseline_type"] == "verified_snapshot_with_open_position"
+    assert math.isclose(rebuilt["cash"], 10768.497731, abs_tol=1e-6)
+    assert "LRCX" in rebuilt["open_positions"]
+    assert math.isclose(rebuilt["equity"], 11885.824057, abs_tol=1e-5)
+
+
+def test_snapshot_baseline_future_exit_closes_restored_lot(monkeypatch):
+    monkeypatch.setattr(bidirectional, "analyze_ledger", getattr(bidirectional.analyze_ledger, "_verified_snapshot_baseline_prior", bidirectional.analyze_ledger))
+    baseline._APPLIED = False
+    core = types.SimpleNamespace()
+    baseline.apply(core)
+    pf = {
+        "positions": {},
+        "trades": [{"action": "exit", "symbol": "LRCX", "side": "long", "shares": 3.42486, "price": 326.24, "timestamp": "2026-08-13 14:00:00 UTC"}],
+        "paper_accounting_epoch": {
+            "baseline_type": "verified_snapshot_with_open_position",
+            "verified_snapshot_baseline": {
+                "verified": True,
+                "cash": 10768.497731,
+                "equity": 11885.824057,
+                "realized_today": 0.0,
+                "realized_total": 0.0,
+                "positions": {"LRCX": {"side": "long", "qty": 3.42486, "entry_price": 312.90, "mark": 326.24}},
+            },
+        },
+    }
+    rebuilt = bidirectional.analyze_ledger(pf, core)
+    assert rebuilt["coverage_complete"] is True
+    assert rebuilt["parsed_trade_rows"] == 1
+    assert rebuilt["open_positions"] == {}
+    assert math.isclose(rebuilt["cash"], 11885.824057, abs_tol=1e-5)

--- a/verified_snapshot_accounting_baseline.py
+++ b/verified_snapshot_accounting_baseline.py
@@ -1,0 +1,183 @@
+"""Accounting adapter for a verified snapshot epoch with an open paper position.
+
+The 2026-08-12 recovery cannot honestly restart from a zero-position baseline:
+independent market evidence proves that the catastrophic LRCX 36.26 paper exit
+was a bad tick and the remaining 3.42486-share lot must be restored.  This
+adapter lets the existing bidirectional reconciler start from a verified cash +
+open-lot snapshot while keeping all future executions on the canonical ledger.
+
+No strategy, sizing, risk-limit, live, or ML authority is changed.
+"""
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, List
+
+VERSION = "verified-snapshot-accounting-baseline-2026-08-12-v1"
+_APPLIED = False
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or isinstance(value, bool):
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def _snapshot(pf: Dict[str, Any]) -> Dict[str, Any]:
+    epoch = _d(pf.get("paper_accounting_epoch"))
+    if str(epoch.get("baseline_type") or "") != "verified_snapshot_with_open_position":
+        return {}
+    snap = _d(epoch.get("verified_snapshot_baseline"))
+    return snap if bool(snap.get("verified", False)) else {}
+
+
+def _synthetic_entry_rows(snapshot: Dict[str, Any]) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for symbol, raw in _d(snapshot.get("positions")).items():
+        pos = _d(raw)
+        side = str(pos.get("side") or "long").lower().strip()
+        qty = _f(pos.get("qty", pos.get("shares")), 0.0)
+        entry = _f(pos.get("entry_price", pos.get("entry")), 0.0)
+        if side not in {"long", "short"} or qty <= 0.0 or entry <= 0.0:
+            continue
+        out.append({
+            "action": "entry",
+            "symbol": str(symbol).upper().strip(),
+            "side": side,
+            "shares": qty,
+            "price": entry,
+            "timestamp": str(snapshot.get("started_utc") or snapshot.get("started_local") or ""),
+            "verified_snapshot_synthetic_opening_lot": True,
+        })
+    return out
+
+
+def _adjust_issue_indexes(rows: Any, synthetic_count: int) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for raw in _l(rows):
+        if not isinstance(raw, dict):
+            continue
+        row = dict(raw)
+        try:
+            idx = int(row.get("trade_index"))
+            row["trade_index"] = idx - synthetic_count
+            if row["trade_index"] < 0:
+                row["trade_index"] = None
+                row["baseline_issue"] = True
+        except Exception:
+            pass
+        out.append(row)
+    return out
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _APPLIED
+    try:
+        import paper_bidirectional_accounting_guard as bidirectional
+        import paper_accounting_integrity_guard as accounting
+        import paper_ledger_matched_exit_guard as matched
+    except Exception as exc:
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": f"{type(exc).__name__}: {exc}"}
+
+    current = getattr(bidirectional, "analyze_ledger", None)
+    if not callable(current):
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": "bidirectional_analyze_missing"}
+    if getattr(current, "_verified_snapshot_baseline_version", None) == VERSION:
+        _APPLIED = True
+        accounting.reconstruct_from_ledger = current
+        matched.analyze_ledger = current
+        return status_payload(core)
+
+    prior = getattr(current, "_verified_snapshot_baseline_prior", current)
+
+    def wrapped(pf: Dict[str, Any], runtime_core: Any = None) -> Dict[str, Any]:
+        snap = _snapshot(pf if isinstance(pf, dict) else {})
+        if not snap:
+            return prior(pf, runtime_core)
+
+        synthetic = _synthetic_entry_rows(snap)
+        if not synthetic and _d(snap.get("positions")):
+            return {
+                "status": "partial",
+                "coverage_complete": False,
+                "parsed_trade_rows": 0,
+                "ignored_trade_rows": 1,
+                "coverage_issues": [{"reason": "verified_snapshot_position_invalid"}],
+                "coverage_issue_count": 1,
+                "economic_issues": [],
+                "economic_issue_count": 0,
+                "accounting_model": "bidirectional_margin_v1",
+                "supports_long_short": True,
+                "baseline_type": "verified_snapshot_with_open_position",
+            }
+
+        working = copy.deepcopy(pf)
+        actual_trades = _l(working.get("trades"))
+        reserved = sum(_f(row.get("shares")) * _f(row.get("price")) for row in synthetic)
+        baseline_cash = _f(snap.get("cash"), 0.0)
+        working["initial_cash"] = baseline_cash + reserved
+        working["starting_cash"] = baseline_cash + reserved
+        working["initial_equity"] = _f(snap.get("equity"), baseline_cash + reserved)
+        working["trades"] = synthetic + actual_trades
+
+        rebuilt = dict(prior(working, runtime_core))
+        n = len(synthetic)
+        rebuilt["parsed_trade_rows"] = max(0, int(rebuilt.get("parsed_trade_rows") or 0) - n)
+        rebuilt["coverage_issues"] = _adjust_issue_indexes(rebuilt.get("coverage_issues"), n)
+        rebuilt["coverage_issue_count"] = len(_l(rebuilt.get("coverage_issues")))
+        rebuilt["economic_issues"] = _adjust_issue_indexes(rebuilt.get("economic_issues"), n)
+        rebuilt["economic_issue_count"] = len(_l(rebuilt.get("economic_issues")))
+        rebuilt["initial_cash"] = round(baseline_cash, 6)
+        rebuilt["baseline_cash"] = round(baseline_cash, 6)
+        rebuilt["baseline_equity"] = round(_f(snap.get("equity"), baseline_cash), 6)
+        rebuilt["baseline_type"] = "verified_snapshot_with_open_position"
+        rebuilt["baseline_position_count"] = len(synthetic)
+        rebuilt["verified_snapshot_epoch"] = True
+        rebuilt["realized_today"] = round(_f(snap.get("realized_today"), 0.0) + _f(rebuilt.get("realized_today"), 0.0), 6)
+        rebuilt["realized_total"] = round(_f(snap.get("realized_total"), 0.0) + _f(rebuilt.get("realized_total"), 0.0), 6)
+        rebuilt["coverage_complete"] = bool(
+            rebuilt.get("status") in {"ok", "partial"}
+            and not rebuilt["coverage_issues"]
+            and not rebuilt["economic_issues"]
+        )
+        rebuilt["status"] = "ok" if rebuilt["coverage_complete"] else "partial"
+        return rebuilt
+
+    wrapped._verified_snapshot_baseline_version = VERSION  # type: ignore[attr-defined]
+    wrapped._verified_snapshot_baseline_prior = prior  # type: ignore[attr-defined]
+    bidirectional.analyze_ledger = wrapped
+    accounting.reconstruct_from_ledger = wrapped
+    matched.analyze_ledger = wrapped
+    _APPLIED = True
+    return status_payload(core)
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    active = False
+    try:
+        import paper_bidirectional_accounting_guard as bidirectional
+        active = getattr(getattr(bidirectional, "analyze_ledger", None), "_verified_snapshot_baseline_version", None) == VERSION
+    except Exception:
+        active = False
+    return {
+        "status": "ok" if active else "pending",
+        "overall": "pass" if active else "warn",
+        "version": VERSION,
+        "snapshot_baseline_supported": bool(active),
+        "paper_accounting_only": True,
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    return apply(core)

--- a/verified_snapshot_epoch_recovery.py
+++ b/verified_snapshot_epoch_recovery.py
@@ -1,0 +1,368 @@
+"""One-shot Stable Paper recovery for the proven 2026-08-12 bad-tick incident.
+
+This migration is intentionally exact-signature and paper-only.  It archives the
+contaminated epoch, reverses only the LRCX 36.26 bad-tick mutation, restores the
+remaining LRCX lot, rotates the old canonical ledger/journal into forensic
+history, and starts a new verified snapshot epoch under a validation hold.
+
+It does not weaken risk limits or change strategy, sizing, live, or ML authority.
+"""
+from __future__ import annotations
+
+import copy
+import datetime as dt
+import json
+import os
+import shutil
+from typing import Any, Dict, List
+
+VERSION = "verified-snapshot-epoch-recovery-2026-08-12-v1"
+OLD_EPOCH_ID = "stable-paper-v1-20260810-clean01"
+TARGET_EPOCH_ID = "stable-paper-v2-20260812-verified01"
+DECISION_ID = "verified-bad-tick-and-ledger-divergence-2026-08-12"
+BAD_EXECUTION_ID = "5ca38922916e4612ae3cda8d9801107d"
+BAD_VST_EXECUTION_ID = "36dbe6c2ee0f4b7bbc8be8f6794105a6"
+EXPECTED_CURRENT_CASH = 10892.683154582748
+LRCX_QTY = 3.42486
+LRCX_ENTRY = 312.90
+BAD_PRICE = 36.26
+VERIFIED_MARK = 326.24
+BAD_PROCEEDS = LRCX_QTY * BAD_PRICE
+BAD_REALIZED = (BAD_PRICE - LRCX_ENTRY) * LRCX_QTY
+STATE_DIR = os.environ.get("STATE_DIR") or os.environ.get("PERSISTENT_STATE_DIR") or os.environ.get("RAILWAY_VOLUME_MOUNT_PATH") or "."
+ARCHIVE_ROOT = os.path.join(STATE_DIR, "forensic_archives")
+MARKER_FILE = os.path.join(STATE_DIR, f"verified_snapshot_{DECISION_ID}.json")
+_LAST_STATUS: Dict[str, Any] = {}
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or isinstance(value, bool):
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def _now(core: Any = None) -> str:
+    try:
+        return str(core.local_ts_text())
+    except Exception:
+        return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _portfolio(core: Any) -> Dict[str, Any]:
+    pf = getattr(core, "portfolio", None) if core is not None else None
+    return pf if isinstance(pf, dict) else {}
+
+
+def _paper_only() -> bool:
+    live = os.environ.get("LIVE_TRADING_ENABLED", "false").lower() in {"1", "true", "yes", "on"}
+    broker_live = os.environ.get("BROKER_MODE", "").lower() in {"live", "real", "production"}
+    return not live and not broker_live
+
+
+def _atomic_json(path: str, payload: Dict[str, Any]) -> None:
+    folder = os.path.dirname(path)
+    if folder:
+        os.makedirs(folder, exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True, default=str)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def _marker() -> Dict[str, Any]:
+    try:
+        with open(MARKER_FILE, "r", encoding="utf-8") as handle:
+            value = json.load(handle)
+        return value if isinstance(value, dict) else {}
+    except Exception:
+        return {}
+
+
+def _row_matches(row: Dict[str, Any], execution_id: str, symbol: str, action: str, price: float, qty: float) -> bool:
+    return bool(
+        str(row.get("execution_id") or "") == execution_id
+        and str(row.get("symbol") or "").upper() == symbol
+        and str(row.get("action") or "").lower() == action
+        and abs(_f(row.get("price")) - price) <= 1e-6
+        and abs(_f(row.get("shares", row.get("qty"))) - qty) <= 1e-6
+    )
+
+
+def contamination_signature(pf: Dict[str, Any]) -> bool:
+    epoch = _d(pf.get("paper_accounting_epoch"))
+    trades = _l(pf.get("trades"))
+    risk = _d(pf.get("risk_controls"))
+    if str(epoch.get("id") or "") != OLD_EPOCH_ID or len(trades) != 11:
+        return False
+    if _d(pf.get("positions")):
+        return False
+    if abs(_f(pf.get("cash")) - EXPECTED_CURRENT_CASH) > 1.0:
+        return False
+    if not bool(risk.get("halted", False)):
+        return False
+    if "absolute daily equity loss halt" not in str(risk.get("halt_reason") or ""):
+        return False
+    last = trades[-1] if trades and isinstance(trades[-1], dict) else {}
+    vst = trades[4] if len(trades) > 4 and isinstance(trades[4], dict) else {}
+    return _row_matches(last, BAD_EXECUTION_ID, "LRCX", "exit", BAD_PRICE, LRCX_QTY) and _row_matches(
+        vst, BAD_VST_EXECUTION_ID, "VST", "exit", 20.16, 11.014993
+    )
+
+
+def _archive_state(core: Any) -> Dict[str, Any]:
+    os.makedirs(ARCHIVE_ROOT, exist_ok=True)
+    stamp = dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    archive_dir = os.path.join(ARCHIVE_ROOT, f"{stamp}_{DECISION_ID}")
+    os.makedirs(archive_dir, exist_ok=False)
+    root_abs = os.path.abspath(ARCHIVE_ROOT)
+    copied: List[Dict[str, Any]] = []
+    for name in sorted(os.listdir(STATE_DIR)):
+        src = os.path.join(STATE_DIR, name)
+        src_abs = os.path.abspath(src)
+        if src_abs == root_abs or src_abs.startswith(root_abs + os.sep):
+            continue
+        dst = os.path.join(archive_dir, name)
+        try:
+            if os.path.isdir(src):
+                shutil.copytree(src, dst)
+                copied.append({"name": name, "type": "directory"})
+            elif os.path.isfile(src):
+                shutil.copy2(src, dst)
+                copied.append({"name": name, "type": "file", "size_bytes": os.path.getsize(dst)})
+        except Exception as exc:
+            copied.append({"name": name, "type": "copy_error", "error": f"{type(exc).__name__}: {exc}"})
+    manifest = {
+        "status": "ok",
+        "type": "verified_snapshot_epoch_forensic_archive",
+        "version": VERSION,
+        "decision_id": DECISION_ID,
+        "old_epoch_id": OLD_EPOCH_ID,
+        "target_epoch_id": TARGET_EPOCH_ID,
+        "created_local": _now(core),
+        "archive_dir": archive_dir,
+        "market_evidence": {
+            "source": "Alpaca IEX 1-minute bars independently verified before migration",
+            "LRCX_2026_08_12_15_43_UTC": {"open": 326.515, "high": 326.515, "low": 326.24, "close": 326.24},
+            "VST_2026_08_11_14_38_to_14_40_UTC": {"observed_range_approx": [145.905, 146.45], "bad_recorded_price": 20.16},
+            "bad_lrcx_recorded_price": BAD_PRICE,
+        },
+        "bad_execution_id": BAD_EXECUTION_ID,
+        "copied_entries": copied,
+    }
+    _atomic_json(os.path.join(archive_dir, "verified_snapshot_recovery_manifest.json"), manifest)
+    return manifest
+
+
+def _adjust_realized(state: Dict[str, Any], correction: float) -> tuple[float, float]:
+    realized = _d(state.setdefault("realized_pnl", {}))
+    today_key = "today" if "today" in realized or "realized_today" not in realized else "realized_today"
+    current_today = _f(realized.get(today_key), _f(_d(state.get("performance")).get("realized_pnl_today"), 0.0))
+    current_total = _f(realized.get("total"), _f(_d(state.get("performance")).get("realized_pnl_total"), 0.0))
+    corrected_today = current_today + correction
+    corrected_total = current_total + correction
+    realized[today_key] = corrected_today
+    realized["total"] = corrected_total
+    if _f(realized.get("losses_today"), 0.0) > 0:
+        realized["losses_today"] = max(0, int(_f(realized.get("losses_today"))) - 1)
+    if _f(realized.get("losses_total"), 0.0) > 0:
+        realized["losses_total"] = max(0, int(_f(realized.get("losses_total"))) - 1)
+    state["realized_pnl"] = realized
+    perf = _d(state.setdefault("performance", {}))
+    perf["realized_pnl_today"] = corrected_today
+    perf["realized_pnl_total"] = corrected_total
+    if _f(perf.get("losses_today"), 0.0) > 0:
+        perf["losses_today"] = max(0, int(_f(perf.get("losses_today"))) - 1)
+    if _f(perf.get("losses_total"), 0.0) > 0:
+        perf["losses_total"] = max(0, int(_f(perf.get("losses_total"))) - 1)
+    state["performance"] = perf
+    return corrected_today, corrected_total
+
+
+def build_recovered_state(pf: Dict[str, Any], archive_dir: str, started_local: str) -> Dict[str, Any]:
+    state = copy.deepcopy(pf)
+    corrected_cash = _f(state.get("cash")) - BAD_PROCEEDS
+    correction = -BAD_REALIZED
+    corrected_today, corrected_total = _adjust_realized(state, correction)
+    unrealized = (VERIFIED_MARK - LRCX_ENTRY) * LRCX_QTY
+    market_value = VERIFIED_MARK * LRCX_QTY
+    position = {
+        "symbol": "LRCX",
+        "side": "long",
+        "shares": LRCX_QTY,
+        "qty": LRCX_QTY,
+        "entry": LRCX_ENTRY,
+        "entry_price": LRCX_ENTRY,
+        "last_price": VERIFIED_MARK,
+        "peak": max(VERIFIED_MARK, 327.1188),
+        "partial_taken": True,
+        "last_partial_exit_time": 1786541619,
+        "cost_basis": LRCX_ENTRY * LRCX_QTY,
+        "market_value": market_value,
+        "unrealized_pnl": unrealized,
+        "pnl_dollars": unrealized,
+        "pnl_pct": (VERIFIED_MARK - LRCX_ENTRY) / LRCX_ENTRY * 100.0,
+        "verified_snapshot_recovery_version": VERSION,
+    }
+    state["cash"] = corrected_cash
+    state["positions"] = {"LRCX": position}
+    state["equity"] = corrected_cash + market_value
+    state["trades"] = []
+    state["accounting_epoch_id"] = TARGET_EPOCH_ID
+    history = _l(state.get("history"))
+    history.append(state["equity"])
+    state["history"] = history[-500:]
+    perf = _d(state.setdefault("performance", {}))
+    perf["unrealized_pnl"] = unrealized
+    perf["open_positions"] = {"LRCX": copy.deepcopy(position)}
+    state["performance"] = perf
+
+    risk = _d(state.setdefault("risk_controls", {}))
+    risk.update({
+        "halted": True,
+        "halt_reason": "verified snapshot recovery validation hold",
+        "verified_snapshot_validation_hold": True,
+        "verified_snapshot_validation_hold_reason": "verify repaired snapshot persistence and accounting before new entries",
+        "clean_epoch_validation_hold": False,
+        "self_defense_active": False,
+        "self_defense_reason": "verified snapshot recovery validation hold",
+        "day_start_equity": state["equity"],
+        "day_peak_equity": state["equity"],
+        "day_pnl_pct": 0.0,
+        "daily_loss_pct": 0.0,
+        "daily_drawdown_pct": 0.0,
+        "intraday_drawdown_pct": 0.0,
+        "net_daily_loss_pct": 0.0,
+        "bad_tick_recovery_execution_id": BAD_EXECUTION_ID,
+        "bad_tick_recovery_version": VERSION,
+    })
+    state["risk_controls"] = risk
+
+    snapshot = {
+        "verified": True,
+        "version": VERSION,
+        "started_local": started_local,
+        "cash": corrected_cash,
+        "equity": state["equity"],
+        "realized_today": corrected_today,
+        "realized_total": corrected_total,
+        "positions": {"LRCX": {"side": "long", "qty": LRCX_QTY, "entry_price": LRCX_ENTRY, "mark": VERIFIED_MARK}},
+        "bad_tick_reversed": {"execution_id": BAD_EXECUTION_ID, "price": BAD_PRICE, "qty": LRCX_QTY, "cash_proceeds_removed": BAD_PROCEEDS, "realized_pnl_reversed": BAD_REALIZED},
+    }
+    state["paper_accounting_epoch"] = {
+        "version": VERSION,
+        "id": TARGET_EPOCH_ID,
+        "decision_id": DECISION_ID,
+        "started_local": started_local,
+        "starting_cash": corrected_cash,
+        "starting_equity": state["equity"],
+        "clean_start": False,
+        "zero_trade_baseline": False,
+        "baseline_type": "verified_snapshot_with_open_position",
+        "verified_snapshot_baseline": snapshot,
+        "historical_recovery_decision": "verified_snapshot_rollforward",
+        "prior_epoch_id": OLD_EPOCH_ID,
+        "prior_epoch_disposition": "archived_after_proven_bad_ticks_and_state_ledger_divergence",
+        "historical_evidence_archived": True,
+        "forensic_archive_dir": archive_dir,
+        "validation_hold": True,
+        "validation_hold_reason": "verified snapshot recovery validation hold",
+        "forward_validation_required": True,
+        "valid_path_rows_baseline": 0,
+    }
+    return state
+
+
+def _rotate_journal(state: Dict[str, Any]) -> None:
+    try:
+        import trade_journal as tj
+        factory = getattr(tj, "_empty_journal", None)
+        journal = factory() if callable(factory) else {"trades": [], "recent_trades": [], "snapshots": [], "event_hook_events": []}
+        if not isinstance(journal, dict):
+            journal = {"trades": [], "recent_trades": [], "snapshots": [], "event_hook_events": []}
+        journal["accounting_epoch_id"] = TARGET_EPOCH_ID
+        journal["verified_snapshot_epoch_started_local"] = _now()
+        for attr in ("TRADE_JOURNAL_FILE", "TRADE_JOURNAL_BACKUP_FILE"):
+            path = str(getattr(tj, attr, "") or "")
+            if path:
+                _atomic_json(path, journal)
+        mirror = getattr(tj, "mirror_state", None)
+        if callable(mirror):
+            mirror(state, source="verified_snapshot_epoch_recovery", source_file=str(getattr(tj, "STATE_FILE", "") or ""))
+    except Exception:
+        pass
+
+
+def _cutover(core: Any) -> Dict[str, Any]:
+    global _LAST_STATUS
+    import clean_accounting_epoch as clean
+    archive = _archive_state(core)
+    started = _now(core)
+    started_marker = {"status": "cutover_started", "version": VERSION, "decision_id": DECISION_ID, "target_epoch_id": TARGET_EPOCH_ID, "archive_dir": archive.get("archive_dir"), "started_local": started}
+    _atomic_json(MARKER_FILE, started_marker)
+    recovered = build_recovered_state(_portfolio(core), str(archive.get("archive_dir") or ""), started)
+    with clean._runtime_locks():
+        state_file = clean._write_clean_state_and_backups(core, recovered)
+        clean._rotate_canonical_ledger()
+        _rotate_journal(recovered)
+        clean._reset_snapshot_archive(recovered, state_file)
+        pf = _portfolio(core)
+        pf.clear()
+        pf.update(recovered)
+    completed = dict(started_marker)
+    completed.update({"status": "completed", "completed_local": _now(core), "state_file": state_file, "validation_hold": True, "corrected_cash": recovered.get("cash"), "corrected_equity": recovered.get("equity"), "restored_positions": ["LRCX"]})
+    _atomic_json(MARKER_FILE, completed)
+    _LAST_STATUS = completed
+    return completed
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _LAST_STATUS
+    if core is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+    if not _paper_only():
+        return {"status": "blocked", "overall": "fail", "version": VERSION, "reason": "paper_runtime_only"}
+    pf = _portfolio(core)
+    epoch = _d(pf.get("paper_accounting_epoch"))
+    if str(epoch.get("id") or "") == TARGET_EPOCH_ID:
+        hold = bool(_d(pf.get("risk_controls")).get("verified_snapshot_validation_hold", False))
+        return {"status": "validation_hold" if hold else "active", "overall": "warn" if hold else "pass", "version": VERSION, "epoch_id": TARGET_EPOCH_ID, "validation_hold": hold, "forensic_archive_dir": epoch.get("forensic_archive_dir")}
+    marker = _marker()
+    if marker.get("status") == "completed":
+        return dict(marker)
+    if not contamination_signature(pf):
+        return {"status": "not_applicable", "overall": "pass", "version": VERSION, "reason": "exact_contamination_signature_not_present"}
+    try:
+        import canonical_execution_ledger as ledger
+        ledger_status = ledger.status_payload(core)
+    except Exception as exc:
+        return {"status": "blocked", "overall": "fail", "version": VERSION, "reason": "canonical_ledger_status_unavailable", "error": f"{type(exc).__name__}: {exc}"}
+    if not bool(ledger_status.get("chain_valid")) or int(ledger_status.get("row_count") or 0) != 11:
+        return {"status": "blocked", "overall": "fail", "version": VERSION, "reason": "canonical_ledger_signature_mismatch", "ledger": ledger_status}
+    try:
+        import paper_exit_bad_tick_guard as bad_tick
+        if not bool(bad_tick.status_payload(core).get("hook_applied")):
+            return {"status": "blocked", "overall": "fail", "version": VERSION, "reason": "future_bad_tick_guard_not_active"}
+    except Exception as exc:
+        return {"status": "blocked", "overall": "fail", "version": VERSION, "reason": "future_bad_tick_guard_unavailable", "error": f"{type(exc).__name__}: {exc}"}
+    return _cutover(core)
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    return apply(core)
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    return apply(core)


### PR DESCRIPTION
One-shot paper-only recovery for the proven 2026-08-12 contaminated Stable Paper epoch.

Evidence already established:
- canonical row 4 recorded VST at 20.16 while independent Alpaca IEX 1-minute bars were ~145.9-146.5;
- canonical row 10 recorded LRCX at 36.26 while the exact 15:43 UTC IEX bar was 326.515/326.515/326.24/326.24;
- reversing only the LRCX bad-tick proceeds and P&L returns the account to the previously observed pre-incident cash/realized state.

Changes:
- exact-signature one-time migration only for epoch stable-paper-v1-20260810-clean01 with the known bad execution IDs;
- archive persistent state before mutation;
- reverse only the LRCX 36.26 cash/P&L mutation and restore the remaining 3.42486-share LRCX lot at 312.90 basis;
- rotate the contaminated canonical ledger/journal after archival;
- start stable-paper-v2-20260812-verified01 with a verified cash+open-position snapshot baseline under an administrative validation hold;
- add an accounting adapter so future canonical exits reconcile from that snapshot baseline;
- retain the 3% risk ceiling, fail-closed bad-tick guard, strategy, sizing, live and ML boundaries unchanged;
- regression tests cover the exact contamination signature, rollback arithmetic, zero-trade snapshot reconciliation, and a future exit from the restored lot.