### PR TITLE
Allow verified snapshot epoch to supersede clean epoch

### DIFF
--- a/clean_epoch_successor_compatibility.py
+++ b/clean_epoch_successor_compatibility.py
@@ -1,0 +1,97 @@
+"""Compatibility guard for legitimately superseded clean accounting epochs.
+
+The 2026-08-10 clean epoch migration leaves a durable completion marker. A later,
+explicit verified-snapshot roll-forward is allowed to supersede that epoch. This
+shim teaches the old migration to treat only that exact successor relationship as
+healthy instead of reporting a missing active epoch.
+
+It does not mutate account state, risk limits, strategy, sizing, live authority,
+or ML authority. Any unrelated epoch mismatch continues to fail closed.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+VERSION = "clean-epoch-successor-compatibility-2026-08-12-v1"
+OLD_EPOCH_ID = "stable-paper-v1-20260810-clean01"
+NEW_EPOCH_ID = "stable-paper-v2-20260812-verified01"
+_APPLIED = False
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _is_verified_successor(core: Any) -> bool:
+    pf = getattr(core, "portfolio", None)
+    pf = pf if isinstance(pf, dict) else {}
+    epoch = _d(pf.get("paper_accounting_epoch"))
+    return bool(
+        str(epoch.get("id") or "") == NEW_EPOCH_ID
+        and str(epoch.get("prior_epoch_id") or "") == OLD_EPOCH_ID
+        and str(epoch.get("historical_recovery_decision") or "") == "verified_snapshot_rollforward"
+        and bool(epoch.get("historical_evidence_archived", False))
+    )
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _APPLIED
+    try:
+        import clean_accounting_epoch as clean
+    except Exception as exc:
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": f"{type(exc).__name__}: {exc}"}
+
+    current = getattr(clean, "apply", None)
+    if not callable(current):
+        return {"status": "error", "overall": "fail", "version": VERSION, "error": "clean_epoch_apply_missing"}
+    if getattr(current, "_successor_compatibility_version", None) == VERSION:
+        _APPLIED = True
+        return status_payload(core)
+
+    prior = getattr(current, "_successor_compatibility_prior", current)
+
+    def wrapped(runtime_core: Any = None):
+        if runtime_core is not None and _is_verified_successor(runtime_core):
+            pf = getattr(runtime_core, "portfolio", None)
+            epoch = _d(_d(pf).get("paper_accounting_epoch"))
+            return {
+                "status": "superseded",
+                "overall": "pass",
+                "version": getattr(clean, "VERSION", None),
+                "compatibility_version": VERSION,
+                "epoch_id": OLD_EPOCH_ID,
+                "superseded_by_epoch_id": NEW_EPOCH_ID,
+                "historical_recovery_decision": epoch.get("historical_recovery_decision"),
+                "historical_evidence_archived": bool(epoch.get("historical_evidence_archived", False)),
+                "authority": {
+                    "mutates_state": False,
+                    "changes_risk_thresholds": False,
+                    "changes_strategy": False,
+                    "places_orders": False,
+                    "changes_live_or_ml_authority": False,
+                },
+            }
+        return prior(runtime_core)
+
+    wrapped._successor_compatibility_version = VERSION  # type: ignore[attr-defined]
+    wrapped._successor_compatibility_prior = prior  # type: ignore[attr-defined]
+    clean.apply = wrapped
+    _APPLIED = True
+    return status_payload(core)
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    successor = bool(core is not None and _is_verified_successor(core))
+    return {
+        "status": "ok" if _APPLIED else "pending",
+        "overall": "pass" if _APPLIED else "warn",
+        "version": VERSION,
+        "verified_successor_present": successor,
+        "old_epoch_id": OLD_EPOCH_ID,
+        "new_epoch_id": NEW_EPOCH_ID,
+        "reporting_compatibility_only": True,
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    return apply(core)

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-12-v24-verified-snapshot-recovery"
+VERSION = "data-integrity-startup-bridge-2026-08-12-v25-verified-snapshot-lock-safety"
 MODULES = (
     "final_daily_audit_compactor",
     "daily_audit_entry_count_bridge",
@@ -31,6 +31,10 @@ MODULES = (
     "clean_accounting_epoch",
     "paper_bidirectional_accounting_guard",
     "paper_execution_timestamp_semantics",
+    # Patch the exact one-shot recovery's journal rotation before the recovery
+    # runs. The migration already owns the journal lock, so it must not call the
+    # journal mirror recursively from inside that critical section.
+    "verified_snapshot_epoch_recovery_lock_safety",
     # Exact-signature one-time recovery for the proven 2026-08-12 bad-tick
     # incident. It archives the contaminated epoch and starts a verified snapshot
     # epoch under a validation hold; it is not a generic loss reset.

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-12-v25-verified-snapshot-lock-safety"
+VERSION = "data-integrity-startup-bridge-2026-08-12-v26-clean-epoch-successor-compatibility"
 MODULES = (
     "final_daily_audit_compactor",
     "daily_audit_entry_count_bridge",
@@ -28,6 +28,11 @@ MODULES = (
     "paper_ledger_economic_integrity",
     "paper_journal_forensic_recovery",
     "clean_accounting_epoch_lock_safety",
+    # The 2026-08-10 clean epoch marker remains durable after a later verified
+    # snapshot roll-forward. Patch the old migration first so that only the exact
+    # explicit v1->v2 successor relationship is reported as healthy/superseded;
+    # unrelated epoch mismatches continue to fail closed.
+    "clean_epoch_successor_compatibility",
     "clean_accounting_epoch",
     "paper_bidirectional_accounting_guard",
     "paper_execution_timestamp_semantics",

--- a/test_clean_epoch_successor_compatibility.py
+++ b/test_clean_epoch_successor_compatibility.py
@@ -1,0 +1,39 @@
+import types
+
+import clean_epoch_successor_compatibility as compat
+
+
+def _core(epoch):
+    core = types.SimpleNamespace()
+    core.portfolio = {"paper_accounting_epoch": epoch}
+    return core
+
+
+def test_exact_verified_successor_is_recognized():
+    core = _core({
+        "id": compat.NEW_EPOCH_ID,
+        "prior_epoch_id": compat.OLD_EPOCH_ID,
+        "historical_recovery_decision": "verified_snapshot_rollforward",
+        "historical_evidence_archived": True,
+    })
+    assert compat._is_verified_successor(core) is True
+
+
+def test_unrelated_epoch_is_not_recognized():
+    core = _core({
+        "id": "some-other-epoch",
+        "prior_epoch_id": compat.OLD_EPOCH_ID,
+        "historical_recovery_decision": "verified_snapshot_rollforward",
+        "historical_evidence_archived": True,
+    })
+    assert compat._is_verified_successor(core) is False
+
+
+def test_successor_requires_archived_evidence():
+    core = _core({
+        "id": compat.NEW_EPOCH_ID,
+        "prior_epoch_id": compat.OLD_EPOCH_ID,
+        "historical_recovery_decision": "verified_snapshot_rollforward",
+        "historical_evidence_archived": False,
+    })
+    assert compat._is_verified_successor(core) is False


### PR DESCRIPTION
Fix startup failure after the successful v1 -> v2 verified snapshot migration.

Root cause:
- the durable 2026-08-10 clean-accounting completion marker remains present by design;
- after the verified snapshot recovery, the active epoch is stable-paper-v2-20260812-verified01;
- clean_accounting_epoch therefore reported completed_marker_present_but_active_state_epoch_missing and caused data-integrity registration to fail.

Fix:
- add a reporting-only compatibility shim that recognizes only the exact verified successor relationship: active epoch v2, prior_epoch_id v1, historical_recovery_decision verified_snapshot_rollforward, historical evidence archived;
- report the old migration as superseded/pass in that exact case;
- leave unrelated epoch mismatches fail-closed;
- no account mutation, risk-threshold change, strategy change, order placement, live authority, or ML authority change;
- add regression tests for the exact successor and rejection cases.