### PR TITLE
Prevent verified snapshot recovery startup deadlock

### DIFF
--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-12-v24-verified-snapshot-recovery"
+VERSION = "data-integrity-startup-bridge-2026-08-12-v25-verified-snapshot-lock-safety"
 MODULES = (
     "final_daily_audit_compactor",
     "daily_audit_entry_count_bridge",
@@ -31,6 +31,10 @@ MODULES = (
     "clean_accounting_epoch",
     "paper_bidirectional_accounting_guard",
     "paper_execution_timestamp_semantics",
+    # Patch the exact one-shot recovery's journal rotation before the recovery
+    # runs. The migration already owns the journal lock, so it must not call the
+    # journal mirror recursively from inside that critical section.
+    "verified_snapshot_epoch_recovery_lock_safety",
     # Exact-signature one-time recovery for the proven 2026-08-12 bad-tick
     # incident. It archives the contaminated epoch and starts a verified snapshot
     # epoch under a validation hold; it is not a generic loss reset.


### PR DESCRIPTION
Hotfix for the Railway bootstrap hang observed after PR #45.

Root cause:
- verified_snapshot_epoch_recovery enters clean_accounting_epoch._runtime_locks(), which already owns the trade-journal mirror lock;
- its journal rotation helper then calls trade_journal.mirror_state() from inside that critical section;
- on persistent Railway state this can self-deadlock during data_integrity_registration.

Fix:
- load verified_snapshot_epoch_recovery_lock_safety immediately before the one-shot recovery;
- replace only that recovery's journal-rotation helper with direct atomic empty-journal writes;
- do not re-enter mirror_state while the mirror lock is held;
- leave all recovery arithmetic, the exact contamination signature, validation hold, 3% risk ceiling, strategy, sizing, live authority and ML authority unchanged.