### PR TITLE
Fail closed on catastrophic persisted equity marks

### DIFF
--- a/paper_exit_price_integrity_guard.py
+++ b/paper_exit_price_integrity_guard.py
@@ -1,14 +1,16 @@
-"""Fail-closed quote-integrity guard for paper exits.
+"""Fail-closed quote-integrity guard for paper valuation and exits.
 
 A paper position should never jump from the normal stop regime to a catastrophic
-single-tick exit without quote-integrity review. This module protects two
-independent boundaries:
+single-tick valuation or exit without quote-integrity review. This module
+protects three independent boundaries:
 
 1. ``latest_price`` rejects a catastrophically implausible terminal 5-minute
    close relative to recent same-symbol bars before that value is cached or
    returned to position management.
-2. Full and partial paper exits retain the existing entry-anchored fail-closed
-   guard as a second independent safety layer.
+2. ``calculate_equity`` refuses to reuse a catastrophically implausible stored
+   ``last_price`` when no independently trusted fresh quote can be obtained.
+3. Full and partial paper exits retain the existing entry-anchored fail-closed
+   guard as a separate safety layer.
 
 Paper-only safety control. It does not change signals, sizing, normal stops,
 profit taking, live authority, or ML authority.
@@ -278,6 +280,66 @@ def _mark(core: Any, symbol: str, row: Dict[str, Any], boundary: str) -> None:
             pass
 
 
+def _wrap_calculate_equity(core: Any) -> bool:
+    current = getattr(core, "calculate_equity", None)
+    if not callable(current):
+        return False
+
+    marker = "_calculate_equity_paper_exit_price_integrity_version"
+    if getattr(current, marker, None) == VERSION:
+        return True
+    prior = getattr(current, "_calculate_equity_paper_exit_price_integrity_prior", current)
+
+    @functools.wraps(prior)
+    def wrapped(*args, **kwargs):
+        refresh_prices = kwargs.get("refresh_prices", args[0] if args else True)
+        pf = _portfolio(core)
+        positions = _d(pf.get("positions"))
+        for symbol, pos in list(positions.items()):
+            if not isinstance(pos, dict):
+                continue
+            stored_price = _f(pos.get("last_price", pos.get("entry", 0.0)), 0.0)
+            stored_issue = anomaly(pos, stored_price)
+            if stored_issue is None:
+                continue
+
+            if bool(refresh_prices):
+                trusted_price = None
+                latest = getattr(core, "latest_price", None)
+                if callable(latest):
+                    try:
+                        trusted_price = latest(symbol)
+                    except Exception:
+                        trusted_price = None
+                if trusted_price is not None and anomaly(pos, trusted_price) is None:
+                    # The original calculate_equity will immediately call the same
+                    # protected latest_price path again. The validated 60-second
+                    # cache makes that second call provider-free and lets the normal
+                    # owner update last_price/equity without this guard fabricating a
+                    # replacement mark.
+                    continue
+
+            issue = {
+                **stored_issue,
+                "stored_mark_reason": stored_issue.get("reason"),
+                "reason": "catastrophic_stored_mark_fallback_blocked",
+                "stored_price": stored_price,
+                "refresh_prices": bool(refresh_prices),
+            }
+            _mark(core, symbol, issue, "calculate_equity_fallback")
+            # Fail closed without invoking the original valuation path. This
+            # preserves the prior account snapshot until a trusted fresh quote is
+            # available rather than reusing or inventing a catastrophic mark.
+            return _f(pf.get("equity"), _f(pf.get("cash"), 0.0))
+
+        return prior(*args, **kwargs)
+
+    setattr(wrapped, marker, VERSION)
+    setattr(wrapped, "_calculate_equity_paper_exit_price_integrity_prior", prior)
+    setattr(core, "calculate_equity", wrapped)
+    return True
+
+
 def _wrap_boundary(core: Any, name: str) -> bool:
     current = getattr(core, name, None)
     if not callable(current):
@@ -309,9 +371,10 @@ def apply(core: Any = None) -> Dict[str, Any]:
         return {"status": "skipped", "overall": "pass", "version": VERSION, "reason": "paper_only"}
 
     source = _wrap_latest_price(core)
+    valuation = _wrap_calculate_equity(core)
     full = _wrap_boundary(core, "exit_position")
     partial = _wrap_boundary(core, "reduce_position")
-    if source or full or partial:
+    if source or valuation or full or partial:
         _APPLIED_CORE_IDS.add(id(core))
     return status_payload(core)
 
@@ -320,7 +383,9 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
     pf = _portfolio(core) if core is not None else {}
     risk = _d(pf.get("risk_controls"))
     current_latest = getattr(core, "latest_price", None) if core is not None else None
+    current_equity = getattr(core, "calculate_equity", None) if core is not None else None
     source_installed = bool(getattr(current_latest, "_latest_price_paper_exit_price_integrity_version", None) == VERSION)
+    valuation_installed = bool(getattr(current_equity, "_calculate_equity_paper_exit_price_integrity_version", None) == VERSION)
     return {
         "status": "ok" if core is not None and id(core) in _APPLIED_CORE_IDS else "pending",
         "overall": "pass" if core is not None and id(core) in _APPLIED_CORE_IDS else "warn",
@@ -336,6 +401,10 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
             "min_price_ratio": SOURCE_MIN_PRICE_RATIO,
             "max_price_ratio": SOURCE_MAX_PRICE_RATIO,
             "last_block": dict(_LAST_SOURCE_BLOCK) if _LAST_SOURCE_BLOCK else None,
+        },
+        "valuation_fallback": {
+            "installed": valuation_installed,
+            "fail_closed_on_catastrophic_stored_mark": True,
         },
         "active_block": risk.get("paper_exit_price_integrity_block"),
         "authority": {

--- a/test_paper_exit_source_price_plausibility.py
+++ b/test_paper_exit_source_price_plausibility.py
@@ -5,10 +5,17 @@ import paper_exit_price_integrity_guard as guard
 
 class FakeCore:
     def __init__(self, prices):
-        self.portfolio = {"positions": {}, "risk_controls": {}}
+        self.portfolio = {
+            "cash": 10000.0,
+            "equity": 10000.0,
+            "positions": {},
+            "risk_controls": {},
+        }
         self._price_cache = {"data": {}}
         self._prices = list(prices)
         self.download_calls = 0
+        self.calculate_calls = 0
+        self.save_calls = 0
 
     def latest_price(self, symbol):
         raise AssertionError("wrapped latest_price must not delegate through the unsafe cache path")
@@ -20,11 +27,32 @@ class FakeCore:
     def price_series(self, frame, column="Close"):
         return list(frame)
 
+    def calculate_equity(self, refresh_prices=True):
+        self.calculate_calls += 1
+        equity = float(self.portfolio.get("cash", 0.0))
+        for symbol, pos in list(self.portfolio.get("positions", {}).items()):
+            px = self.latest_price(symbol) if refresh_prices else None
+            if px is None:
+                px = float(pos.get("last_price", pos.get("entry", 0.0)))
+            pos["last_price"] = float(px)
+            shares = float(pos.get("shares", 0.0))
+            entry = float(pos.get("entry", 0.0))
+            if pos.get("side", "long") == "short":
+                margin = float(pos.get("margin", entry * shares))
+                equity += margin + ((entry - float(px)) * shares)
+            else:
+                equity += shares * float(px)
+        self.portfolio["equity"] = round(float(equity), 2)
+        return equity
+
     def exit_position(self, symbol, px, *args, **kwargs):
         return {"symbol": symbol, "price": px}
 
     def reduce_position(self, symbol, px, *args, **kwargs):
         return {"symbol": symbol, "price": px}
+
+    def save_state(self, state=None):
+        self.save_calls += 1
 
 
 def test_catastrophic_terminal_outlier_is_rejected_before_cache():
@@ -96,3 +124,69 @@ def test_valid_unvalidated_cache_is_checked_once_then_keeps_60_second_cache_beha
     core._prices = [1.0]
     assert core.latest_price("QQQ") == 730.0
     assert core.download_calls == 1
+
+
+def test_catastrophic_persisted_qqq_mark_recovers_only_through_trusted_latest_price():
+    core = FakeCore([716.8, 717.1, 717.4, 717.7, 717.5, 717.8, 717.9, 718.0])
+    core.portfolio.update({
+        "cash": 11578.035535712186,
+        "equity": 11680.54,
+        "positions": {
+            "QQQ": {
+                "side": "long",
+                "entry": 730.92,
+                "shares": 2.218803,
+                "last_price": 46.198091623192646,
+                "peak": 730.92,
+            }
+        },
+        "risk_controls": {},
+    })
+    guard.apply(core)
+
+    result = core.calculate_equity(refresh_prices=True)
+
+    assert core.download_calls == 1
+    assert core.calculate_calls == 1
+    assert core.portfolio["positions"]["QQQ"]["last_price"] == 718.0
+    assert result > 13100.0
+    status = guard.status_payload(core)
+    assert status["valuation_fallback"]["installed"] is True
+    assert status["active_block"] is None
+
+
+def test_catastrophic_persisted_qqq_mark_is_not_reused_without_trusted_refresh():
+    core = FakeCore([])
+    core.portfolio.update({
+        "cash": 11578.035535712186,
+        "equity": 11680.54,
+        "positions": {
+            "QQQ": {
+                "side": "long",
+                "entry": 730.92,
+                "shares": 2.218803,
+                "last_price": 46.198091623192646,
+                "peak": 730.92,
+            }
+        },
+        "risk_controls": {},
+    })
+    guard.apply(core)
+
+    result = core.calculate_equity(refresh_prices=True)
+
+    assert result == 11680.54
+    assert core.portfolio["equity"] == 11680.54
+    assert core.portfolio["positions"]["QQQ"]["last_price"] == 46.198091623192646
+    assert core.calculate_calls == 0
+    assert core.download_calls == 1
+    assert core.save_calls == 1
+
+    status = guard.status_payload(core)
+    assert status["valuation_fallback"]["installed"] is True
+    block = status["active_block"]
+    assert block["symbol"] == "QQQ"
+    assert block["boundary"] == "calculate_equity_fallback"
+    assert block["reason"] == "catastrophic_stored_mark_fallback_blocked"
+    assert block["stored_price"] == 46.198091623192646
+    assert core.portfolio["risk_controls"]["halted"] is True


### PR DESCRIPTION
Urgent operational follow-up for Issue #76 after PR #79 deployment exposed a second valuation bypass.

Production evidence at 2026-08-18 13:20 CDT:
- cash 11578.0355, equity 11680.54, only QQQ open with 2.218803 shares;
- account math implies QQQ was being marked near $46.20 versus $730.92 entry;
- `/paper/exit-price-integrity-status` remained installed/pass with no active source block;
- risk escalated to 37.717% intraday drawdown and 12.01% daily loss, triggering the absolute daily equity-loss halt.

Root cause proven in current `app.calculate_equity(refresh_prices=True)`: if protected `latest_price(symbol)` returns `None`, the function blindly falls back to persisted `pos['last_price']`, writes that fallback back to the position, recomputes equity, and feeds it into risk controls. A previously poisoned stored mark can therefore survive deployment and continue contaminating valuation even after the latest-price cache path is protected.

What this PR changes:
- stays inside the existing `paper_exit_price_integrity_guard.py` architecture;
- adds a narrow `calculate_equity` boundary wrapper;
- only intervenes when the persisted `last_price` is already catastrophic under the existing entry-anchored 0.40x/2.50x policy;
- when refresh is allowed, first requires a trusted price from the already-protected `latest_price` path; if a trusted price is available, the original valuation owner runs normally and updates state from the trusted cache;
- if no trusted price is available, fail closed before the original valuation function can reuse the catastrophic stored mark: preserve the prior account snapshot, emit an integrity block/halt diagnostic, and do not invent a replacement price;
- adds status visibility under `valuation_fallback.installed`.

Regression coverage uses the exact production-shaped QQQ case with stored mark ~46.1981. It proves both safe recovery through a trusted fresh quote and no reuse/no valuation mutation when trusted refresh is unavailable.

Safety boundaries preserved:
- no strategy, sizing, entry, stop, trail, or risk-threshold changes;
- no account/ledger/history rewrite or manual correction;
- no TEM/UCTT history change;
- paper-only; live authority unchanged; ML authority unchanged;
- PR #56/#79 source and downstream exit guards remain intact;
- the current runtime risk halt must not be cleared as part of this change.

Do not merge until the exact diff is reviewed and both authoritative repository workflows are green. Post-deploy validation must include `/paper/self-check`, `/paper/exit-price-integrity-status`, and a routine audit; the halt remains until clean trusted valuation evidence is established.