### PR TITLE
Guard fresh-day risk baseline initialization

### DIFF
--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-12-v26-clean-epoch-successor-compatibility"
+VERSION = "data-integrity-startup-bridge-2026-08-19-v27-fresh-risk-day-baseline"
 MODULES = (
     "final_daily_audit_compactor",
     "daily_audit_entry_count_bridge",
@@ -43,6 +43,10 @@ MODULES = (
     # Final accounting adapter so the new epoch can begin from verified cash plus
     # the restored open LRCX lot and all future executions remain canonical.
     "verified_snapshot_accounting_baseline",
+    # Issue #82 fresh-day gate: never initialize a new risk day from a
+    # non-finite/non-positive persisted valuation.  This guard is prospective and
+    # never rewrites an already-initialized current day.
+    "fresh_risk_day_baseline_guard",
     "absolute_daily_halt_lifecycle_guard",
     "administrative_halt_classification_guard",
     "clean_epoch_validation_release",

--- a/fresh_risk_day_baseline_guard.py
+++ b/fresh_risk_day_baseline_guard.py
@@ -1,0 +1,207 @@
+"""Fail closed until a fresh risk day has a sane current equity baseline.
+
+Issue #82 requires the normal next-day reset to initialize ``day_start_equity``
+and ``day_peak_equity`` from a sane protected valuation.  The legacy
+``get_risk_controls`` reset used the first persisted ``portfolio['equity']`` it
+saw on a new date without validating it.  A contaminated/non-positive persisted
+value could therefore become the new day's baseline before valuation recovery,
+and the later ``0.01`` arithmetic floor could manufacture an enormous loss
+percentage and latch a false hard halt.
+
+This guard is intentionally prospective and fail-closed:
+
+* a new-day reset is deferred while the candidate equity is non-finite or <= $1;
+* risk metrics are not recomputed from that invalid candidate while deferred;
+* once a sane current equity reaches the normal update boundary, the ordinary
+  daily reset is allowed to initialize from that value;
+* an already-initialized current day is never rewritten, so this module does not
+  clear today's halt or rewrite today's peak after the fact.
+
+No strategy, sizing, risk thresholds, accounting history, live authority, ML
+authority, or order-placement behavior is changed.
+"""
+from __future__ import annotations
+
+import functools
+import math
+from typing import Any, Dict
+
+VERSION = "fresh-risk-day-baseline-guard-2026-08-19-v1"
+MIN_SANE_EQUITY = 1.0
+_APPLIED_CORE_IDS: set[int] = set()
+_REGISTERED_APP_IDS: set[int] = set()
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        number = float(value)
+    except Exception:
+        return default
+    return number if math.isfinite(number) else default
+
+
+def _today(core: Any) -> str:
+    try:
+        return str(core.today_key())
+    except Exception:
+        return ""
+
+
+def _sane_equity(value: Any) -> bool:
+    return _f(value, 0.0) > MIN_SANE_EQUITY
+
+
+def _mark_pending(rc: Dict[str, Any], candidate: Any, source: str) -> None:
+    rc["fresh_day_reset_pending"] = True
+    rc["fresh_day_reset_pending_reason"] = "sane_current_equity_required"
+    rc["fresh_day_reset_candidate_equity"] = _f(candidate, 0.0)
+    rc["fresh_day_reset_candidate_source"] = source
+    rc["fresh_day_reset_guard_version"] = VERSION
+
+
+def _clear_pending(rc: Dict[str, Any], source: str) -> None:
+    rc.pop("fresh_day_reset_pending", None)
+    rc.pop("fresh_day_reset_pending_reason", None)
+    rc.pop("fresh_day_reset_candidate_equity", None)
+    rc.pop("fresh_day_reset_candidate_source", None)
+    rc["fresh_day_reset_guard_version"] = VERSION
+    rc["fresh_day_reset_source"] = source
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    if core is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+
+    get_current = getattr(core, "get_risk_controls", None)
+    update_current = getattr(core, "update_daily_risk_controls", None)
+    default_factory = getattr(core, "default_risk_controls", None)
+    if not callable(get_current) or not callable(update_current) or not callable(default_factory):
+        return {
+            "status": "error",
+            "overall": "fail",
+            "version": VERSION,
+            "error": "required_risk_control_boundaries_missing",
+        }
+
+    if getattr(get_current, "_fresh_risk_day_baseline_version", None) == VERSION:
+        _APPLIED_CORE_IDS.add(id(core))
+        return status_payload(core)
+
+    prior_get = getattr(get_current, "_fresh_risk_day_baseline_prior", get_current)
+    prior_update = getattr(update_current, "_fresh_risk_day_baseline_prior", update_current)
+
+    @functools.wraps(prior_get)
+    def guarded_get_risk_controls():
+        portfolio = _d(getattr(core, "portfolio", {}))
+        rc = portfolio.setdefault("risk_controls", default_factory())
+        if not isinstance(rc, dict):
+            rc = default_factory()
+            portfolio["risk_controls"] = rc
+
+        today = _today(core)
+        if today and str(rc.get("date") or "") != today:
+            candidate = portfolio.get("equity")
+            if not _sane_equity(candidate):
+                _mark_pending(rc, candidate, "portfolio.equity")
+                return rc
+
+        out = prior_get()
+        if isinstance(out, dict) and today and str(out.get("date") or "") == today:
+            if _sane_equity(out.get("day_start_equity")) and _sane_equity(out.get("day_peak_equity")):
+                _clear_pending(out, "normal_get_risk_controls_reset")
+        return out
+
+    @functools.wraps(prior_update)
+    def guarded_update_daily_risk_controls(equity):
+        portfolio = _d(getattr(core, "portfolio", {}))
+        rc = portfolio.setdefault("risk_controls", default_factory())
+        if not isinstance(rc, dict):
+            rc = default_factory()
+            portfolio["risk_controls"] = rc
+
+        today = _today(core)
+        if today and str(rc.get("date") or "") != today:
+            if not _sane_equity(equity):
+                _mark_pending(rc, equity, "update_daily_risk_controls.argument")
+                return rc
+
+            # This is the normal new-day reset, performed only when the valuation
+            # boundary itself supplies a sane current equity.  It is not a repair
+            # of an already-initialized current day.
+            fresh = default_factory()
+            fresh["date"] = today
+            fresh["day_start_equity"] = float(equity)
+            fresh["day_peak_equity"] = float(equity)
+            _clear_pending(fresh, "update_daily_risk_controls.argument")
+            portfolio["risk_controls"] = fresh
+
+        return prior_update(equity)
+
+    guarded_get_risk_controls._fresh_risk_day_baseline_version = VERSION  # type: ignore[attr-defined]
+    guarded_get_risk_controls._fresh_risk_day_baseline_prior = prior_get  # type: ignore[attr-defined]
+    guarded_update_daily_risk_controls._fresh_risk_day_baseline_version = VERSION  # type: ignore[attr-defined]
+    guarded_update_daily_risk_controls._fresh_risk_day_baseline_prior = prior_update  # type: ignore[attr-defined]
+
+    core.get_risk_controls = guarded_get_risk_controls
+    core.update_daily_risk_controls = guarded_update_daily_risk_controls
+    _APPLIED_CORE_IDS.add(id(core))
+    return status_payload(core)
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    installed = bool(
+        core is not None
+        and getattr(getattr(core, "get_risk_controls", None), "_fresh_risk_day_baseline_version", None) == VERSION
+        and getattr(getattr(core, "update_daily_risk_controls", None), "_fresh_risk_day_baseline_version", None) == VERSION
+    )
+    portfolio = _d(getattr(core, "portfolio", {})) if core is not None else {}
+    rc = _d(portfolio.get("risk_controls"))
+    return {
+        "status": "ok" if installed else "pending",
+        "overall": "pass" if installed else "warn",
+        "type": "fresh_risk_day_baseline_guard_status",
+        "version": VERSION,
+        "installed": installed,
+        "prospective_only": True,
+        "current_day_rewrite": False,
+        "minimum_sane_equity": MIN_SANE_EQUITY,
+        "current_equity_sane": _sane_equity(portfolio.get("equity")),
+        "day_start_equity_sane": _sane_equity(rc.get("day_start_equity")),
+        "day_peak_equity_sane": _sane_equity(rc.get("day_peak_equity")),
+        "fresh_day_reset_pending": bool(rc.get("fresh_day_reset_pending", False)),
+        "authority": {
+            "risk_correctness_only": True,
+            "changes_risk_thresholds": False,
+            "changes_strategy": False,
+            "changes_sizing": False,
+            "places_orders": False,
+            "changes_live_or_ml_authority": False,
+            "edits_historical_accounting": False,
+            "clears_current_day_halt": False,
+            "rewrites_current_day_peak": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    result = apply(core)
+    if flask_app is None:
+        return result
+    app_id = id(flask_app)
+    if app_id not in _REGISTERED_APP_IDS:
+        from flask import jsonify
+
+        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+        path = "/paper/fresh-risk-day-baseline-guard-status"
+        if path not in existing:
+            flask_app.add_url_rule(
+                path,
+                "fresh_risk_day_baseline_guard_status",
+                lambda: jsonify(status_payload(core)),
+            )
+        _REGISTERED_APP_IDS.add(app_id)
+    return status_payload(core)

--- a/test_fresh_risk_day_baseline_guard.py
+++ b/test_fresh_risk_day_baseline_guard.py
@@ -1,0 +1,141 @@
+import importlib
+
+import fresh_risk_day_baseline_guard as guard
+
+
+class FakeCore:
+    def __init__(self):
+        self.portfolio = {
+            "equity": -26064.31,
+            "risk_controls": {
+                "date": "2026-08-18",
+                "day_start_equity": 13274.84,
+                "day_peak_equity": 13274.84,
+                "halted": True,
+                "halt_reason": "daily loss limit hit (3.0%)",
+            },
+        }
+
+    def today_key(self):
+        return "2026-08-19"
+
+    def default_risk_controls(self):
+        return {
+            "date": self.today_key(),
+            "day_start_equity": 10000.0,
+            "day_peak_equity": 10000.0,
+            "day_pnl_pct": 0.0,
+            "daily_loss_pct": 0.0,
+            "daily_drawdown_pct": 0.0,
+            "intraday_drawdown_pct": 0.0,
+            "halted": False,
+            "halt_reason": "",
+            "self_defense_active": False,
+            "self_defense_reason": "",
+            "cooldowns": {},
+        }
+
+    def get_risk_controls(self):
+        rc = self.portfolio.setdefault("risk_controls", self.default_risk_controls())
+        if rc.get("date") != self.today_key():
+            current_equity = float(self.portfolio.get("equity", 10000.0))
+            rc.clear()
+            rc.update(self.default_risk_controls())
+            rc["day_start_equity"] = current_equity
+            rc["day_peak_equity"] = current_equity
+        return rc
+
+    def update_daily_risk_controls(self, equity):
+        rc = self.get_risk_controls()
+        equity = float(equity)
+        start = max(float(rc.get("day_start_equity", equity)), 0.01)
+        old_peak = max(float(rc.get("day_peak_equity", equity)), 0.01)
+        peak = max(old_peak, equity, 0.01)
+        rc["day_peak_equity"] = peak
+        rc["day_pnl_pct"] = round(((equity - start) / start) * 100.0, 3)
+        rc["daily_loss_pct"] = round(max(0.0, ((start - equity) / start) * 100.0), 3)
+        return rc
+
+
+def _fresh_module():
+    return importlib.reload(guard)
+
+
+def test_invalid_persisted_equity_defers_new_day_reset_without_point_zero_one_baseline():
+    module = _fresh_module()
+    core = FakeCore()
+    result = module.apply(core)
+    assert result["overall"] == "pass"
+
+    rc = core.get_risk_controls()
+    assert rc["date"] == "2026-08-18"
+    assert rc["day_start_equity"] == 13274.84
+    assert rc["day_peak_equity"] == 13274.84
+    assert rc["fresh_day_reset_pending"] is True
+    assert rc["fresh_day_reset_candidate_equity"] == -26064.31
+
+
+def test_invalid_update_candidate_does_not_manufacture_huge_loss_or_rewrite_baseline():
+    module = _fresh_module()
+    core = FakeCore()
+    module.apply(core)
+
+    rc = core.update_daily_risk_controls(-26064.31)
+    assert rc["date"] == "2026-08-18"
+    assert rc["day_start_equity"] == 13274.84
+    assert rc["day_peak_equity"] == 13274.84
+    assert rc.get("day_pnl_pct") is None
+    assert rc["fresh_day_reset_pending"] is True
+
+
+def test_sane_update_candidate_performs_normal_new_day_reset_from_current_equity():
+    module = _fresh_module()
+    core = FakeCore()
+    module.apply(core)
+
+    rc = core.update_daily_risk_controls(13250.25)
+    assert rc["date"] == "2026-08-19"
+    assert rc["day_start_equity"] == 13250.25
+    assert rc["day_peak_equity"] == 13250.25
+    assert rc["day_pnl_pct"] == 0.0
+    assert rc["daily_loss_pct"] == 0.0
+    assert rc["halted"] is False
+    assert rc["halt_reason"] == ""
+    assert rc["fresh_day_reset_source"] == "update_daily_risk_controls.argument"
+
+
+def test_sane_portfolio_equity_allows_legacy_reset_path():
+    module = _fresh_module()
+    core = FakeCore()
+    core.portfolio["equity"] = 13190.5
+    module.apply(core)
+
+    rc = core.get_risk_controls()
+    assert rc["date"] == "2026-08-19"
+    assert rc["day_start_equity"] == 13190.5
+    assert rc["day_peak_equity"] == 13190.5
+    assert rc["halted"] is False
+    assert rc["fresh_day_reset_source"] == "normal_get_risk_controls_reset"
+
+
+def test_already_initialized_current_day_is_never_rewritten():
+    module = _fresh_module()
+    core = FakeCore()
+    core.portfolio["risk_controls"] = {
+        "date": "2026-08-19",
+        "day_start_equity": -26064.31,
+        "day_peak_equity": 0.01,
+        "day_pnl_pct": -260643183.249,
+        "daily_loss_pct": 0.0,
+        "intraday_drawdown_pct": 0.0,
+        "halted": True,
+        "halt_reason": "daily loss limit hit (3.0%)",
+    }
+    core.portfolio["equity"] = 13200.0
+    module.apply(core)
+
+    rc = core.get_risk_controls()
+    assert rc["day_start_equity"] == -26064.31
+    assert rc["day_peak_equity"] == 0.01
+    assert rc["halted"] is True
+    assert rc["halt_reason"] == "daily loss limit hit (3.0%)"


### PR DESCRIPTION
## What changed
- added a prospective fresh-risk-day baseline guard at the existing risk-control boundaries
- defer a new-day reset when the candidate equity is non-finite or <= $1 instead of allowing the legacy `0.01` arithmetic floor to manufacture a catastrophic loss percentage
- allow the ordinary new-day reset only when a sane current equity reaches the normal valuation/update boundary
- explicitly preserve an already-initialized current day; the guard does not clear today's halt or rewrite today's peak
- registered the guard in the deterministic data-integrity startup bridge
- added regressions for invalid persisted equity, invalid update equity, sane rollover, sane legacy reset, and non-rewrite of the already-contaminated current day

## Root cause
`app.get_risk_controls()` initializes a fresh day directly from the first persisted `portfolio['equity']` it observes. It does not validate that value before assigning it to both `day_start_equity` and `day_peak_equity`. `update_daily_risk_controls()` later applies a `0.01` floor for percentage arithmetic. On 2026-08-19 the persisted account state was `-26064.31`; the fresh-day state therefore became `day_start_equity=-26064.31`, `day_peak_equity=0.01`, and an enormous negative `day_pnl_pct`, latching a false 3% daily-loss halt even though current daily/intraday/realized loss metrics were 0.0%.

## Scope / authority
This maps directly to Issue #82's failed fresh-risk-day proof. It changes no strategy, sizing, risk threshold, live authority, ML authority, accounting history, or order-placement behavior. It is fail-closed and prospective only.

## Validation
Unit regressions are included on the branch. CI should run them before merge. Runtime acceptance still requires a future normal day reset from a sane protected valuation and a clean forward session; this PR intentionally does not repair the already-initialized 2026-08-19 risk state.