### PR TITLE
Stable Paper Core v3 Stage A: canonical shadow state models

### DIFF
--- a/stable_paper_core_v3_contract.json
+++ b/stable_paper_core_v3_contract.json
@@ -1,0 +1,42 @@
+{
+  "version": "stable-paper-core-v3-stage-a-2026-08-19-v1",
+  "issue": 84,
+  "stage": "A",
+  "policy": {
+    "shadow_only": true,
+    "authoritative_runtime_source": false,
+    "places_orders": false,
+    "reads_market_data": false,
+    "reads_state_file": false,
+    "writes_state_file": false,
+    "changes_strategy": false,
+    "changes_thresholds": false,
+    "changes_risk_or_sizing": false,
+    "changes_live_or_ml_authority": false,
+    "historical_accounting_rewrite": false,
+    "requires_parity_before_authoritative_cutover": true
+  },
+  "target_owners": {
+    "portfolio_state": "trading.state.PortfolioSnapshot",
+    "risk_state": "trading.state.RiskStateSnapshot",
+    "persistence": "trading.state.StateStore",
+    "execution_ledger": "canonical_execution_ledger.py",
+    "valuation": "future_stage_b",
+    "accounting_projection": "future_stage_e"
+  },
+  "invariants": [
+    "canonical protected equity is finite and positive",
+    "risk day_start_equity and day_peak_equity are finite and positive",
+    "risk day_peak_equity cannot be below day_start_equity at validated snapshot boundary",
+    "position symbols are unique",
+    "position quantities and prices are positive",
+    "execution ledger row count is non-negative",
+    "Stage A StateStore has no file I/O or write authority"
+  ],
+  "cutover_blocked_until": [
+    "Issue #82 fresh-day acceptance passes prospectively",
+    "Stage B deterministic valuation parity passes",
+    "Stage C risk-engine parity passes",
+    "Stage D persistence transaction parity passes"
+  ]
+}

--- a/test_stable_paper_core_v3_stage_a.py
+++ b/test_stable_paper_core_v3_stage_a.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import ast
+import json
+import unittest
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+from trading.state import (
+    CanonicalStateSnapshot,
+    PortfolioSnapshot,
+    PositionSnapshot,
+    RiskStateSnapshot,
+    StateStore,
+)
+
+ROOT = Path(__file__).resolve().parent
+
+
+class StablePaperCoreStageATests(unittest.TestCase):
+    def test_contract_is_shadow_only(self) -> None:
+        contract = json.loads((ROOT / "stable_paper_core_v3_contract.json").read_text(encoding="utf-8"))
+        policy = contract["policy"]
+        self.assertTrue(policy["shadow_only"])
+        self.assertFalse(policy["authoritative_runtime_source"])
+        self.assertFalse(policy["places_orders"])
+        self.assertFalse(policy["reads_state_file"])
+        self.assertFalse(policy["writes_state_file"])
+        self.assertTrue(policy["requires_parity_before_authoritative_cutover"])
+
+    def test_models_are_frozen(self) -> None:
+        portfolio = PortfolioSnapshot(
+            cash=9000.0,
+            equity=10000.0,
+            realized_total=0.0,
+            realized_today=0.0,
+            unrealized_pnl=0.0,
+            positions=(),
+        )
+        with self.assertRaises(FrozenInstanceError):
+            portfolio.equity = 1.0  # type: ignore[misc]
+
+    def test_invalid_protected_equity_is_rejected(self) -> None:
+        for equity in (0.0, -1.0, float("nan"), float("inf")):
+            with self.assertRaises(ValueError):
+                PortfolioSnapshot(
+                    cash=10000.0,
+                    equity=equity,
+                    realized_total=0.0,
+                    realized_today=0.0,
+                    unrealized_pnl=0.0,
+                    positions=(),
+                )
+
+    def test_invalid_risk_baseline_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            RiskStateSnapshot(
+                date="2026-08-19",
+                day_start_equity=-26064.31,
+                day_peak_equity=0.01,
+                daily_loss_fraction=0.0,
+                intraday_drawdown_fraction=0.0,
+                halted=True,
+                halt_reason="daily loss limit hit (3.0%)",
+            )
+
+    def test_duplicate_position_symbols_are_rejected(self) -> None:
+        first = PositionSnapshot("QQQ", "long", 1.0, 500.0, 505.0)
+        second = PositionSnapshot("qqq", "long", 2.0, 500.0, 505.0)
+        with self.assertRaises(ValueError):
+            PortfolioSnapshot(
+                cash=9000.0,
+                equity=10000.0,
+                realized_total=0.0,
+                realized_today=0.0,
+                unrealized_pnl=0.0,
+                positions=(first, second),
+            )
+
+    def test_state_store_is_descriptor_only(self) -> None:
+        descriptor = StateStore.descriptor()
+        self.assertEqual(descriptor["authority"], "shadow_only")
+        self.assertFalse(descriptor["write_enabled"])
+        self.assertFalse(descriptor["reads_state_file"])
+        self.assertFalse(descriptor["writes_state_file"])
+
+    def test_canonical_snapshot_is_shadow_only(self) -> None:
+        portfolio = PortfolioSnapshot(9000.0, 10000.0, 0.0, 0.0, 0.0, ())
+        risk = RiskStateSnapshot("2026-08-19", 10000.0, 10000.0, 0.0, 0.0, False, "")
+        snapshot = CanonicalStateSnapshot(portfolio, risk, 0, True)
+        self.assertEqual(snapshot.authority, "shadow_only")
+        self.assertTrue(snapshot.execution_chain_valid)
+
+    def test_module_has_no_runtime_provider_order_or_persistence_authority(self) -> None:
+        path = ROOT / "trading" / "state.py"
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        forbidden_imports = {"app", "alpaca_trade_api", "yfinance", "requests"}
+        forbidden_calls = {
+            "submit_order",
+            "place_order",
+            "execute_order",
+            "enter_position",
+            "exit_position",
+            "save_state",
+            "open",
+            "replace",
+            "unlink",
+            "remove",
+        }
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    self.assertNotIn(alias.name.split(".", 1)[0], forbidden_imports)
+            elif isinstance(node, ast.ImportFrom):
+                self.assertNotIn((node.module or "").split(".", 1)[0], forbidden_imports)
+            elif isinstance(node, ast.Call):
+                func = node.func
+                name = (
+                    func.id
+                    if isinstance(func, ast.Name)
+                    else func.attr
+                    if isinstance(func, ast.Attribute)
+                    else ""
+                )
+                self.assertNotIn(name, forbidden_calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trading/__init__.py
+++ b/trading/__init__.py
@@ -1,0 +1,7 @@
+"""Future canonical trading-core interfaces.
+
+This package is introduced shadow-only by Stable Paper Core v3. Importing it
+must not start runners, place orders, read providers, or mutate persisted state.
+"""
+
+__all__ = ["state"]

--- a/trading/state.py
+++ b/trading/state.py
@@ -1,0 +1,216 @@
+"""Shadow-only canonical state models for Stable Paper Core v3 Stage A.
+
+No object in this module has runtime, persistence, market-data, or order authority.
+The models define the future ownership boundary and deterministic invariants only.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from math import isfinite
+from types import MappingProxyType
+from typing import Any, Mapping, Tuple
+
+VERSION = "stable-paper-core-v3-stage-a-2026-08-19-v1"
+AUTHORITY = "shadow_only"
+
+
+def _finite(value: Any, *, name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be numeric")
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be numeric") from exc
+    if not isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _non_negative(value: Any, *, name: str) -> float:
+    result = _finite(value, name=name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return result
+
+
+@dataclass(frozen=True)
+class PositionSnapshot:
+    symbol: str
+    side: str
+    quantity: float
+    entry_price: float
+    mark_price: float
+
+    def __post_init__(self) -> None:
+        symbol = str(self.symbol or "").upper().strip()
+        side = str(self.side or "").lower().strip()
+        if not symbol:
+            raise ValueError("symbol is required")
+        if side not in {"long", "short"}:
+            raise ValueError("side must be long or short")
+        quantity = _non_negative(self.quantity, name="quantity")
+        if quantity <= 0.0:
+            raise ValueError("quantity must be positive")
+        entry_price = _non_negative(self.entry_price, name="entry_price")
+        mark_price = _non_negative(self.mark_price, name="mark_price")
+        if entry_price <= 0.0 or mark_price <= 0.0:
+            raise ValueError("position prices must be positive")
+        object.__setattr__(self, "symbol", symbol)
+        object.__setattr__(self, "side", side)
+        object.__setattr__(self, "quantity", quantity)
+        object.__setattr__(self, "entry_price", entry_price)
+        object.__setattr__(self, "mark_price", mark_price)
+
+    @property
+    def signed_market_value(self) -> float:
+        notional = self.quantity * self.mark_price
+        return notional if self.side == "long" else -notional
+
+
+@dataclass(frozen=True)
+class AccountingEpochSnapshot:
+    epoch_id: str
+    baseline_type: str
+    historical_evidence_archived: bool
+    validation_hold: bool
+
+    def __post_init__(self) -> None:
+        if not str(self.epoch_id or "").strip():
+            raise ValueError("epoch_id is required")
+        if not str(self.baseline_type or "").strip():
+            raise ValueError("baseline_type is required")
+
+
+@dataclass(frozen=True)
+class PortfolioSnapshot:
+    cash: float
+    equity: float
+    realized_total: float
+    realized_today: float
+    unrealized_pnl: float
+    positions: Tuple[PositionSnapshot, ...] = field(default_factory=tuple)
+    accounting_epoch: AccountingEpochSnapshot | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "cash", _finite(self.cash, name="cash"))
+        equity = _finite(self.equity, name="equity")
+        if equity <= 0.0:
+            raise ValueError("equity must be positive for a canonical protected snapshot")
+        object.__setattr__(self, "equity", equity)
+        object.__setattr__(self, "realized_total", _finite(self.realized_total, name="realized_total"))
+        object.__setattr__(self, "realized_today", _finite(self.realized_today, name="realized_today"))
+        object.__setattr__(self, "unrealized_pnl", _finite(self.unrealized_pnl, name="unrealized_pnl"))
+        object.__setattr__(self, "positions", tuple(self.positions))
+        symbols = [position.symbol for position in self.positions]
+        if len(symbols) != len(set(symbols)):
+            raise ValueError("canonical portfolio cannot contain duplicate position symbols")
+
+
+@dataclass(frozen=True)
+class RiskStateSnapshot:
+    date: str
+    day_start_equity: float
+    day_peak_equity: float
+    daily_loss_fraction: float
+    intraday_drawdown_fraction: float
+    halted: bool
+    halt_reason: str = ""
+
+    def __post_init__(self) -> None:
+        if not str(self.date or "").strip():
+            raise ValueError("risk date is required")
+        start = _finite(self.day_start_equity, name="day_start_equity")
+        peak = _finite(self.day_peak_equity, name="day_peak_equity")
+        if start <= 0.0 or peak <= 0.0:
+            raise ValueError("risk baselines must be positive")
+        if peak < start:
+            raise ValueError("day_peak_equity cannot be below day_start_equity at snapshot validation")
+        daily = _non_negative(self.daily_loss_fraction, name="daily_loss_fraction")
+        drawdown = _non_negative(self.intraday_drawdown_fraction, name="intraday_drawdown_fraction")
+        object.__setattr__(self, "day_start_equity", start)
+        object.__setattr__(self, "day_peak_equity", peak)
+        object.__setattr__(self, "daily_loss_fraction", daily)
+        object.__setattr__(self, "intraday_drawdown_fraction", drawdown)
+        object.__setattr__(self, "halt_reason", str(self.halt_reason or ""))
+
+
+@dataclass(frozen=True)
+class CanonicalStateSnapshot:
+    portfolio: PortfolioSnapshot
+    risk: RiskStateSnapshot
+    execution_ledger_rows: int
+    execution_chain_valid: bool
+    source_version: str = VERSION
+    authority: str = AUTHORITY
+
+    def __post_init__(self) -> None:
+        if int(self.execution_ledger_rows) < 0:
+            raise ValueError("execution_ledger_rows must be non-negative")
+        object.__setattr__(self, "execution_ledger_rows", int(self.execution_ledger_rows))
+        if self.authority != AUTHORITY:
+            raise ValueError("Stage A snapshots are shadow-only")
+
+    def to_dict(self) -> Mapping[str, Any]:
+        positions = tuple(
+            MappingProxyType(
+                {
+                    "symbol": row.symbol,
+                    "side": row.side,
+                    "quantity": row.quantity,
+                    "entry_price": row.entry_price,
+                    "mark_price": row.mark_price,
+                }
+            )
+            for row in self.portfolio.positions
+        )
+        return MappingProxyType(
+            {
+                "authority": self.authority,
+                "source_version": self.source_version,
+                "portfolio": MappingProxyType(
+                    {
+                        "cash": self.portfolio.cash,
+                        "equity": self.portfolio.equity,
+                        "realized_total": self.portfolio.realized_total,
+                        "realized_today": self.portfolio.realized_today,
+                        "unrealized_pnl": self.portfolio.unrealized_pnl,
+                        "positions": positions,
+                    }
+                ),
+                "risk": MappingProxyType(
+                    {
+                        "date": self.risk.date,
+                        "day_start_equity": self.risk.day_start_equity,
+                        "day_peak_equity": self.risk.day_peak_equity,
+                        "daily_loss_fraction": self.risk.daily_loss_fraction,
+                        "intraday_drawdown_fraction": self.risk.intraday_drawdown_fraction,
+                        "halted": self.risk.halted,
+                        "halt_reason": self.risk.halt_reason,
+                    }
+                ),
+                "execution_ledger_rows": self.execution_ledger_rows,
+                "execution_chain_valid": bool(self.execution_chain_valid),
+            }
+        )
+
+
+class StateStore:
+    """Stage A future interface descriptor; deliberately has no persistence authority."""
+
+    authority = AUTHORITY
+    write_enabled = False
+    reads_state_file = False
+    writes_state_file = False
+
+    @classmethod
+    def descriptor(cls) -> Mapping[str, Any]:
+        return MappingProxyType(
+            {
+                "target_interface": "trading.state.StateStore",
+                "authority": cls.authority,
+                "write_enabled": cls.write_enabled,
+                "reads_state_file": cls.reads_state_file,
+                "writes_state_file": cls.writes_state_file,
+                "version": VERSION,
+            }
+        )


### PR DESCRIPTION
## Scope
Implements Stage A of #84 only.

- introduces the future `trading.state` ownership boundary
- adds immutable canonical portfolio, position, accounting-epoch, risk, and combined state snapshots
- rejects non-finite/non-positive protected equity and invalid fresh-day risk baselines at the model boundary
- rejects duplicate position symbols and invalid quantities/prices
- introduces a `StateStore` interface descriptor that is explicitly shadow-only with no file I/O or write authority
- adds a machine-readable Stage A contract and targeted invariant tests

## Authority
This PR does not register the new package into runtime startup, does not read/write state, does not place orders, does not fetch market data, and changes no strategy, sizing, risk threshold, live authority, ML authority, or historical accounting.

## Relationship to stabilization
PR #83 remains the deployed prospective fix for Issue #82. This Stage A PR is intentionally non-authoritative so it cannot interfere with the required future fresh-day acceptance proof.

## Acceptance for this PR
- repository/refactor/startup audits pass
- targeted Stage A invariants pass
- no new runtime ownership violation
- no startup behavior change

Closes no stabilization gate by itself; it advances #84 Stage A.