### PR TITLE
Reject catastrophic terminal quotes before latest-price cache

### DIFF
--- a/paper_exit_price_integrity_guard.py
+++ b/paper_exit_price_integrity_guard.py
@@ -1,9 +1,14 @@
 """Fail-closed quote-integrity guard for paper exits.
 
 A paper position should never jump from the normal stop regime to a catastrophic
-single-tick exit without quote-integrity review. This module wraps the core full
-and partial exit boundaries and blocks only extreme adverse prices that are far
-outside the position's entry/peak context.
+single-tick exit without quote-integrity review. This module protects two
+independent boundaries:
+
+1. ``latest_price`` rejects a catastrophically implausible terminal 5-minute
+   close relative to recent same-symbol bars before that value is cached or
+   returned to position management.
+2. Full and partial paper exits retain the existing entry-anchored fail-closed
+   guard as a second independent safety layer.
 
 Paper-only safety control. It does not change signals, sizing, normal stops,
 profit taking, live authority, or ML authority.
@@ -13,13 +18,21 @@ from __future__ import annotations
 import functools
 import math
 import os
+import statistics
+import time
 from typing import Any, Dict
 
-VERSION = "paper-exit-price-integrity-2026-08-12-v1"
+VERSION = "paper-exit-price-integrity-2026-08-13-v2-source-plausibility"
 LONG_MIN_PRICE_RATIO = 0.40
 SHORT_MAX_PRICE_RATIO = 2.50
+SOURCE_MIN_PRIOR_BARS = 6
+SOURCE_RECENT_PRIOR_BARS = 24
+SOURCE_MIN_PRICE_RATIO = 0.40
+SOURCE_MAX_PRICE_RATIO = 2.50
+SOURCE_CACHE_TTL_SECONDS = 60
 _APPLIED_CORE_IDS: set[int] = set()
 _REGISTERED_APP_IDS: set[int] = set()
+_LAST_SOURCE_BLOCK: Dict[str, Any] = {}
 
 
 def _d(value: Any) -> Dict[str, Any]:
@@ -85,6 +98,95 @@ def anomaly(pos: Dict[str, Any], px: Any) -> Dict[str, Any] | None:
     return None
 
 
+def _source_issue(prices: Any) -> Dict[str, Any] | None:
+    try:
+        values = [float(value) for value in list(prices)]
+    except Exception:
+        return None
+    values = [value for value in values if math.isfinite(value) and value > 0.0]
+    if len(values) < SOURCE_MIN_PRIOR_BARS + 1:
+        return None
+
+    terminal = float(values[-1])
+    prior = values[:-1][-SOURCE_RECENT_PRIOR_BARS:]
+    if len(prior) < SOURCE_MIN_PRIOR_BARS:
+        return None
+    anchor = float(statistics.median(prior))
+    if not math.isfinite(anchor) or anchor <= 0.0:
+        return None
+
+    ratio = terminal / anchor
+    if ratio <= SOURCE_MIN_PRICE_RATIO or ratio >= SOURCE_MAX_PRICE_RATIO:
+        return {
+            "reason": "catastrophic_terminal_bar_outlier",
+            "price": terminal,
+            "recent_median_anchor": anchor,
+            "price_to_recent_median_ratio": ratio,
+            "prior_bars_used": len(prior),
+        }
+    return None
+
+
+def _mark_source_block(symbol: str, issue: Dict[str, Any]) -> None:
+    global _LAST_SOURCE_BLOCK
+    _LAST_SOURCE_BLOCK = {
+        **issue,
+        "symbol": str(symbol or "").upper().strip(),
+        "boundary": "latest_price",
+        "version": VERSION,
+        "blocked_at_epoch": time.time(),
+    }
+
+
+def _wrap_latest_price(core: Any) -> bool:
+    current = getattr(core, "latest_price", None)
+    download = getattr(core, "download_prices", None)
+    price_series = getattr(core, "price_series", None)
+    cache = getattr(core, "_price_cache", None)
+    if not callable(current) or not callable(download) or not callable(price_series) or not isinstance(cache, dict):
+        return False
+
+    marker = "_latest_price_paper_exit_price_integrity_version"
+    if getattr(current, marker, None) == VERSION:
+        return True
+    prior = getattr(current, "_latest_price_paper_exit_price_integrity_prior", current)
+
+    @functools.wraps(prior)
+    def wrapped(symbol):
+        key = str(symbol or "").upper().strip()
+        if not key:
+            return None
+        now = time.time()
+        data = cache.setdefault("data", {})
+        cached = data.get(key)
+        if isinstance(cached, dict) and now - _f(cached.get("ts"), 0.0) < SOURCE_CACHE_TTL_SECONDS:
+            cached_price = _f(cached.get("price"), 0.0)
+            if cached_price > 0.0:
+                return cached_price
+
+        try:
+            frame = download(key, period="1d", interval="5m")
+            prices = price_series(frame, "Close")
+            if len(prices) == 0:
+                return None
+            issue = _source_issue(prices)
+            if issue is not None:
+                _mark_source_block(key, issue)
+                return None
+            px = _f(prices[-1], 0.0)
+            if px <= 0.0:
+                return None
+            data[key] = {"ts": now, "price": px}
+            return px
+        except Exception:
+            return None
+
+    setattr(wrapped, marker, VERSION)
+    setattr(wrapped, "_latest_price_paper_exit_price_integrity_prior", prior)
+    setattr(core, "latest_price", wrapped)
+    return True
+
+
 def _mark(core: Any, symbol: str, row: Dict[str, Any], boundary: str) -> None:
     pf = _portfolio(core)
     risk = _d(pf.setdefault("risk_controls", {}))
@@ -145,9 +247,10 @@ def apply(core: Any = None) -> Dict[str, Any]:
     if not _paper_only():
         return {"status": "skipped", "overall": "pass", "version": VERSION, "reason": "paper_only"}
 
+    source = _wrap_latest_price(core)
     full = _wrap_boundary(core, "exit_position")
     partial = _wrap_boundary(core, "reduce_position")
-    if full or partial:
+    if source or full or partial:
         _APPLIED_CORE_IDS.add(id(core))
     return status_payload(core)
 
@@ -155,6 +258,8 @@ def apply(core: Any = None) -> Dict[str, Any]:
 def status_payload(core: Any = None) -> Dict[str, Any]:
     pf = _portfolio(core) if core is not None else {}
     risk = _d(pf.get("risk_controls"))
+    current_latest = getattr(core, "latest_price", None) if core is not None else None
+    source_installed = bool(getattr(current_latest, "_latest_price_paper_exit_price_integrity_version", None) == VERSION)
     return {
         "status": "ok" if core is not None and id(core) in _APPLIED_CORE_IDS else "pending",
         "overall": "pass" if core is not None and id(core) in _APPLIED_CORE_IDS else "warn",
@@ -163,6 +268,14 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "paper_only": True,
         "long_min_price_ratio": LONG_MIN_PRICE_RATIO,
         "short_max_price_ratio": SHORT_MAX_PRICE_RATIO,
+        "source_plausibility": {
+            "installed": source_installed,
+            "min_prior_bars": SOURCE_MIN_PRIOR_BARS,
+            "recent_prior_bars": SOURCE_RECENT_PRIOR_BARS,
+            "min_price_ratio": SOURCE_MIN_PRICE_RATIO,
+            "max_price_ratio": SOURCE_MAX_PRICE_RATIO,
+            "last_block": dict(_LAST_SOURCE_BLOCK) if _LAST_SOURCE_BLOCK else None,
+        },
         "active_block": risk.get("paper_exit_price_integrity_block"),
         "authority": {
             "fail_closed_quote_integrity_only": True,

--- a/paper_exit_price_integrity_guard.py
+++ b/paper_exit_price_integrity_guard.py
@@ -140,10 +140,9 @@ def _mark_source_block(symbol: str, issue: Dict[str, Any]) -> None:
 
 def _wrap_latest_price(core: Any) -> bool:
     current = getattr(core, "latest_price", None)
-    download = getattr(core, "download_prices", None)
     price_series = getattr(core, "price_series", None)
     cache = getattr(core, "_price_cache", None)
-    if not callable(current) or not callable(download) or not callable(price_series) or not isinstance(cache, dict):
+    if not callable(current) or not callable(price_series) or not isinstance(cache, dict):
         return False
 
     marker = "_latest_price_paper_exit_price_integrity_version"
@@ -165,6 +164,9 @@ def _wrap_latest_price(core: Any) -> bool:
                 return cached_price
 
         try:
+            download = getattr(core, "download_prices", None)
+            if not callable(download):
+                return None
             frame = download(key, period="1d", interval="5m")
             prices = price_series(frame, "Close")
             if len(prices) == 0:

--- a/test_paper_exit_source_price_plausibility.py
+++ b/test_paper_exit_source_price_plausibility.py
@@ -1,0 +1,54 @@
+import paper_exit_price_integrity_guard as guard
+
+
+class FakeCore:
+    def __init__(self, prices):
+        self.portfolio = {"positions": {}, "risk_controls": {}}
+        self._price_cache = {"data": {}}
+        self._prices = list(prices)
+        self.download_calls = 0
+
+    def latest_price(self, symbol):
+        raise AssertionError("wrapped latest_price must not delegate through the unsafe cache path")
+
+    def download_prices(self, symbol, period="5d", interval="5m"):
+        self.download_calls += 1
+        return list(self._prices)
+
+    def price_series(self, frame, column="Close"):
+        return list(frame)
+
+    def exit_position(self, symbol, px, *args, **kwargs):
+        return {"symbol": symbol, "price": px}
+
+    def reduce_position(self, symbol, px, *args, **kwargs):
+        return {"symbol": symbol, "price": px}
+
+
+def test_catastrophic_terminal_outlier_is_rejected_before_cache():
+    core = FakeCore([311.8, 312.2, 312.5, 312.7, 312.4, 312.9, 313.1, 18.401199340820312])
+    guard.apply(core)
+
+    assert core.latest_price("LRCX") is None
+    assert "LRCX" not in core._price_cache["data"]
+
+    status = guard.status_payload(core)
+    source = status["source_plausibility"]
+    assert source["installed"] is True
+    assert source["last_block"]["symbol"] == "LRCX"
+    assert source["last_block"]["boundary"] == "latest_price"
+    assert source["last_block"]["reason"] == "catastrophic_terminal_bar_outlier"
+    assert source["last_block"]["price"] == 18.401199340820312
+
+
+def test_plausible_terminal_price_is_returned_and_cached():
+    core = FakeCore([311.8, 312.2, 312.5, 312.7, 312.4, 312.9, 313.1, 313.25])
+    guard.apply(core)
+
+    assert core.latest_price("LRCX") == 313.25
+    assert core._price_cache["data"]["LRCX"]["price"] == 313.25
+    assert core.download_calls == 1
+
+    core._prices = [1.0]
+    assert core.latest_price("LRCX") == 313.25
+    assert core.download_calls == 1

--- a/tests/test_paper_exit_guard_dynamic_owner.py
+++ b/tests/test_paper_exit_guard_dynamic_owner.py
@@ -1,0 +1,35 @@
+import types
+
+import paper_exit_price_integrity_guard as guard
+
+
+def test_latest_price_uses_current_download_owner_after_installation():
+    calls = []
+
+    def original_latest(symbol):
+        return None
+
+    def download_v1(symbol, period="1d", interval="5m"):
+        calls.append(("v1", symbol))
+        return [100.0, 100.2, 99.9, 100.1, 100.0, 100.3, 100.2]
+
+    def download_v2(symbol, period="1d", interval="5m"):
+        calls.append(("v2", symbol))
+        return [200.0, 200.2, 199.9, 200.1, 200.0, 200.3, 200.2]
+
+    core = types.SimpleNamespace(
+        latest_price=original_latest,
+        download_prices=download_v1,
+        price_series=lambda frame, column="Close": frame,
+        _price_cache={"data": {}},
+    )
+
+    assert guard._wrap_latest_price(core) is True
+    assert core.latest_price("TEST") == 100.2
+    assert calls == [("v1", "TEST")]
+
+    core.download_prices = download_v2
+    core._price_cache["data"].clear()
+
+    assert core.latest_price("TEST") == 200.2
+    assert calls == [("v1", "TEST"), ("v2", "TEST")]


### PR DESCRIPTION
Surgical paper-only containment for the proven LRCX bad-quote path.

What changed:
- Extend the existing `paper_exit_price_integrity_guard` with a source-level `latest_price` wrapper.
- Preserve the existing 60-second per-symbol cache behavior for valid prices.
- On a fresh 1-day/5-minute fetch, compare the terminal close with the median of up to 24 recent same-symbol prior closes.
- If the terminal close is catastrophically implausible (`<= 0.40x` or `>= 2.50x` the recent median) and at least 6 prior bars exist, return `None` and do not cache the value.
- Keep the existing entry-anchored full/partial exit integrity guard unchanged as a second independent fail-closed layer.
- Add focused regression tests for the exact LRCX-style outlier rejection/not-cached behavior and normal valid-price cache behavior.

Why:
The canonical runtime proved LRCX reached `exit_position` with `18.401199340820312` against a verified `312.90` entry. The existing exit guard correctly halted. Root tracing showed `app.latest_price()` trusted the terminal yfinance 5-minute close and cached it before position management. This PR contains that bad value at the source boundary without altering the provider resilience owner or `app.py`.

Safety boundaries preserved:
- paper-only
- no account-state mutation
- no halt clearing
- no strategy/signal changes
- no stop/trail/risk-threshold changes
- no sizing changes
- no order-placement changes
- no live authority changes
- no ML authority changes
- no market-data resilience rewrite

PR only. Do not merge unless both authoritative repository CI workflows pass and the diff remains limited to the integrity guard plus focused regression coverage.