### PR TITLE
Stable Paper Core v3 Stage B deterministic valuation

### DIFF
--- a/stable_paper_core_v3_stage_b_contract.json
+++ b/stable_paper_core_v3_stage_b_contract.json
@@ -1,0 +1,43 @@
+{
+  "version": "stable-paper-core-v3-stage-b-contract-2026-08-20-v1",
+  "stage": "B",
+  "authority": "shadow_only",
+  "target_interface": "trading.valuation.DeterministicValuationService",
+  "accounting_model": "bidirectional_margin_v1",
+  "inputs": {
+    "cash": "finite numeric current cash after execution reservation/release semantics",
+    "positions": "immutable PositionSnapshot basis/side/quantity records",
+    "marks": "exact symbol coverage with ProtectedMarkSnapshot rows already proven fresh and plausible upstream"
+  },
+  "invariants": [
+    "all protected marks are finite and positive",
+    "all protected marks are fresh",
+    "all protected marks are plausible",
+    "protected mark symbols exactly match open position symbols",
+    "long position value equals quantity times protected mark",
+    "short position value equals reserved entry basis plus unrealized P&L",
+    "total position value equals total cost basis plus total unrealized P&L",
+    "equity equals cash plus total deterministic position value",
+    "protected equity must be finite and positive before it is risk-baseline eligible"
+  ],
+  "prohibited_authority": {
+    "market_data_fetches": true,
+    "state_file_reads": true,
+    "state_file_writes": true,
+    "risk_mutation": true,
+    "order_placement": true,
+    "runtime_registration": true,
+    "strategy_changes": true,
+    "threshold_changes": true,
+    "sizing_changes": true,
+    "live_authority_changes": true,
+    "ml_execution_authority_changes": true
+  },
+  "promotion": {
+    "automatic": false,
+    "requires_issue_82_acceptance_before_authoritative_cutover": true,
+    "requires_shadow_parity": true,
+    "requires_restart_reload_parity": true,
+    "requires_exact_gunicorn_startup_smoke": true
+  }
+}

--- a/test_architecture_stage_b.py
+++ b/test_architecture_stage_b.py
@@ -15,6 +15,12 @@ from shadow_decision_models import (
     Side,
     SignalSnapshot,
 )
+from trading.state import PositionSnapshot
+from trading.valuation import (
+    DeterministicValuationService,
+    ProtectedMarkSnapshot,
+    ValuationInvariantError,
+)
 
 ROOT = Path(__file__).resolve().parent
 
@@ -129,6 +135,131 @@ class ShadowDecisionModelTests(unittest.TestCase):
                     else ""
                 )
                 self.assertNotIn(name, forbidden_calls)
+
+
+class StablePaperCoreStageBValuationTests(unittest.TestCase):
+    def test_long_and_short_valuation_matches_bidirectional_margin_model(self) -> None:
+        positions = (
+            PositionSnapshot("LONG", "long", 10.0, 100.0, 1.0),
+            PositionSnapshot("SHORT", "short", 5.0, 200.0, 1.0),
+        )
+        marks = (
+            ProtectedMarkSnapshot("LONG", 110.0, "test", True, True),
+            ProtectedMarkSnapshot("SHORT", 180.0, "test", True, True),
+        )
+        snapshot = DeterministicValuationService.value(
+            cash=8000.0,
+            positions=positions,
+            marks=marks,
+        )
+
+        self.assertEqual(snapshot.accounting_model, "bidirectional_margin_v1")
+        self.assertAlmostEqual(snapshot.total_cost_basis, 2000.0)
+        self.assertAlmostEqual(snapshot.total_unrealized_pnl, 200.0)
+        self.assertAlmostEqual(snapshot.total_position_value, 2200.0)
+        self.assertAlmostEqual(snapshot.equity, 10200.0)
+        self.assertAlmostEqual(snapshot.gross_market_exposure, 2000.0)
+        self.assertAlmostEqual(snapshot.net_market_exposure, 200.0)
+        self.assertTrue(snapshot.risk_baseline_eligible)
+
+    def test_invalid_protected_marks_fail_closed(self) -> None:
+        with self.assertRaises(ValuationInvariantError):
+            ProtectedMarkSnapshot("BAD", 0.0, "test", True, True)
+        with self.assertRaises(ValuationInvariantError):
+            ProtectedMarkSnapshot("STALE", 100.0, "test", False, True)
+        with self.assertRaises(ValuationInvariantError):
+            ProtectedMarkSnapshot("OUTLIER", 100.0, "test", True, False)
+
+    def test_protected_mark_coverage_must_exactly_match_positions(self) -> None:
+        position = PositionSnapshot("ONLY", "long", 1.0, 100.0, 1.0)
+        with self.assertRaises(ValuationInvariantError):
+            DeterministicValuationService.value(
+                cash=900.0,
+                positions=(position,),
+                marks=(),
+            )
+        with self.assertRaises(ValuationInvariantError):
+            DeterministicValuationService.value(
+                cash=900.0,
+                positions=(position,),
+                marks=(
+                    ProtectedMarkSnapshot("ONLY", 100.0, "test", True, True),
+                    ProtectedMarkSnapshot("EXTRA", 100.0, "test", True, True),
+                ),
+            )
+
+    def test_non_positive_equity_cannot_become_risk_baseline(self) -> None:
+        position = PositionSnapshot("SHORT", "short", 10.0, 100.0, 1.0)
+        with self.assertRaises(ValuationInvariantError):
+            DeterministicValuationService.value(
+                cash=0.0,
+                positions=(position,),
+                marks=(
+                    ProtectedMarkSnapshot("SHORT", 250.0, "test", True, True),
+                ),
+            )
+
+    def test_stage_b_contract_is_shadow_only_and_requires_issue_82(self) -> None:
+        contract = json.loads(
+            (ROOT / "stable_paper_core_v3_stage_b_contract.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(contract["authority"], "shadow_only")
+        self.assertEqual(contract["accounting_model"], "bidirectional_margin_v1")
+        self.assertFalse(contract["promotion"]["automatic"])
+        self.assertTrue(
+            contract["promotion"][
+                "requires_issue_82_acceptance_before_authoritative_cutover"
+            ]
+        )
+
+    def test_stage_b_module_has_no_runtime_state_provider_or_order_authority(self) -> None:
+        path = ROOT / "trading" / "valuation.py"
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        forbidden_imports = {
+            "app",
+            "alpaca_trade_api",
+            "yfinance",
+            "requests",
+            "httpx",
+        }
+        forbidden_calls = {
+            "submit_order",
+            "place_order",
+            "execute_order",
+            "enter_position",
+            "exit_position",
+            "save_state",
+            "load_state",
+            "download_prices",
+            "get_risk_controls",
+            "update_daily_risk_controls",
+        }
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    self.assertNotIn(alias.name.split(".", 1)[0], forbidden_imports)
+            elif isinstance(node, ast.ImportFrom):
+                self.assertNotIn((node.module or "").split(".", 1)[0], forbidden_imports)
+            elif isinstance(node, ast.Call):
+                func = node.func
+                name = (
+                    func.id
+                    if isinstance(func, ast.Name)
+                    else func.attr
+                    if isinstance(func, ast.Attribute)
+                    else ""
+                )
+                self.assertNotIn(name, forbidden_calls)
+
+        descriptor = DeterministicValuationService.descriptor()
+        self.assertEqual(descriptor["authority"], "shadow_only")
+        self.assertFalse(descriptor["fetches_market_data"])
+        self.assertFalse(descriptor["reads_state_file"])
+        self.assertFalse(descriptor["writes_state_file"])
+        self.assertFalse(descriptor["mutates_risk"])
+        self.assertFalse(descriptor["places_orders"])
 
 
 if __name__ == "__main__":

--- a/trading/valuation.py
+++ b/trading/valuation.py
@@ -1,0 +1,343 @@
+"""Shadow-only deterministic valuation for Stable Paper Core v3 Stage B.
+
+This module defines the future canonical valuation boundary. It performs no
+market-data fetches, state-file I/O, runtime registration, order placement, or
+risk mutation. Upstream code must supply already-validated protected marks.
+
+Accounting semantics intentionally match the existing bidirectional margin
+model:
+
+- long entry reserves entry notional; position value is quantity * mark;
+- short entry reserves entry notional as margin; position value is reserved
+  basis plus unrealized P&L.
+
+Therefore total equity is always:
+
+    cash + total_cost_basis + total_unrealized_pnl
+
+for both long and short positions.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from math import isfinite
+from types import MappingProxyType
+from typing import Any, Iterable, Mapping, Tuple
+
+from trading.state import PositionSnapshot
+
+VERSION = "stable-paper-core-v3-stage-b-valuation-2026-08-20-v1"
+AUTHORITY = "shadow_only"
+ACCOUNTING_MODEL = "bidirectional_margin_v1"
+
+
+class ValuationInvariantError(ValueError):
+    """Raised when a protected valuation cannot be produced safely."""
+
+
+def _finite(value: Any, *, name: str) -> float:
+    if isinstance(value, bool):
+        raise ValuationInvariantError(f"{name} must be numeric")
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValuationInvariantError(f"{name} must be numeric") from exc
+    if not isfinite(out):
+        raise ValuationInvariantError(f"{name} must be finite")
+    return out
+
+
+def _positive(value: Any, *, name: str) -> float:
+    out = _finite(value, name=name)
+    if out <= 0.0:
+        raise ValuationInvariantError(f"{name} must be positive")
+    return out
+
+
+@dataclass(frozen=True)
+class ProtectedMarkSnapshot:
+    """A mark whose freshness and plausibility were proven upstream."""
+
+    symbol: str
+    price: float
+    source: str
+    fresh: bool
+    plausible: bool
+    observed_at: str = ""
+
+    def __post_init__(self) -> None:
+        symbol = str(self.symbol or "").upper().strip()
+        source = str(self.source or "").strip()
+        if not symbol:
+            raise ValuationInvariantError("mark symbol is required")
+        if not source:
+            raise ValuationInvariantError("mark source is required")
+        price = _positive(self.price, name="mark price")
+        if not bool(self.fresh):
+            raise ValuationInvariantError(f"{symbol} mark is not fresh")
+        if not bool(self.plausible):
+            raise ValuationInvariantError(f"{symbol} mark is not plausible")
+        object.__setattr__(self, "symbol", symbol)
+        object.__setattr__(self, "price", price)
+        object.__setattr__(self, "source", source)
+        object.__setattr__(self, "fresh", True)
+        object.__setattr__(self, "plausible", True)
+        object.__setattr__(self, "observed_at", str(self.observed_at or ""))
+
+
+@dataclass(frozen=True)
+class PositionValuation:
+    symbol: str
+    side: str
+    quantity: float
+    entry_price: float
+    mark_price: float
+    cost_basis: float
+    market_notional: float
+    position_value: float
+    unrealized_pnl: float
+    mark_source: str
+    mark_observed_at: str = ""
+
+    def __post_init__(self) -> None:
+        for name in (
+            "quantity",
+            "entry_price",
+            "mark_price",
+            "cost_basis",
+            "market_notional",
+            "position_value",
+            "unrealized_pnl",
+        ):
+            _finite(getattr(self, name), name=name)
+        if self.quantity <= 0.0:
+            raise ValuationInvariantError("quantity must be positive")
+        if self.entry_price <= 0.0 or self.mark_price <= 0.0:
+            raise ValuationInvariantError("position prices must be positive")
+        if self.cost_basis <= 0.0 or self.market_notional <= 0.0:
+            raise ValuationInvariantError("position basis/notional must be positive")
+        if self.side not in {"long", "short"}:
+            raise ValuationInvariantError("side must be long or short")
+
+
+@dataclass(frozen=True)
+class ValuationSnapshot:
+    cash: float
+    equity: float
+    total_cost_basis: float
+    total_position_value: float
+    total_unrealized_pnl: float
+    gross_market_exposure: float
+    net_market_exposure: float
+    positions: Tuple[PositionValuation, ...] = field(default_factory=tuple)
+    accounting_model: str = ACCOUNTING_MODEL
+    authority: str = AUTHORITY
+    version: str = VERSION
+
+    def __post_init__(self) -> None:
+        cash = _finite(self.cash, name="cash")
+        equity = _finite(self.equity, name="equity")
+        basis = _finite(self.total_cost_basis, name="total_cost_basis")
+        position_value = _finite(
+            self.total_position_value, name="total_position_value"
+        )
+        unrealized = _finite(
+            self.total_unrealized_pnl, name="total_unrealized_pnl"
+        )
+        gross = _finite(self.gross_market_exposure, name="gross_market_exposure")
+        net = _finite(self.net_market_exposure, name="net_market_exposure")
+        if equity <= 0.0:
+            raise ValuationInvariantError(
+                "protected equity must be positive; risk baseline is ineligible"
+            )
+        if basis < 0.0 or gross < 0.0:
+            raise ValuationInvariantError("basis and gross exposure cannot be negative")
+        if self.accounting_model != ACCOUNTING_MODEL:
+            raise ValuationInvariantError("unexpected accounting model")
+        if self.authority != AUTHORITY:
+            raise ValuationInvariantError("Stage B valuation must remain shadow-only")
+        positions = tuple(self.positions)
+        symbols = [row.symbol for row in positions]
+        if len(symbols) != len(set(symbols)):
+            raise ValuationInvariantError("duplicate position valuation symbols")
+
+        expected_position_value = basis + unrealized
+        expected_equity = cash + expected_position_value
+        tolerance = max(1e-9, abs(expected_equity) * 1e-12)
+        if abs(position_value - expected_position_value) > tolerance:
+            raise ValuationInvariantError(
+                "position value must equal cost basis plus unrealized P&L"
+            )
+        if abs(equity - expected_equity) > tolerance:
+            raise ValuationInvariantError(
+                "equity must equal cash plus deterministic position value"
+            )
+
+        object.__setattr__(self, "cash", cash)
+        object.__setattr__(self, "equity", equity)
+        object.__setattr__(self, "total_cost_basis", basis)
+        object.__setattr__(self, "total_position_value", position_value)
+        object.__setattr__(self, "total_unrealized_pnl", unrealized)
+        object.__setattr__(self, "gross_market_exposure", gross)
+        object.__setattr__(self, "net_market_exposure", net)
+        object.__setattr__(self, "positions", positions)
+
+    @property
+    def risk_baseline_eligible(self) -> bool:
+        return self.equity > 0.0
+
+    def to_dict(self) -> Mapping[str, Any]:
+        rows = tuple(
+            MappingProxyType(
+                {
+                    "symbol": row.symbol,
+                    "side": row.side,
+                    "quantity": row.quantity,
+                    "entry_price": row.entry_price,
+                    "mark_price": row.mark_price,
+                    "cost_basis": row.cost_basis,
+                    "market_notional": row.market_notional,
+                    "position_value": row.position_value,
+                    "unrealized_pnl": row.unrealized_pnl,
+                    "mark_source": row.mark_source,
+                    "mark_observed_at": row.mark_observed_at,
+                }
+            )
+            for row in self.positions
+        )
+        return MappingProxyType(
+            {
+                "authority": self.authority,
+                "version": self.version,
+                "accounting_model": self.accounting_model,
+                "cash": self.cash,
+                "equity": self.equity,
+                "total_cost_basis": self.total_cost_basis,
+                "total_position_value": self.total_position_value,
+                "total_unrealized_pnl": self.total_unrealized_pnl,
+                "gross_market_exposure": self.gross_market_exposure,
+                "net_market_exposure": self.net_market_exposure,
+                "risk_baseline_eligible": self.risk_baseline_eligible,
+                "positions": rows,
+            }
+        )
+
+
+class DeterministicValuationService:
+    """Pure Stage B valuation service with no external/runtime authority."""
+
+    authority = AUTHORITY
+    accounting_model = ACCOUNTING_MODEL
+    fetches_market_data = False
+    reads_state_file = False
+    writes_state_file = False
+    mutates_risk = False
+    places_orders = False
+
+    @classmethod
+    def value(
+        cls,
+        *,
+        cash: float,
+        positions: Iterable[PositionSnapshot],
+        marks: Iterable[ProtectedMarkSnapshot],
+    ) -> ValuationSnapshot:
+        cash_value = _finite(cash, name="cash")
+        position_rows = tuple(positions)
+        mark_rows = tuple(marks)
+
+        position_symbols = [row.symbol for row in position_rows]
+        if len(position_symbols) != len(set(position_symbols)):
+            raise ValuationInvariantError("duplicate position symbols")
+
+        mark_map: dict[str, ProtectedMarkSnapshot] = {}
+        for mark in mark_rows:
+            if mark.symbol in mark_map:
+                raise ValuationInvariantError(
+                    f"duplicate protected mark for {mark.symbol}"
+                )
+            mark_map[mark.symbol] = mark
+
+        if set(mark_map) != set(position_symbols):
+            missing = sorted(set(position_symbols) - set(mark_map))
+            extra = sorted(set(mark_map) - set(position_symbols))
+            raise ValuationInvariantError(
+                f"protected mark coverage mismatch; missing={missing}; extra={extra}"
+            )
+
+        valued: list[PositionValuation] = []
+        total_basis = 0.0
+        total_position_value = 0.0
+        total_unrealized = 0.0
+        gross_exposure = 0.0
+        net_exposure = 0.0
+
+        for position in position_rows:
+            mark = mark_map[position.symbol]
+            quantity = _positive(position.quantity, name=f"{position.symbol} quantity")
+            entry = _positive(position.entry_price, name=f"{position.symbol} entry")
+            price = _positive(mark.price, name=f"{position.symbol} protected mark")
+            basis = quantity * entry
+            market_notional = quantity * price
+
+            if position.side == "long":
+                unrealized = (price - entry) * quantity
+                position_value = market_notional
+                signed_exposure = market_notional
+            elif position.side == "short":
+                unrealized = (entry - price) * quantity
+                position_value = basis + unrealized
+                signed_exposure = -market_notional
+            else:
+                raise ValuationInvariantError(
+                    f"unsupported side for {position.symbol}: {position.side}"
+                )
+
+            valued.append(
+                PositionValuation(
+                    symbol=position.symbol,
+                    side=position.side,
+                    quantity=quantity,
+                    entry_price=entry,
+                    mark_price=price,
+                    cost_basis=basis,
+                    market_notional=market_notional,
+                    position_value=position_value,
+                    unrealized_pnl=unrealized,
+                    mark_source=mark.source,
+                    mark_observed_at=mark.observed_at,
+                )
+            )
+            total_basis += basis
+            total_position_value += position_value
+            total_unrealized += unrealized
+            gross_exposure += market_notional
+            net_exposure += signed_exposure
+
+        equity = cash_value + total_position_value
+        return ValuationSnapshot(
+            cash=cash_value,
+            equity=equity,
+            total_cost_basis=total_basis,
+            total_position_value=total_position_value,
+            total_unrealized_pnl=total_unrealized,
+            gross_market_exposure=gross_exposure,
+            net_market_exposure=net_exposure,
+            positions=tuple(valued),
+        )
+
+    @classmethod
+    def descriptor(cls) -> Mapping[str, Any]:
+        return MappingProxyType(
+            {
+                "target_interface": "trading.valuation.DeterministicValuationService",
+                "authority": cls.authority,
+                "accounting_model": cls.accounting_model,
+                "fetches_market_data": cls.fetches_market_data,
+                "reads_state_file": cls.reads_state_file,
+                "writes_state_file": cls.writes_state_file,
+                "mutates_risk": cls.mutates_risk,
+                "places_orders": cls.places_orders,
+                "version": VERSION,
+            }
+        )


### PR DESCRIPTION
## Purpose
Implement Issue #84 Stage B as a shadow-only deterministic valuation boundary. This does not change runtime trading authority.

## What it adds
- `trading/valuation.py`: pure deterministic valuation service using protected marks and the existing `bidirectional_margin_v1` long/short accounting semantics.
- `stable_paper_core_v3_stage_b_contract.json`: machine-readable invariants and promotion constraints.
- expanded `test_architecture_stage_b.py`: long/short valuation parity, exact protected-mark coverage, stale/implausible/non-positive mark rejection, non-positive-equity fail-closed behavior, and AST authority-boundary checks.

## Key invariant
A protected valuation is only produced when every open position has exactly one fresh/plausible positive protected mark and resulting equity is finite and positive. Therefore this Stage B snapshot is eligible to seed a future risk baseline only when those invariants hold.

## Safety
- shadow-only;
- no provider calls;
- no state-file I/O;
- no runtime registration;
- no risk mutation;
- no order placement;
- no strategy, threshold, sizing, live authority, ML authority, or historical ledger changes;
- no current-day halt clearing or state repair;
- authoritative cutover remains blocked by Issue #82 acceptance.

Do not merge unless repository validation, architecture-debt regression, refactor/ownership/startup audit, and exact Gunicorn startup smoke all pass.