### PR TITLE
Block duplicate full exits at canonical pre-mutation boundary

### DIFF
--- a/.github/workflows/tem-duplicate-exit-runtime-guard-validation.yml
+++ b/.github/workflows/tem-duplicate-exit-runtime-guard-validation.yml
@@ -1,0 +1,22 @@
+name: TEM Duplicate Exit Runtime Guard Validation
+
+on:
+  pull_request:
+    paths:
+      - "paper_ledger_matched_exit_guard.py"
+      - "test_paper_ledger_matched_exit_runtime_guard.py"
+      - ".github/workflows/tem-duplicate-exit-runtime-guard-validation.yml"
+  workflow_dispatch:
+
+jobs:
+  tem-duplicate-exit-runtime-guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run exact canonical full-exit preflight regressions
+        run: python -m unittest -v test_paper_ledger_matched_exit_runtime_guard.py

--- a/paper_ledger_matched_exit_guard.py
+++ b/paper_ledger_matched_exit_guard.py
@@ -9,8 +9,8 @@ The runtime preflight is deliberately narrow:
 - it runs before the existing ``exit_position`` owner can mutate cash/P&L/state;
 - it uses the existing canonical JSONL reader and hash-chain verifier;
 - it fails closed on missing/unreadable/invalid canonical evidence;
-- it still permits a verified-snapshot baseline position when the canonical
-  ledger is healthy and contains no current-epoch entry for that inherited lot;
+- it includes an explicitly verified snapshot opening lot in canonical remaining
+  quantity so that inherited positions remain manageable but cannot be re-closed;
 - it does not alter partial exits, strategy, sizing, thresholds, live authority,
   or ML authority.
 
@@ -301,19 +301,21 @@ def analyze_ledger(pf: Dict[str, Any], core: Any = None) -> Dict[str, Any]:
     }
 
 
-def _verified_snapshot_baseline_position(pf: Dict[str, Any], symbol: str, side: str) -> bool:
+def _verified_snapshot_baseline_qty(pf: Dict[str, Any], symbol: str, side: str) -> float:
     epoch = _d(pf.get("paper_accounting_epoch"))
     if str(epoch.get("baseline_type") or "") != "verified_snapshot_with_open_position":
-        return False
+        return 0.0
     snapshot = _d(epoch.get("verified_snapshot_baseline"))
     if not bool(snapshot.get("verified", False)):
-        return False
+        return 0.0
     raw = _d(_d(snapshot.get("positions")).get(str(symbol or "").upper().strip()))
     if not raw:
-        return False
+        return 0.0
     snapshot_side = str(raw.get("side") or "long").lower().strip()
+    if snapshot_side != str(side or "long").lower().strip():
+        return 0.0
     snapshot_qty = _f(raw.get("qty", raw.get("shares")), 0.0)
-    return bool(snapshot_side == str(side or "long").lower().strip() and snapshot_qty > FULL_EXIT_EPSILON)
+    return snapshot_qty if snapshot_qty > FULL_EXIT_EPSILON else 0.0
 
 
 def _canonical_full_exit_preflight(core: Any, symbol: str, side: str, requested_qty: float) -> Dict[str, Any]:
@@ -381,25 +383,16 @@ def _canonical_full_exit_preflight(core: Any, symbol: str, side: str, requested_
         and str(row.get("symbol") or "").upper().strip() == sym
         and str(row.get("side") or "long").lower().strip() == side_key
     ]
+    baseline_qty = _verified_snapshot_baseline_qty(_portfolio(core), sym, side_key)
     entry_qty = sum(_f(row.get("shares"), 0.0) for row in relevant if str(row.get("action") or "").lower().strip() == "entry")
     exit_qty = sum(
         _f(row.get("shares"), 0.0)
         for row in relevant
         if str(row.get("action") or "").lower().strip() in {"partial_exit", "exit"}
     )
+    opening_qty = baseline_qty + entry_qty
 
-    if entry_qty <= FULL_EXIT_EPSILON:
-        if _verified_snapshot_baseline_position(_portfolio(core), sym, side_key):
-            return {
-                "allow": True,
-                "reason": "verified_snapshot_baseline_position_without_canonical_entry",
-                "symbol": sym,
-                "side": side_key,
-                "requested_qty": qty,
-                "accounting_epoch_id": epoch_id,
-                "canonical_entry_qty": 0.0,
-                "canonical_exit_qty": round(exit_qty, 9),
-            }
+    if opening_qty <= FULL_EXIT_EPSILON:
         return {
             "allow": False,
             "reason": "canonical_entry_missing_for_runtime_position",
@@ -407,12 +400,13 @@ def _canonical_full_exit_preflight(core: Any, symbol: str, side: str, requested_
             "side": side_key,
             "requested_qty": qty,
             "accounting_epoch_id": epoch_id,
+            "verified_snapshot_baseline_qty": round(baseline_qty, 9),
             "canonical_entry_qty": round(entry_qty, 9),
             "canonical_exit_qty": round(exit_qty, 9),
         }
 
-    remaining = entry_qty - exit_qty
-    tolerance = max(FULL_EXIT_EPSILON, abs(entry_qty) * 1e-9)
+    remaining = opening_qty - exit_qty
+    tolerance = max(FULL_EXIT_EPSILON, abs(opening_qty) * 1e-9)
     if remaining <= tolerance:
         return {
             "allow": False,
@@ -421,6 +415,7 @@ def _canonical_full_exit_preflight(core: Any, symbol: str, side: str, requested_
             "side": side_key,
             "requested_qty": qty,
             "accounting_epoch_id": epoch_id,
+            "verified_snapshot_baseline_qty": round(baseline_qty, 9),
             "canonical_entry_qty": round(entry_qty, 9),
             "canonical_exit_qty": round(exit_qty, 9),
             "canonical_remaining_qty": round(remaining, 9),
@@ -433,6 +428,7 @@ def _canonical_full_exit_preflight(core: Any, symbol: str, side: str, requested_
             "side": side_key,
             "requested_qty": round(qty, 9),
             "accounting_epoch_id": epoch_id,
+            "verified_snapshot_baseline_qty": round(baseline_qty, 9),
             "canonical_entry_qty": round(entry_qty, 9),
             "canonical_exit_qty": round(exit_qty, 9),
             "canonical_remaining_qty": round(remaining, 9),
@@ -444,6 +440,7 @@ def _canonical_full_exit_preflight(core: Any, symbol: str, side: str, requested_
         "side": side_key,
         "requested_qty": round(qty, 9),
         "accounting_epoch_id": epoch_id,
+        "verified_snapshot_baseline_qty": round(baseline_qty, 9),
         "canonical_entry_qty": round(entry_qty, 9),
         "canonical_exit_qty": round(exit_qty, 9),
         "canonical_remaining_qty": round(remaining, 9),

--- a/paper_ledger_matched_exit_guard.py
+++ b/paper_ledger_matched_exit_guard.py
@@ -1,8 +1,18 @@
-"""Matched-exit accounting guard for paper-ledger recovery.
+"""Matched-exit accounting guard for paper-ledger recovery and execution safety.
 
 Prevents unmatched/duplicate exits from creating synthetic cash during ledger
-reconstruction. This module is paper-only and changes accounting reconstruction
-and reporting only; it does not place orders or change strategy/risk authority.
+reconstruction and, at the live paper full-exit boundary, prevents stale runtime
+state from closing more quantity than the authoritative canonical execution
+ledger says remains open.
+
+The runtime preflight is deliberately narrow:
+- it runs before the existing ``exit_position`` owner can mutate cash/P&L/state;
+- it uses the existing canonical JSONL reader and hash-chain verifier;
+- it fails closed on missing/unreadable/invalid canonical evidence;
+- it still permits a verified-snapshot baseline position when the canonical
+  ledger is healthy and contains no current-epoch entry for that inherited lot;
+- it does not alter partial exits, strategy, sizing, thresholds, live authority,
+  or ML authority.
 
 A deliberately created clean accounting epoch is also a valid zero-trade ledger
 baseline when cash/equity/P&L and the canonical execution ledger all agree.
@@ -10,11 +20,15 @@ baseline when cash/equity/P&L and the canonical execution ledger all agree.
 from __future__ import annotations
 
 import datetime as dt
+import functools
+import os
 from typing import Any, Dict, List
 
-VERSION = "paper-ledger-matched-exit-guard-2026-08-10-v2-clean-epoch"
+VERSION = "paper-ledger-matched-exit-guard-2026-08-18-v3-runtime-preflight"
+FULL_EXIT_EPSILON = 1e-6
 _APPLIED = False
 _REGISTERED_APP_IDS: set[int] = set()
+_RUNTIME_GUARD_CORE_IDS: set[int] = set()
 
 
 def _d(value: Any) -> Dict[str, Any]:
@@ -287,6 +301,211 @@ def analyze_ledger(pf: Dict[str, Any], core: Any = None) -> Dict[str, Any]:
     }
 
 
+def _verified_snapshot_baseline_position(pf: Dict[str, Any], symbol: str, side: str) -> bool:
+    epoch = _d(pf.get("paper_accounting_epoch"))
+    if str(epoch.get("baseline_type") or "") != "verified_snapshot_with_open_position":
+        return False
+    snapshot = _d(epoch.get("verified_snapshot_baseline"))
+    if not bool(snapshot.get("verified", False)):
+        return False
+    raw = _d(_d(snapshot.get("positions")).get(str(symbol or "").upper().strip()))
+    if not raw:
+        return False
+    snapshot_side = str(raw.get("side") or "long").lower().strip()
+    snapshot_qty = _f(raw.get("qty", raw.get("shares")), 0.0)
+    return bool(snapshot_side == str(side or "long").lower().strip() and snapshot_qty > FULL_EXIT_EPSILON)
+
+
+def _canonical_full_exit_preflight(core: Any, symbol: str, side: str, requested_qty: float) -> Dict[str, Any]:
+    """Return a fail-closed canonical lifecycle decision for one paper full exit."""
+    sym = str(symbol or "").upper().strip()
+    side_key = str(side or "long").lower().strip()
+    qty = _f(requested_qty, 0.0)
+    if not sym or side_key not in {"long", "short"} or qty <= FULL_EXIT_EPSILON:
+        return {
+            "allow": False,
+            "reason": "canonical_full_exit_request_invalid",
+            "symbol": sym,
+            "side": side_key,
+            "requested_qty": qty,
+        }
+
+    try:
+        import canonical_execution_ledger as ledger
+        with ledger._LOCK:
+            file_exists = os.path.exists(ledger.LEDGER_FILE)
+            rows, parse_errors = ledger._read_rows()
+            if parse_errors:
+                return {
+                    "allow": False,
+                    "reason": "canonical_execution_ledger_unreadable_for_full_exit",
+                    "symbol": sym,
+                    "side": side_key,
+                    "requested_qty": qty,
+                    "errors": parse_errors[:3],
+                }
+            chain_valid, chain_errors = ledger._verify_rows(rows)
+            if rows and not chain_valid:
+                return {
+                    "allow": False,
+                    "reason": "canonical_execution_ledger_chain_invalid_for_full_exit",
+                    "symbol": sym,
+                    "side": side_key,
+                    "requested_qty": qty,
+                    "errors": chain_errors[:3],
+                }
+            epoch_id = str(ledger._epoch_id(core) or "")
+    except Exception as exc:
+        return {
+            "allow": False,
+            "reason": "canonical_execution_ledger_preflight_error",
+            "symbol": sym,
+            "side": side_key,
+            "requested_qty": qty,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+    if not file_exists:
+        return {
+            "allow": False,
+            "reason": "canonical_execution_ledger_missing_for_full_exit",
+            "symbol": sym,
+            "side": side_key,
+            "requested_qty": qty,
+            "accounting_epoch_id": epoch_id,
+        }
+
+    relevant = [
+        row for row in rows
+        if str(row.get("accounting_epoch_id") or "") == epoch_id
+        and str(row.get("symbol") or "").upper().strip() == sym
+        and str(row.get("side") or "long").lower().strip() == side_key
+    ]
+    entry_qty = sum(_f(row.get("shares"), 0.0) for row in relevant if str(row.get("action") or "").lower().strip() == "entry")
+    exit_qty = sum(
+        _f(row.get("shares"), 0.0)
+        for row in relevant
+        if str(row.get("action") or "").lower().strip() in {"partial_exit", "exit"}
+    )
+
+    if entry_qty <= FULL_EXIT_EPSILON:
+        if _verified_snapshot_baseline_position(_portfolio(core), sym, side_key):
+            return {
+                "allow": True,
+                "reason": "verified_snapshot_baseline_position_without_canonical_entry",
+                "symbol": sym,
+                "side": side_key,
+                "requested_qty": qty,
+                "accounting_epoch_id": epoch_id,
+                "canonical_entry_qty": 0.0,
+                "canonical_exit_qty": round(exit_qty, 9),
+            }
+        return {
+            "allow": False,
+            "reason": "canonical_entry_missing_for_runtime_position",
+            "symbol": sym,
+            "side": side_key,
+            "requested_qty": qty,
+            "accounting_epoch_id": epoch_id,
+            "canonical_entry_qty": round(entry_qty, 9),
+            "canonical_exit_qty": round(exit_qty, 9),
+        }
+
+    remaining = entry_qty - exit_qty
+    tolerance = max(FULL_EXIT_EPSILON, abs(entry_qty) * 1e-9)
+    if remaining <= tolerance:
+        return {
+            "allow": False,
+            "reason": "canonical_position_already_closed",
+            "symbol": sym,
+            "side": side_key,
+            "requested_qty": qty,
+            "accounting_epoch_id": epoch_id,
+            "canonical_entry_qty": round(entry_qty, 9),
+            "canonical_exit_qty": round(exit_qty, 9),
+            "canonical_remaining_qty": round(remaining, 9),
+        }
+    if qty > remaining + tolerance:
+        return {
+            "allow": False,
+            "reason": "requested_full_exit_exceeds_canonical_remaining_quantity",
+            "symbol": sym,
+            "side": side_key,
+            "requested_qty": round(qty, 9),
+            "accounting_epoch_id": epoch_id,
+            "canonical_entry_qty": round(entry_qty, 9),
+            "canonical_exit_qty": round(exit_qty, 9),
+            "canonical_remaining_qty": round(remaining, 9),
+        }
+    return {
+        "allow": True,
+        "reason": "canonical_remaining_quantity_allows_full_exit",
+        "symbol": sym,
+        "side": side_key,
+        "requested_qty": round(qty, 9),
+        "accounting_epoch_id": epoch_id,
+        "canonical_entry_qty": round(entry_qty, 9),
+        "canonical_exit_qty": round(exit_qty, 9),
+        "canonical_remaining_qty": round(remaining, 9),
+    }
+
+
+def _mark_runtime_full_exit_block(core: Any, decision: Dict[str, Any]) -> None:
+    pf = _portfolio(core)
+    risk = _d(pf.setdefault("risk_controls", {}))
+    diagnostic = {
+        **decision,
+        "boundary": "exit_position_pre_mutation",
+        "version": VERSION,
+        "blocked_local": _now(core),
+    }
+    risk["canonical_full_exit_preflight_block"] = diagnostic
+    risk["canonical_full_exit_preflight_active"] = True
+    if not bool(risk.get("halted", False)):
+        risk["halted"] = True
+        risk["halt_reason"] = "canonical execution lifecycle integrity halt"
+    pf["risk_controls"] = risk
+    save = getattr(core, "save_state", None)
+    if callable(save):
+        try:
+            save(pf)
+        except TypeError:
+            save()
+        except Exception:
+            pass
+
+
+def _install_runtime_full_exit_guard(core: Any) -> bool:
+    current = getattr(core, "exit_position", None)
+    if not callable(current):
+        return False
+    marker = "_canonical_full_exit_preflight_version"
+    if getattr(current, marker, None) == VERSION:
+        _RUNTIME_GUARD_CORE_IDS.add(id(core))
+        return True
+    prior = getattr(current, "_canonical_full_exit_preflight_prior", current)
+
+    @functools.wraps(prior)
+    def guarded(symbol, px, *args, **kwargs):
+        pf = _portfolio(core)
+        pos = _d(_d(pf.get("positions")).get(str(symbol or "").upper().strip()))
+        if not pos:
+            return prior(symbol, px, *args, **kwargs)
+        side = str(pos.get("side") or "long").lower().strip()
+        shares = _f(pos.get("shares", pos.get("qty")), 0.0)
+        decision = _canonical_full_exit_preflight(core, symbol, side, shares)
+        if not bool(decision.get("allow")):
+            _mark_runtime_full_exit_block(core, decision)
+            return None
+        return prior(symbol, px, *args, **kwargs)
+
+    setattr(guarded, marker, VERSION)
+    setattr(guarded, "_canonical_full_exit_preflight_prior", prior)
+    setattr(core, "exit_position", guarded)
+    _RUNTIME_GUARD_CORE_IDS.add(id(core))
+    return True
+
+
 def _economic_status(core: Any = None) -> Dict[str, Any]:
     pf = _portfolio(core)
     rebuilt = analyze_ledger(pf, core)
@@ -328,6 +547,8 @@ def apply(core: Any = None) -> Dict[str, Any]:
         accounting.reconstruct_from_ledger = analyze_ledger
         economics.status_payload = _economic_status
         economics.apply = _economic_status
+        if core is not None and not _install_runtime_full_exit_guard(core):
+            raise RuntimeError("core.exit_position_missing_for_canonical_full_exit_preflight")
         _APPLIED = True
     except Exception as exc:
         return {"status": "error", "overall": "fail", "version": VERSION, "error": f"{type(exc).__name__}: {exc}"}
@@ -336,12 +557,18 @@ def apply(core: Any = None) -> Dict[str, Any]:
 
 def status_payload(core: Any = None) -> Dict[str, Any]:
     rebuilt = analyze_ledger(_portfolio(core), core) if core is not None else {}
+    risk = _d(_portfolio(core).get("risk_controls")) if core is not None else {}
+    runtime_installed = bool(core is not None and id(core) in _RUNTIME_GUARD_CORE_IDS)
     return {
-        "status": "ok" if _APPLIED else "pending",
-        "overall": "pass" if _APPLIED else "warn",
+        "status": "ok" if _APPLIED and (core is None or runtime_installed) else "pending",
+        "overall": "pass" if _APPLIED and (core is None or runtime_installed) else "warn",
         "type": "paper_ledger_matched_exit_guard_status",
         "version": VERSION,
         "applied": _APPLIED,
+        "runtime_full_exit_guard_installed": runtime_installed,
+        "runtime_full_exit_guard_boundary": "exit_position_pre_mutation",
+        "runtime_full_exit_guard_fail_closed": True,
+        "runtime_full_exit_guard_block": risk.get("canonical_full_exit_preflight_block"),
         "coverage_complete": bool(rebuilt.get("coverage_complete")),
         "baseline_type": rebuilt.get("baseline_type"),
         "parsed_trade_rows": int(rebuilt.get("parsed_trade_rows") or 0),
@@ -350,7 +577,10 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "coverage_issues": _l(rebuilt.get("coverage_issues"))[:20],
         "reconstructed_cash": rebuilt.get("cash"),
         "authority": {
-            "paper_accounting_reconstruction_only": True,
+            "paper_accounting_reconstruction": True,
+            "blocks_duplicate_or_unmatched_full_exit_before_mutation": True,
+            "verified_snapshot_baseline_positions_remain_manageable": True,
+            "repairs_historical_state": False,
             "places_orders": False,
             "changes_strategy": False,
             "changes_thresholds": False,

--- a/test_paper_ledger_matched_exit_runtime_guard.py
+++ b/test_paper_ledger_matched_exit_runtime_guard.py
@@ -1,5 +1,9 @@
 import json
+import tempfile
 import types
+import unittest
+from pathlib import Path
+from unittest import mock
 
 import canonical_execution_ledger as ledger
 import paper_ledger_matched_exit_guard as guard
@@ -48,102 +52,107 @@ class FakeCore:
         return {"symbol": symbol, "price": px, "shares": shares, "reason": reason}
 
 
-def _set_ledger(tmp_path, monkeypatch):
-    path = tmp_path / "canonical_execution_ledger.jsonl"
-    monkeypatch.setattr(ledger, "LEDGER_FILE", str(path))
-    return path
+class CanonicalFullExitRuntimeGuardTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.path = Path(self.tempdir.name) / "canonical_execution_ledger.jsonl"
+        self.ledger_patch = mock.patch.object(ledger, "LEDGER_FILE", str(self.path))
+        self.ledger_patch.start()
+
+    def tearDown(self):
+        self.ledger_patch.stop()
+        self.tempdir.cleanup()
+
+    def test_literal_tem_second_full_exit_is_blocked_before_any_state_mutation(self):
+        core = FakeCore()
+        ids = iter([
+            "d647d8a0580b44edbab0224e6c339bfd",
+            "7b13d9194a23407f926667b2f48d4057",
+        ])
+        with mock.patch.object(ledger.uuid, "uuid4", side_effect=lambda: types.SimpleNamespace(hex=next(ids))):
+            ledger.append_execution("entry", "TEM", "long", 54.885, 29.640567, {}, core)
+            ledger.append_execution("exit", "TEM", "long", 53.105, 29.640567, {}, core)
+
+        rows_before = [json.loads(line) for line in self.path.read_text().splitlines()]
+        self.assertEqual(
+            [row["execution_id"] for row in rows_before],
+            [
+                "d647d8a0580b44edbab0224e6c339bfd",
+                "7b13d9194a23407f926667b2f48d4057",
+            ],
+        )
+
+        cash_before = core.portfolio["cash"]
+        applied = guard.apply(core)
+        self.assertTrue(applied["runtime_full_exit_guard_installed"])
+        result = core.exit_position("TEM", 52.905, "stop_loss")
+
+        self.assertIsNone(result)
+        self.assertEqual(core.exit_calls, 0)
+        self.assertEqual(core.portfolio["cash"], cash_before)
+        self.assertEqual(core.portfolio["positions"]["TEM"]["shares"], 29.640567)
+        self.assertEqual(core.save_calls, 1)
+
+        rows_after = [json.loads(line) for line in self.path.read_text().splitlines()]
+        self.assertEqual(rows_after, rows_before)
+
+        risk = core.portfolio["risk_controls"]
+        self.assertTrue(risk["halted"])
+        block = risk["canonical_full_exit_preflight_block"]
+        self.assertEqual(block["boundary"], "exit_position_pre_mutation")
+        self.assertEqual(block["symbol"], "TEM")
+        self.assertEqual(block["reason"], "canonical_position_already_closed")
+        self.assertEqual(block["canonical_remaining_qty"], 0.0)
+
+    def test_verified_snapshot_baseline_position_without_canonical_entry_remains_manageable(self):
+        self.path.write_text("")
+        core = FakeCore(symbol="LRCX", shares=3.42486, entry=312.90)
+        core.portfolio["paper_accounting_epoch"]["verified_snapshot_baseline"] = {
+            "verified": True,
+            "positions": {
+                "LRCX": {
+                    "side": "long",
+                    "qty": 3.42486,
+                    "entry_price": 312.90,
+                }
+            },
+        }
+
+        guard.apply(core)
+        result = core.exit_position("LRCX", 333.12, "target")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(core.exit_calls, 1)
+        self.assertNotIn("LRCX", core.portfolio["positions"])
+        self.assertIsNone(core.portfolio["risk_controls"].get("canonical_full_exit_preflight_block"))
+
+    def test_malformed_canonical_ledger_fails_closed_before_full_exit(self):
+        self.path.write_text("{not-json}\n")
+        core = FakeCore(symbol="QQQ", shares=2.218803, entry=730.92)
+        cash_before = core.portfolio["cash"]
+
+        guard.apply(core)
+        result = core.exit_position("QQQ", 718.0, "stop_loss")
+
+        self.assertIsNone(result)
+        self.assertEqual(core.exit_calls, 0)
+        self.assertEqual(core.portfolio["cash"], cash_before)
+        self.assertIn("QQQ", core.portfolio["positions"])
+        block = core.portfolio["risk_controls"]["canonical_full_exit_preflight_block"]
+        self.assertEqual(block["reason"], "canonical_execution_ledger_unreadable_for_full_exit")
+
+    def test_runtime_position_without_canonical_entry_or_verified_baseline_fails_closed(self):
+        self.path.write_text("")
+        core = FakeCore(symbol="QQQ", shares=2.218803, entry=730.92)
+
+        guard.apply(core)
+        result = core.exit_position("QQQ", 718.0, "stop_loss")
+
+        self.assertIsNone(result)
+        self.assertEqual(core.exit_calls, 0)
+        block = core.portfolio["risk_controls"]["canonical_full_exit_preflight_block"]
+        self.assertEqual(block["reason"], "canonical_entry_missing_for_runtime_position")
 
 
-def test_literal_tem_second_full_exit_is_blocked_before_any_state_mutation(tmp_path, monkeypatch):
-    path = _set_ledger(tmp_path, monkeypatch)
-    core = FakeCore()
-    ids = iter([
-        "d647d8a0580b44edbab0224e6c339bfd",
-        "7b13d9194a23407f926667b2f48d4057",
-    ])
-    monkeypatch.setattr(ledger.uuid, "uuid4", lambda: types.SimpleNamespace(hex=next(ids)))
-
-    ledger.append_execution("entry", "TEM", "long", 54.885, 29.640567, {}, core)
-    ledger.append_execution("exit", "TEM", "long", 53.105, 29.640567, {}, core)
-
-    rows_before = [json.loads(line) for line in path.read_text().splitlines()]
-    assert [row["execution_id"] for row in rows_before] == [
-        "d647d8a0580b44edbab0224e6c339bfd",
-        "7b13d9194a23407f926667b2f48d4057",
-    ]
-
-    cash_before = core.portfolio["cash"]
-    guard.apply(core)
-    result = core.exit_position("TEM", 52.905, "stop_loss")
-
-    assert result is None
-    assert core.exit_calls == 0
-    assert core.portfolio["cash"] == cash_before
-    assert core.portfolio["positions"]["TEM"]["shares"] == 29.640567
-    assert core.save_calls == 1
-
-    rows_after = [json.loads(line) for line in path.read_text().splitlines()]
-    assert rows_after == rows_before
-
-    risk = core.portfolio["risk_controls"]
-    assert risk["halted"] is True
-    block = risk["canonical_full_exit_preflight_block"]
-    assert block["boundary"] == "exit_position_pre_mutation"
-    assert block["symbol"] == "TEM"
-    assert block["reason"] == "canonical_position_already_closed"
-    assert block["canonical_remaining_qty"] == 0.0
-
-
-def test_verified_snapshot_baseline_position_without_canonical_entry_remains_manageable(tmp_path, monkeypatch):
-    path = _set_ledger(tmp_path, monkeypatch)
-    path.write_text("")
-    core = FakeCore(symbol="LRCX", shares=3.42486, entry=312.90)
-    core.portfolio["paper_accounting_epoch"]["verified_snapshot_baseline"] = {
-        "verified": True,
-        "positions": {
-            "LRCX": {
-                "side": "long",
-                "qty": 3.42486,
-                "entry_price": 312.90,
-            }
-        },
-    }
-
-    guard.apply(core)
-    result = core.exit_position("LRCX", 333.12, "target")
-
-    assert result is not None
-    assert core.exit_calls == 1
-    assert "LRCX" not in core.portfolio["positions"]
-    assert core.portfolio["risk_controls"].get("canonical_full_exit_preflight_block") is None
-
-
-def test_malformed_canonical_ledger_fails_closed_before_full_exit(tmp_path, monkeypatch):
-    path = _set_ledger(tmp_path, monkeypatch)
-    path.write_text("{not-json}\n")
-    core = FakeCore(symbol="QQQ", shares=2.218803, entry=730.92)
-    cash_before = core.portfolio["cash"]
-
-    guard.apply(core)
-    result = core.exit_position("QQQ", 718.0, "stop_loss")
-
-    assert result is None
-    assert core.exit_calls == 0
-    assert core.portfolio["cash"] == cash_before
-    assert "QQQ" in core.portfolio["positions"]
-    block = core.portfolio["risk_controls"]["canonical_full_exit_preflight_block"]
-    assert block["reason"] == "canonical_execution_ledger_unreadable_for_full_exit"
-
-
-def test_runtime_position_without_canonical_entry_or_verified_baseline_fails_closed(tmp_path, monkeypatch):
-    path = _set_ledger(tmp_path, monkeypatch)
-    path.write_text("")
-    core = FakeCore(symbol="QQQ", shares=2.218803, entry=730.92)
-
-    guard.apply(core)
-    result = core.exit_position("QQQ", 718.0, "stop_loss")
-
-    assert result is None
-    assert core.exit_calls == 0
-    block = core.portfolio["risk_controls"]["canonical_full_exit_preflight_block"]
-    assert block["reason"] == "canonical_entry_missing_for_runtime_position"
+if __name__ == "__main__":
+    unittest.main()

--- a/test_paper_ledger_matched_exit_runtime_guard.py
+++ b/test_paper_ledger_matched_exit_runtime_guard.py
@@ -63,6 +63,21 @@ class CanonicalFullExitRuntimeGuardTests(unittest.TestCase):
         self.ledger_patch.stop()
         self.tempdir.cleanup()
 
+    @staticmethod
+    def _verified_lrcx_core():
+        core = FakeCore(symbol="LRCX", shares=3.42486, entry=312.90)
+        core.portfolio["paper_accounting_epoch"]["verified_snapshot_baseline"] = {
+            "verified": True,
+            "positions": {
+                "LRCX": {
+                    "side": "long",
+                    "qty": 3.42486,
+                    "entry_price": 312.90,
+                }
+            },
+        }
+        return core
+
     def test_literal_tem_second_full_exit_is_blocked_before_any_state_mutation(self):
         core = FakeCore()
         ids = iter([
@@ -104,19 +119,9 @@ class CanonicalFullExitRuntimeGuardTests(unittest.TestCase):
         self.assertEqual(block["reason"], "canonical_position_already_closed")
         self.assertEqual(block["canonical_remaining_qty"], 0.0)
 
-    def test_verified_snapshot_baseline_position_without_canonical_entry_remains_manageable(self):
+    def test_verified_snapshot_baseline_position_without_canonical_exit_remains_manageable(self):
         self.path.write_text("")
-        core = FakeCore(symbol="LRCX", shares=3.42486, entry=312.90)
-        core.portfolio["paper_accounting_epoch"]["verified_snapshot_baseline"] = {
-            "verified": True,
-            "positions": {
-                "LRCX": {
-                    "side": "long",
-                    "qty": 3.42486,
-                    "entry_price": 312.90,
-                }
-            },
-        }
+        core = self._verified_lrcx_core()
 
         guard.apply(core)
         result = core.exit_position("LRCX", 333.12, "target")
@@ -125,6 +130,31 @@ class CanonicalFullExitRuntimeGuardTests(unittest.TestCase):
         self.assertEqual(core.exit_calls, 1)
         self.assertNotIn("LRCX", core.portfolio["positions"])
         self.assertIsNone(core.portfolio["risk_controls"].get("canonical_full_exit_preflight_block"))
+
+    def test_verified_snapshot_baseline_cannot_be_closed_twice_after_canonical_exit(self):
+        core = self._verified_lrcx_core()
+        with mock.patch.object(
+            ledger.uuid,
+            "uuid4",
+            return_value=types.SimpleNamespace(hex="5d89575302e74a0087af342a6b82d851"),
+        ):
+            ledger.append_execution("exit", "LRCX", "long", 333.12, 3.42486, {}, core)
+
+        rows_before = [json.loads(line) for line in self.path.read_text().splitlines()]
+        cash_before = core.portfolio["cash"]
+        guard.apply(core)
+        result = core.exit_position("LRCX", 332.50, "stale_restart_retry")
+
+        self.assertIsNone(result)
+        self.assertEqual(core.exit_calls, 0)
+        self.assertEqual(core.portfolio["cash"], cash_before)
+        self.assertIn("LRCX", core.portfolio["positions"])
+        self.assertEqual([json.loads(line) for line in self.path.read_text().splitlines()], rows_before)
+        block = core.portfolio["risk_controls"]["canonical_full_exit_preflight_block"]
+        self.assertEqual(block["reason"], "canonical_position_already_closed")
+        self.assertEqual(block["verified_snapshot_baseline_qty"], 3.42486)
+        self.assertEqual(block["canonical_exit_qty"], 3.42486)
+        self.assertEqual(block["canonical_remaining_qty"], 0.0)
 
     def test_malformed_canonical_ledger_fails_closed_before_full_exit(self):
         self.path.write_text("{not-json}\n")

--- a/test_paper_ledger_matched_exit_runtime_guard.py
+++ b/test_paper_ledger_matched_exit_runtime_guard.py
@@ -1,0 +1,149 @@
+import json
+import types
+
+import canonical_execution_ledger as ledger
+import paper_ledger_matched_exit_guard as guard
+
+
+class FakeCore:
+    def __init__(self, *, symbol="TEM", side="long", shares=29.640567, entry=54.885):
+        self.exit_calls = 0
+        self.save_calls = 0
+        self.portfolio = {
+            "cash": 11500.0,
+            "equity": 13000.0,
+            "accounting_epoch_id": "stable-paper-v2-20260812-verified01",
+            "paper_accounting_epoch": {
+                "id": "stable-paper-v2-20260812-verified01",
+                "epoch_id": "stable-paper-v2-20260812-verified01",
+                "baseline_type": "verified_snapshot_with_open_position",
+            },
+            "positions": {
+                symbol: {
+                    "side": side,
+                    "shares": shares,
+                    "entry": entry,
+                    "last_price": entry,
+                }
+            },
+            "risk_controls": {"halted": False, "halt_reason": ""},
+            "trades": [],
+        }
+
+    def local_ts_text(self):
+        return "2026-08-18 13:30:00 CDT"
+
+    def save_state(self, state=None):
+        self.save_calls += 1
+
+    def exit_position(self, symbol, px, reason, market_mode=None, extra=None):
+        self.exit_calls += 1
+        pos = self.portfolio["positions"].get(symbol)
+        if not pos:
+            return None
+        shares = float(pos.get("shares", 0.0))
+        if pos.get("side", "long") == "long":
+            self.portfolio["cash"] += shares * float(px)
+        del self.portfolio["positions"][symbol]
+        return {"symbol": symbol, "price": px, "shares": shares, "reason": reason}
+
+
+def _set_ledger(tmp_path, monkeypatch):
+    path = tmp_path / "canonical_execution_ledger.jsonl"
+    monkeypatch.setattr(ledger, "LEDGER_FILE", str(path))
+    return path
+
+
+def test_literal_tem_second_full_exit_is_blocked_before_any_state_mutation(tmp_path, monkeypatch):
+    path = _set_ledger(tmp_path, monkeypatch)
+    core = FakeCore()
+    ids = iter([
+        "d647d8a0580b44edbab0224e6c339bfd",
+        "7b13d9194a23407f926667b2f48d4057",
+    ])
+    monkeypatch.setattr(ledger.uuid, "uuid4", lambda: types.SimpleNamespace(hex=next(ids)))
+
+    ledger.append_execution("entry", "TEM", "long", 54.885, 29.640567, {}, core)
+    ledger.append_execution("exit", "TEM", "long", 53.105, 29.640567, {}, core)
+
+    rows_before = [json.loads(line) for line in path.read_text().splitlines()]
+    assert [row["execution_id"] for row in rows_before] == [
+        "d647d8a0580b44edbab0224e6c339bfd",
+        "7b13d9194a23407f926667b2f48d4057",
+    ]
+
+    cash_before = core.portfolio["cash"]
+    guard.apply(core)
+    result = core.exit_position("TEM", 52.905, "stop_loss")
+
+    assert result is None
+    assert core.exit_calls == 0
+    assert core.portfolio["cash"] == cash_before
+    assert core.portfolio["positions"]["TEM"]["shares"] == 29.640567
+    assert core.save_calls == 1
+
+    rows_after = [json.loads(line) for line in path.read_text().splitlines()]
+    assert rows_after == rows_before
+
+    risk = core.portfolio["risk_controls"]
+    assert risk["halted"] is True
+    block = risk["canonical_full_exit_preflight_block"]
+    assert block["boundary"] == "exit_position_pre_mutation"
+    assert block["symbol"] == "TEM"
+    assert block["reason"] == "canonical_position_already_closed"
+    assert block["canonical_remaining_qty"] == 0.0
+
+
+def test_verified_snapshot_baseline_position_without_canonical_entry_remains_manageable(tmp_path, monkeypatch):
+    path = _set_ledger(tmp_path, monkeypatch)
+    path.write_text("")
+    core = FakeCore(symbol="LRCX", shares=3.42486, entry=312.90)
+    core.portfolio["paper_accounting_epoch"]["verified_snapshot_baseline"] = {
+        "verified": True,
+        "positions": {
+            "LRCX": {
+                "side": "long",
+                "qty": 3.42486,
+                "entry_price": 312.90,
+            }
+        },
+    }
+
+    guard.apply(core)
+    result = core.exit_position("LRCX", 333.12, "target")
+
+    assert result is not None
+    assert core.exit_calls == 1
+    assert "LRCX" not in core.portfolio["positions"]
+    assert core.portfolio["risk_controls"].get("canonical_full_exit_preflight_block") is None
+
+
+def test_malformed_canonical_ledger_fails_closed_before_full_exit(tmp_path, monkeypatch):
+    path = _set_ledger(tmp_path, monkeypatch)
+    path.write_text("{not-json}\n")
+    core = FakeCore(symbol="QQQ", shares=2.218803, entry=730.92)
+    cash_before = core.portfolio["cash"]
+
+    guard.apply(core)
+    result = core.exit_position("QQQ", 718.0, "stop_loss")
+
+    assert result is None
+    assert core.exit_calls == 0
+    assert core.portfolio["cash"] == cash_before
+    assert "QQQ" in core.portfolio["positions"]
+    block = core.portfolio["risk_controls"]["canonical_full_exit_preflight_block"]
+    assert block["reason"] == "canonical_execution_ledger_unreadable_for_full_exit"
+
+
+def test_runtime_position_without_canonical_entry_or_verified_baseline_fails_closed(tmp_path, monkeypatch):
+    path = _set_ledger(tmp_path, monkeypatch)
+    path.write_text("")
+    core = FakeCore(symbol="QQQ", shares=2.218803, entry=730.92)
+
+    guard.apply(core)
+    result = core.exit_position("QQQ", 718.0, "stop_loss")
+
+    assert result is None
+    assert core.exit_calls == 0
+    block = core.portfolio["risk_controls"]["canonical_full_exit_preflight_block"]
+    assert block["reason"] == "canonical_entry_missing_for_runtime_position"


### PR DESCRIPTION
Fixes the remaining prospective TEM duplicate-full-exit defect tracked in Issue #66 without rewriting historical rows.

Why this exists:
- canonical execution ledger is durable before the state trade mirror;
- `app.exit_position()` mutates cash/P&L/position before `record_trade()`;
- after a restart with stale persisted state, a symbol already fully closed canonically can appear open again in runtime state and be closed a second time.

This PR keeps the established canonical ledger API/file/hash-chain intact and upgrades the already-wired `paper_ledger_matched_exit_guard` so its existing startup `apply(core)` installs one narrow full-exit preflight before the underlying `exit_position` mutation owner runs.

Preflight behavior:
- reads `canonical_execution_ledger.jsonl` with the existing `_read_rows()` and `_verify_rows()` semantics;
- filters the current accounting epoch, symbol, and side;
- allows a full exit only when canonical remaining quantity can cover the requested state quantity;
- blocks when canonical quantity is already zero or requested quantity exceeds canonical remaining quantity;
- fails closed on missing, unreadable, malformed, or hash-invalid canonical evidence;
- preserves manageability for the explicitly verified snapshot opening lot when the ledger is healthy and contains no canonical current-epoch entry for that inherited position;
- does not change partial exits.

Exact regression:
- TEM entry `d647d8a0580b44edbab0224e6c339bfd`, 29.640567 @ 54.885;
- TEM first full exit `7b13d9194a23407f926667b2f48d4057`, 29.640567 @ 53.105;
- stale runtime state still containing TEM then attempts another full exit @ 52.905;
- expected result: no base exit call, no cash mutation, no position deletion, no new canonical row, and a fail-closed diagnostic/halt marker.

Additional regressions prove:
- verified-snapshot LRCX opening lot with no canonical entry remains manageable;
- malformed canonical ledger blocks a full exit before mutation;
- a non-baseline runtime position with no canonical entry blocks rather than silently proceeding.

Safety boundaries:
- paper-only;
- no strategy, scanner, score, sizing, exposure, stop, trail, or risk-threshold changes;
- no account repair or historical TEM/UCTT/LRCX row rewrite;
- no canonical ledger filename/API/hash-chain redesign;
- no live or ML authority change;
- current risk halt remains untouched.

A dedicated dependency-free unit workflow is included so the literal TEM lifecycle regression runs on this PR in addition to the two authoritative repository workflows and startup smoke. Do not merge unless all three are green and the exact diff remains narrow.