### PR TITLE
Validate fresh cached quotes before latest_price return

### DIFF
--- a/paper_exit_price_integrity_guard.py
+++ b/paper_exit_price_integrity_guard.py
@@ -127,6 +127,38 @@ def _source_issue(prices: Any) -> Dict[str, Any] | None:
     return None
 
 
+def _cached_source_issue(cached_price: float, prices: Any) -> Dict[str, Any] | None:
+    try:
+        values = [float(value) for value in list(prices)]
+    except Exception:
+        values = []
+    values = [value for value in values if math.isfinite(value) and value > 0.0]
+    prior = values[-SOURCE_RECENT_PRIOR_BARS:]
+    if len(prior) < SOURCE_MIN_PRIOR_BARS:
+        return {
+            "reason": "cached_price_plausibility_unverified",
+            "price": cached_price,
+            "prior_bars_used": len(prior),
+        }
+    anchor = float(statistics.median(prior))
+    if not math.isfinite(anchor) or anchor <= 0.0:
+        return {
+            "reason": "cached_price_plausibility_unverified",
+            "price": cached_price,
+            "prior_bars_used": len(prior),
+        }
+    ratio = cached_price / anchor
+    if ratio <= SOURCE_MIN_PRICE_RATIO or ratio >= SOURCE_MAX_PRICE_RATIO:
+        return {
+            "reason": "catastrophic_cached_price_outlier",
+            "price": cached_price,
+            "recent_median_anchor": anchor,
+            "price_to_recent_median_ratio": ratio,
+            "prior_bars_used": len(prior),
+        }
+    return None
+
+
 def _mark_source_block(symbol: str, issue: Dict[str, Any]) -> None:
     global _LAST_SOURCE_BLOCK
     _LAST_SOURCE_BLOCK = {
@@ -161,6 +193,27 @@ def _wrap_latest_price(core: Any) -> bool:
         if isinstance(cached, dict) and now - _f(cached.get("ts"), 0.0) < SOURCE_CACHE_TTL_SECONDS:
             cached_price = _f(cached.get("price"), 0.0)
             if cached_price > 0.0:
+                validated_version = str(cached.get("source_plausibility_validated_version") or "")
+                validated_price = _f(cached.get("source_plausibility_validated_price"), 0.0)
+                if validated_version == VERSION and validated_price == cached_price:
+                    return cached_price
+                try:
+                    download = getattr(core, "download_prices", None)
+                    if not callable(download):
+                        issue = {"reason": "cached_price_plausibility_unverified", "price": cached_price, "prior_bars_used": 0}
+                    else:
+                        frame = download(key, period="1d", interval="5m")
+                        prices = price_series(frame, "Close")
+                        issue = _cached_source_issue(cached_price, prices)
+                except Exception:
+                    issue = {"reason": "cached_price_plausibility_unverified", "price": cached_price, "prior_bars_used": 0}
+                if issue is not None:
+                    _mark_source_block(key, issue)
+                    data.pop(key, None)
+                    return None
+                cached["source_plausibility_validated_version"] = VERSION
+                cached["source_plausibility_validated_price"] = cached_price
+                cached["source_plausibility_validated_at"] = now
                 return cached_price
 
         try:
@@ -178,7 +231,13 @@ def _wrap_latest_price(core: Any) -> bool:
             px = _f(prices[-1], 0.0)
             if px <= 0.0:
                 return None
-            data[key] = {"ts": now, "price": px}
+            data[key] = {
+                "ts": now,
+                "price": px,
+                "source_plausibility_validated_version": VERSION,
+                "source_plausibility_validated_price": px,
+                "source_plausibility_validated_at": now,
+            }
             return px
         except Exception:
             return None

--- a/test_paper_exit_source_price_plausibility.py
+++ b/test_paper_exit_source_price_plausibility.py
@@ -1,3 +1,5 @@
+import time
+
 import paper_exit_price_integrity_guard as guard
 
 
@@ -46,9 +48,51 @@ def test_plausible_terminal_price_is_returned_and_cached():
     guard.apply(core)
 
     assert core.latest_price("LRCX") == 313.25
-    assert core._price_cache["data"]["LRCX"]["price"] == 313.25
+    cached = core._price_cache["data"]["LRCX"]
+    assert cached["price"] == 313.25
+    assert cached["source_plausibility_validated_version"] == guard.VERSION
+    assert cached["source_plausibility_validated_price"] == 313.25
     assert core.download_calls == 1
 
     core._prices = [1.0]
     assert core.latest_price("LRCX") == 313.25
+    assert core.download_calls == 1
+
+
+def test_poisoned_fresh_cached_qqq_price_is_blocked_before_return():
+    core = FakeCore([728.9, 729.4, 730.1, 730.5, 731.0, 730.7, 729.9, 730.2])
+    core._price_cache["data"]["QQQ"] = {
+        "ts": time.time(),
+        "price": 236.49000549316406,
+    }
+    guard.apply(core)
+
+    assert core.latest_price("QQQ") is None
+    assert "QQQ" not in core._price_cache["data"]
+    assert core.download_calls == 1
+
+    source = guard.status_payload(core)["source_plausibility"]
+    assert source["last_block"]["symbol"] == "QQQ"
+    assert source["last_block"]["boundary"] == "latest_price"
+    assert source["last_block"]["reason"] == "catastrophic_cached_price_outlier"
+    assert source["last_block"]["price"] == 236.49000549316406
+    assert source["last_block"]["price_to_recent_median_ratio"] < guard.SOURCE_MIN_PRICE_RATIO
+
+
+def test_valid_unvalidated_cache_is_checked_once_then_keeps_60_second_cache_behavior():
+    core = FakeCore([728.9, 729.4, 730.1, 730.5, 731.0, 730.7, 729.9, 730.2])
+    core._price_cache["data"]["QQQ"] = {
+        "ts": time.time(),
+        "price": 730.0,
+    }
+    guard.apply(core)
+
+    assert core.latest_price("QQQ") == 730.0
+    assert core.download_calls == 1
+    cached = core._price_cache["data"]["QQQ"]
+    assert cached["source_plausibility_validated_version"] == guard.VERSION
+    assert cached["source_plausibility_validated_price"] == 730.0
+
+    core._prices = [1.0]
+    assert core.latest_price("QQQ") == 730.0
     assert core.download_calls == 1


### PR DESCRIPTION
Surgical follow-up for Issue #76 after rejecting PRs #77 and #78.

What changed:
- Preserve the existing PR #56 `paper_exit_price_integrity_guard` module, version, paper-only gating, status route, dynamic `download_prices` ownership, fresh-fetch source validation, and downstream full/partial exit guards.
- Change only the fresh-cache branch in `_wrap_latest_price()` so a cached value is returned immediately only when validation provenance is bound to that exact price.
- A fresh unvalidated cache value is independently checked against recent same-symbol 5-minute bars using the existing 0.40x / 2.50x policy.
- If independent evidence is unavailable or the cached value is catastrophic, fail closed, record `_LAST_SOURCE_BLOCK`, evict the poisoned cache row, and return `None`.
- On successful validation, bind provenance to the exact cached price so subsequent hits within the existing 60-second TTL remain provider-free.
- Fresh values validated through the existing download path are cached with the same price-bound provenance.

Regression coverage:
- exact production-shaped QQQ cache poison `236.49000549316406` against normal recent bars around ~730 must return `None`, record `catastrophic_cached_price_outlier`, and evict the cache row;
- a valid unvalidated cached QQQ price is independently checked once, then preserves normal 60-second cache behavior without another provider call;
- existing LRCX terminal-source rejection and valid cache tests remain intact.

Safety boundaries:
- no strategy/sizing/normal stop or trailing changes;
- no risk threshold or halt-state changes;
- no account, trade, ledger, TEM, or UCTT history changes;
- paper-only; live authority unchanged; ML authority unchanged;
- downstream fail-closed exit guard unchanged.

Do not merge until the exact diff is reviewed and both authoritative repository CI workflows are green.