### PR TITLE
Install fresh-day risk guard before WSGI runtime composition

### DIFF
--- a/bootstrap_wsgi.py
+++ b/bootstrap_wsgi.py
@@ -15,7 +15,7 @@ import time
 import traceback
 from typing import Any, Callable, Iterable
 
-VERSION = "deferred-wsgi-bootstrap-2026-08-06-v6-registration-heartbeat"
+VERSION = "deferred-wsgi-bootstrap-2026-08-20-v7-pre-wsgi-fresh-risk-guard"
 _START_MONOTONIC = time.monotonic()
 _LOCK = threading.RLock()
 _DELEGATE: Callable[..., Any] | None = None
@@ -114,16 +114,41 @@ def _load_application() -> None:
     registration_heartbeat_stop: threading.Event | None = None
     registration_started_monotonic: float | None = None
     try:
-        _set_state(status="loading", phase="legacy_wsgi_import")
+        # Issue #82 startup-order fix: import the legacy core first, then install
+        # the fresh-day risk baseline guard before importing wsgi.py.  wsgi.py
+        # composes many auxiliary modules at import time and some of those may
+        # consult get_risk_controls().  Installing the guard only after the full
+        # legacy WSGI import was therefore too late to protect the first daily
+        # reset of a new process.
+        _set_state(status="loading", phase="legacy_core_import")
+        import app as core
+
+        _set_state(status="loading", phase="pre_wsgi_fresh_day_guard")
+        import fresh_risk_day_baseline_guard
+
+        pre_wsgi_fresh_day_guard = fresh_risk_day_baseline_guard.apply(core)
+        if not isinstance(pre_wsgi_fresh_day_guard, dict) or pre_wsgi_fresh_day_guard.get("status") == "error":
+            raise RuntimeError(
+                "pre-wsgi fresh-day guard installation failed: "
+                + json.dumps(pre_wsgi_fresh_day_guard, sort_keys=True, default=str)[:2000]
+            )
+
+        _set_state(
+            status="loading",
+            phase="legacy_wsgi_import",
+            pre_wsgi_fresh_day_guard=pre_wsgi_fresh_day_guard,
+        )
         import wsgi as legacy_wsgi
 
         delegate = getattr(legacy_wsgi, "app", None)
         if delegate is None or not callable(delegate):
             raise RuntimeError("legacy wsgi app missing or not callable")
 
-        core = sys.modules.get("app")
-        if core is None:
+        loaded_core = sys.modules.get("app")
+        if loaded_core is None:
             raise RuntimeError("app module missing after legacy WSGI import")
+        if loaded_core is not core:
+            raise RuntimeError("app module identity changed during legacy WSGI import")
 
         _set_state(status="loading", phase="data_integrity_registration")
         import data_integrity_startup_bridge
@@ -194,6 +219,7 @@ def _load_application() -> None:
             phase="delegating",
             registration=registration,
             registration_duration_seconds=registration_duration,
+            pre_wsgi_fresh_day_guard=pre_wsgi_fresh_day_guard,
             data_integrity_registration={
                 "apply": integrity_apply,
                 "routes": integrity_routes,

--- a/test_fresh_day_bootstrap_order.py
+++ b/test_fresh_day_bootstrap_order.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def test_fresh_day_guard_installs_before_legacy_wsgi_composition():
+    text = (ROOT / "bootstrap_wsgi.py").read_text(encoding="utf-8")
+
+    core_import = text.index("import app as core")
+    guard_apply = text.index("pre_wsgi_fresh_day_guard = fresh_risk_day_baseline_guard.apply(core)")
+    wsgi_import = text.index("import wsgi as legacy_wsgi")
+
+    assert core_import < guard_apply < wsgi_import
+
+
+def test_bootstrap_preserves_single_app_module_identity():
+    text = (ROOT / "bootstrap_wsgi.py").read_text(encoding="utf-8")
+    assert 'loaded_core = sys.modules.get("app")' in text
+    assert 'if loaded_core is not core:' in text
+    assert 'raise RuntimeError("app module identity changed during legacy WSGI import")' in text
+
+
+def test_pre_wsgi_guard_failure_is_fail_closed():
+    text = (ROOT / "bootstrap_wsgi.py").read_text(encoding="utf-8")
+    assert 'phase="pre_wsgi_fresh_day_guard"' in text
+    assert 'pre_wsgi_fresh_day_guard.get("status") == "error"' in text
+    assert 'raise RuntimeError(' in text


### PR DESCRIPTION
## Why
The 2026-08-20 compact production check proved the prospective fresh-day protection was still too late in startup composition: date=2026-08-20, day_start_equity=-26064.31, day_peak_equity=0.01, halted=true, fresh_day_reset_pending=false.

Root cause is startup ordering. `bootstrap_wsgi._load_application()` imported the full legacy `wsgi` module before applying `data_integrity_startup_bridge`. But `wsgi.py` imports `app` and composes many auxiliary runtime modules at import time; those modules can consult `get_risk_controls()` before the fresh-day guard is installed. That allows the first new-day reset to consume contaminated persisted equity.

## Change
- import the legacy `app` core first inside the deferred bootstrap loader;
- install `fresh_risk_day_baseline_guard` immediately after the core import;
- only then import the full legacy `wsgi` composition;
- fail closed if that pre-WSGI guard cannot install;
- verify the `app` module identity does not change during WSGI composition;
- expose pre-WSGI guard status in bootstrap diagnostics;
- add an ordering regression proving `app import < guard apply < wsgi import`.

## Safety
- prospective only;
- does not rewrite the already-contaminated 2026-08-20 risk state;
- does not clear the current halt;
- no strategy, sizing, thresholds, account history, live authority, ML authority, or order behavior changes;
- maps directly to Issue #82 fresh-day proof failure.

Do not merge unless both authoritative workflows and the exact Gunicorn startup smoke pass.