### PR TITLE
Stable Paper Core v3 Stage C shadow risk engine

### DIFF
--- a/.github/workflows/stable-paper-core-v3-stage-c.yml
+++ b/.github/workflows/stable-paper-core-v3-stage-c.yml
@@ -1,0 +1,34 @@
+name: Stable Paper Core v3 Stage C Risk Validation
+
+on:
+  pull_request:
+    paths:
+      - "trading/risk.py"
+      - "trading/valuation.py"
+      - "trading/state.py"
+      - "test_architecture_stage_c.py"
+      - "stable_paper_core_v3_stage_c_contract.json"
+      - ".github/workflows/stable-paper-core-v3-stage-c.yml"
+  push:
+    branches: [main]
+    paths:
+      - "trading/risk.py"
+      - "trading/valuation.py"
+      - "trading/state.py"
+      - "test_architecture_stage_c.py"
+      - "stable_paper_core_v3_stage_c_contract.json"
+      - ".github/workflows/stable-paper-core-v3-stage-c.yml"
+  workflow_dispatch:
+
+jobs:
+  stage-c-risk:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Test deterministic shadow risk engine
+        run: python -m unittest -v test_architecture_stage_c.py

--- a/stable_paper_core_v3_stage_c_contract.json
+++ b/stable_paper_core_v3_stage_c_contract.json
@@ -1,0 +1,45 @@
+{
+  "version": "stable-paper-core-v3-stage-c-contract-2026-08-20-v1",
+  "stage": "C",
+  "authority": "shadow_only",
+  "purpose": "Deterministic daily-risk lifecycle parity against the legacy runtime without mutating runtime state.",
+  "depends_on": [
+    "trading.state.RiskStateSnapshot",
+    "trading.valuation.ValuationSnapshot"
+  ],
+  "target_interface": "trading.risk.ShadowRiskEngine",
+  "configuration_policy": {
+    "reads_environment": false,
+    "thresholds_supplied_explicitly": true,
+    "canonical_units": "fraction",
+    "new_configuration_owner": false
+  },
+  "invariants": [
+    "fresh-day baseline requires a positive Stage B protected valuation",
+    "fresh day initializes day_start_equity and day_peak_equity from the same protected valuation",
+    "prior-day halt state does not carry into a new day",
+    "same-day hard halt remains latched unless a future authoritative lifecycle explicitly changes policy",
+    "daily loss is measured from day_start_equity",
+    "intraday drawdown is measured from the monotonic same-day peak",
+    "realized hard loss is measured from day_start_equity",
+    "hard-risk trigger precedence mirrors the current app owner: daily loss, intraday drawdown, realized hard loss",
+    "legacy percentage-point telemetry is converted to fractions only inside the parity comparator"
+  ],
+  "forbidden_authority": [
+    "state_file_read",
+    "state_file_write",
+    "environment_read",
+    "market_data_fetch",
+    "legacy_risk_mutation",
+    "runtime_registration",
+    "order_placement",
+    "halt_clear",
+    "historical_state_repair"
+  ],
+  "promotion_constraints": [
+    "Issue #82 prospective fresh-day acceptance must pass before authoritative cutover",
+    "shadow parity must be demonstrated across normal, daily-loss, intraday-drawdown, realized-loss, halt-latch, restart, and fresh-day cases",
+    "hard risk limits must remain unchanged unless separately approved and validated",
+    "authoritative cutover must use the canonical Stage B protected valuation and future StateStore transaction boundary"
+  ]
+}

--- a/test_architecture_stage_c.py
+++ b/test_architecture_stage_c.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import ast
+import json
+import unittest
+from pathlib import Path
+
+from trading.risk import RiskInvariantError, RiskLimits, ShadowRiskEngine
+from trading.state import RiskStateSnapshot
+from trading.valuation import DeterministicValuationService, ValuationInvariantError
+
+ROOT = Path(__file__).resolve().parent
+
+
+def valuation(equity: float):
+    return DeterministicValuationService.value(
+        cash=equity,
+        positions=(),
+        marks=(),
+    )
+
+
+class StablePaperCoreStageCRiskTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.limits = RiskLimits(
+            max_daily_loss_fraction=0.03,
+            max_intraday_drawdown_fraction=0.025,
+            hard_realized_loss_fraction=0.025,
+        )
+
+    def test_contract_is_shadow_only(self) -> None:
+        contract = json.loads(
+            (ROOT / "stable_paper_core_v3_stage_c_contract.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(contract["authority"], "shadow_only")
+        self.assertFalse(contract["configuration_policy"]["reads_environment"])
+        self.assertTrue(
+            contract["configuration_policy"]["thresholds_supplied_explicitly"]
+        )
+
+    def test_fresh_day_uses_protected_valuation_and_clears_prior_day_halt(self) -> None:
+        previous = RiskStateSnapshot(
+            date="2026-08-20",
+            day_start_equity=10000.0,
+            day_peak_equity=10200.0,
+            daily_loss_fraction=0.03,
+            intraday_drawdown_fraction=0.04,
+            halted=True,
+            halt_reason="prior-day halt",
+        )
+        result = ShadowRiskEngine.evaluate(
+            date="2026-08-21",
+            valuation=valuation(10150.0),
+            realized_today=0.0,
+            limits=self.limits,
+            previous=previous,
+        )
+        self.assertTrue(result.fresh_day)
+        self.assertEqual(result.state.day_start_equity, 10150.0)
+        self.assertEqual(result.state.day_peak_equity, 10150.0)
+        self.assertFalse(result.state.halted)
+        self.assertEqual(result.state.halt_reason, "")
+        self.assertEqual(result.state.daily_loss_fraction, 0.0)
+        self.assertEqual(result.state.intraday_drawdown_fraction, 0.0)
+
+    def test_same_day_peak_is_monotonic(self) -> None:
+        previous = RiskStateSnapshot(
+            date="2026-08-20",
+            day_start_equity=10000.0,
+            day_peak_equity=10500.0,
+            daily_loss_fraction=0.0,
+            intraday_drawdown_fraction=0.0,
+            halted=False,
+        )
+        result = ShadowRiskEngine.evaluate(
+            date="2026-08-20",
+            valuation=valuation(10300.0),
+            realized_today=0.0,
+            limits=self.limits,
+            previous=previous,
+        )
+        self.assertFalse(result.fresh_day)
+        self.assertEqual(result.state.day_start_equity, 10000.0)
+        self.assertEqual(result.state.day_peak_equity, 10500.0)
+        self.assertAlmostEqual(
+            result.state.intraday_drawdown_fraction,
+            (10500.0 - 10300.0) / 10500.0,
+        )
+        self.assertFalse(result.state.halted)
+
+    def test_daily_loss_halt_matches_three_percent_limit(self) -> None:
+        previous = RiskStateSnapshot(
+            date="2026-08-20",
+            day_start_equity=10000.0,
+            day_peak_equity=10000.0,
+            daily_loss_fraction=0.0,
+            intraday_drawdown_fraction=0.0,
+            halted=False,
+        )
+        result = ShadowRiskEngine.evaluate(
+            date="2026-08-20",
+            valuation=valuation(9700.0),
+            realized_today=0.0,
+            limits=self.limits,
+            previous=previous,
+        )
+        self.assertTrue(result.daily_loss_triggered)
+        self.assertTrue(result.state.halted)
+        self.assertEqual(result.state.halt_reason, "daily loss limit hit (3.0%)")
+
+    def test_intraday_drawdown_halt_uses_same_day_peak(self) -> None:
+        previous = RiskStateSnapshot(
+            date="2026-08-20",
+            day_start_equity=10000.0,
+            day_peak_equity=10500.0,
+            daily_loss_fraction=0.0,
+            intraday_drawdown_fraction=0.0,
+            halted=False,
+        )
+        result = ShadowRiskEngine.evaluate(
+            date="2026-08-20",
+            valuation=valuation(10200.0),
+            realized_today=0.0,
+            limits=self.limits,
+            previous=previous,
+        )
+        self.assertTrue(result.intraday_drawdown_triggered)
+        self.assertTrue(result.state.halted)
+        self.assertEqual(
+            result.state.halt_reason, "intraday drawdown limit hit (2.5%)"
+        )
+
+    def test_realized_hard_loss_halt_matches_current_policy(self) -> None:
+        previous = RiskStateSnapshot(
+            date="2026-08-20",
+            day_start_equity=10000.0,
+            day_peak_equity=10000.0,
+            daily_loss_fraction=0.0,
+            intraday_drawdown_fraction=0.0,
+            halted=False,
+        )
+        result = ShadowRiskEngine.evaluate(
+            date="2026-08-20",
+            valuation=valuation(10000.0),
+            realized_today=-250.0,
+            limits=self.limits,
+            previous=previous,
+        )
+        self.assertTrue(result.realized_loss_triggered)
+        self.assertTrue(result.state.halted)
+        self.assertEqual(
+            result.state.halt_reason,
+            "self-defense hard realized loss hit (2.50%)",
+        )
+
+    def test_same_day_halt_remains_latched_when_metrics_recover(self) -> None:
+        previous = RiskStateSnapshot(
+            date="2026-08-20",
+            day_start_equity=10000.0,
+            day_peak_equity=10000.0,
+            daily_loss_fraction=0.03,
+            intraday_drawdown_fraction=0.03,
+            halted=True,
+            halt_reason="daily loss limit hit (3.0%)",
+        )
+        result = ShadowRiskEngine.evaluate(
+            date="2026-08-20",
+            valuation=valuation(10000.0),
+            realized_today=0.0,
+            limits=self.limits,
+            previous=previous,
+        )
+        self.assertTrue(result.state.halted)
+        self.assertEqual(result.state.halt_reason, previous.halt_reason)
+        self.assertFalse(result.daily_loss_triggered)
+        self.assertFalse(result.intraday_drawdown_triggered)
+        self.assertFalse(result.realized_loss_triggered)
+
+    def test_invalid_non_positive_valuation_cannot_seed_risk(self) -> None:
+        with self.assertRaises(ValuationInvariantError):
+            valuation(-26064.31)
+
+    def test_limits_require_explicit_fraction_units(self) -> None:
+        with self.assertRaises(RiskInvariantError):
+            RiskLimits(3.0, 0.025, 0.025)
+        with self.assertRaises(RiskInvariantError):
+            RiskLimits(0.03, 2.5, 0.025)
+
+    def test_legacy_percentage_point_parity_comparator(self) -> None:
+        previous = RiskStateSnapshot(
+            date="2026-08-20",
+            day_start_equity=10000.0,
+            day_peak_equity=10000.0,
+            daily_loss_fraction=0.0,
+            intraday_drawdown_fraction=0.0,
+            halted=False,
+        )
+        result = ShadowRiskEngine.evaluate(
+            date="2026-08-20",
+            valuation=valuation(9700.0),
+            realized_today=0.0,
+            limits=self.limits,
+            previous=previous,
+        )
+        parity = ShadowRiskEngine.compare_legacy(
+            evaluation=result,
+            legacy={
+                "day_start_equity": 10000.0,
+                "day_peak_equity": 10000.0,
+                "daily_loss_pct": 3.0,
+                "intraday_drawdown_pct": 3.0,
+                "halted": True,
+                "halt_reason": "daily loss limit hit (3.0%)",
+            },
+            tolerance=1e-12,
+        )
+        self.assertEqual(parity["overall"], "pass")
+        self.assertTrue(all(parity["checks"].values()))
+
+    def test_shadow_module_has_no_runtime_or_order_authority(self) -> None:
+        path = ROOT / "trading" / "risk.py"
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        forbidden_imports = {
+            "app",
+            "os",
+            "yfinance",
+            "alpaca_trade_api",
+        }
+        forbidden_calls = {
+            "save_state",
+            "load_state",
+            "submit_order",
+            "place_order",
+            "execute_order",
+            "enter_position",
+            "exit_position",
+            "register_routes",
+            "start_watchdog",
+        }
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    self.assertNotIn(alias.name.split(".", 1)[0], forbidden_imports)
+            elif isinstance(node, ast.ImportFrom):
+                self.assertNotIn((node.module or "").split(".", 1)[0], forbidden_imports)
+            elif isinstance(node, ast.Call):
+                func = node.func
+                name = (
+                    func.id
+                    if isinstance(func, ast.Name)
+                    else func.attr
+                    if isinstance(func, ast.Attribute)
+                    else ""
+                )
+                self.assertNotIn(name, forbidden_calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trading/risk.py
+++ b/trading/risk.py
@@ -1,0 +1,304 @@
+"""Shadow-only deterministic risk lifecycle for Stable Paper Core v3 Stage C.
+
+This module defines the future canonical daily-risk boundary. It consumes a
+Stage B protected valuation snapshot and produces an immutable risk evaluation.
+It performs no market-data fetches, state-file I/O, runtime registration, order
+placement, or mutation of the legacy paper runtime.
+
+Hard-risk semantics intentionally mirror the current app owner:
+- absolute daily loss ceiling;
+- intraday drawdown halt;
+- hard realized-loss halt;
+- same-day halt latching;
+- normal fresh-day reset from the current protected valuation.
+
+Threshold values are supplied explicitly by the caller. This module does not read
+environment variables or become a second configuration owner.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from trading.state import RiskStateSnapshot
+from trading.valuation import ValuationSnapshot
+
+VERSION = "stable-paper-core-v3-stage-c-risk-2026-08-20-v1"
+AUTHORITY = "shadow_only"
+
+
+class RiskInvariantError(ValueError):
+    """Raised when a deterministic risk transition cannot be evaluated safely."""
+
+
+def _finite(value: Any, *, name: str) -> float:
+    if isinstance(value, bool):
+        raise RiskInvariantError(f"{name} must be numeric")
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise RiskInvariantError(f"{name} must be numeric") from exc
+    if not isfinite(out):
+        raise RiskInvariantError(f"{name} must be finite")
+    return out
+
+
+def _positive(value: Any, *, name: str) -> float:
+    out = _finite(value, name=name)
+    if out <= 0.0:
+        raise RiskInvariantError(f"{name} must be positive")
+    return out
+
+
+def _risk_fraction(value: Any, *, name: str) -> float:
+    out = _finite(value, name=name)
+    if out <= 0.0 or out > 1.0:
+        raise RiskInvariantError(f"{name} must be a fraction in (0, 1]")
+    return out
+
+
+@dataclass(frozen=True)
+class RiskLimits:
+    max_daily_loss_fraction: float
+    max_intraday_drawdown_fraction: float
+    hard_realized_loss_fraction: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "max_daily_loss_fraction",
+            _risk_fraction(
+                self.max_daily_loss_fraction, name="max_daily_loss_fraction"
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_intraday_drawdown_fraction",
+            _risk_fraction(
+                self.max_intraday_drawdown_fraction,
+                name="max_intraday_drawdown_fraction",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "hard_realized_loss_fraction",
+            _risk_fraction(
+                self.hard_realized_loss_fraction, name="hard_realized_loss_fraction"
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class RiskEvaluation:
+    state: RiskStateSnapshot
+    day_pnl_fraction: float
+    realized_loss_fraction: float
+    daily_loss_triggered: bool
+    intraday_drawdown_triggered: bool
+    realized_loss_triggered: bool
+    fresh_day: bool
+    valuation_version: str
+    authority: str = AUTHORITY
+    version: str = VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "day_pnl_fraction", _finite(self.day_pnl_fraction, name="day_pnl_fraction")
+        )
+        realized = _finite(self.realized_loss_fraction, name="realized_loss_fraction")
+        if realized < 0.0:
+            raise RiskInvariantError("realized_loss_fraction cannot be negative")
+        object.__setattr__(self, "realized_loss_fraction", realized)
+        if self.authority != AUTHORITY:
+            raise RiskInvariantError("Stage C risk evaluation must remain shadow-only")
+        if not str(self.valuation_version or "").strip():
+            raise RiskInvariantError("valuation_version is required")
+
+    def to_dict(self) -> Mapping[str, Any]:
+        return MappingProxyType(
+            {
+                "authority": self.authority,
+                "version": self.version,
+                "valuation_version": self.valuation_version,
+                "fresh_day": self.fresh_day,
+                "date": self.state.date,
+                "day_start_equity": self.state.day_start_equity,
+                "day_peak_equity": self.state.day_peak_equity,
+                "day_pnl_fraction": self.day_pnl_fraction,
+                "daily_loss_fraction": self.state.daily_loss_fraction,
+                "intraday_drawdown_fraction": self.state.intraday_drawdown_fraction,
+                "realized_loss_fraction": self.realized_loss_fraction,
+                "halted": self.state.halted,
+                "halt_reason": self.state.halt_reason,
+                "daily_loss_triggered": self.daily_loss_triggered,
+                "intraday_drawdown_triggered": self.intraday_drawdown_triggered,
+                "realized_loss_triggered": self.realized_loss_triggered,
+            }
+        )
+
+
+class ShadowRiskEngine:
+    """Pure Stage C risk engine with no runtime mutation authority."""
+
+    authority = AUTHORITY
+    fetches_market_data = False
+    reads_environment = False
+    reads_state_file = False
+    writes_state_file = False
+    mutates_legacy_risk = False
+    places_orders = False
+
+    @classmethod
+    def evaluate(
+        cls,
+        *,
+        date: str,
+        valuation: ValuationSnapshot,
+        realized_today: float,
+        limits: RiskLimits,
+        previous: RiskStateSnapshot | None = None,
+    ) -> RiskEvaluation:
+        risk_date = str(date or "").strip()
+        if not risk_date:
+            raise RiskInvariantError("risk date is required")
+        if not isinstance(valuation, ValuationSnapshot):
+            raise RiskInvariantError("valuation must be a Stage B ValuationSnapshot")
+        if not valuation.risk_baseline_eligible:
+            raise RiskInvariantError("valuation is not eligible to seed risk state")
+
+        equity = _positive(valuation.equity, name="protected equity")
+        realized = _finite(realized_today, name="realized_today")
+        fresh_day = previous is None or previous.date != risk_date
+
+        if fresh_day:
+            start = equity
+            old_peak = equity
+            prior_halted = False
+            prior_reason = ""
+        else:
+            start = _positive(previous.day_start_equity, name="day_start_equity")
+            old_peak = _positive(previous.day_peak_equity, name="day_peak_equity")
+            prior_halted = bool(previous.halted)
+            prior_reason = str(previous.halt_reason or "")
+
+        peak = max(old_peak, equity)
+        day_pnl = (equity - start) / start
+        daily_loss = max(0.0, (start - equity) / start)
+        intraday_drawdown = max(0.0, (peak - equity) / peak)
+        realized_loss = max(0.0, -realized / start)
+
+        daily_triggered = daily_loss >= limits.max_daily_loss_fraction
+        intraday_triggered = (
+            intraday_drawdown >= limits.max_intraday_drawdown_fraction
+        )
+        realized_triggered = realized_loss >= limits.hard_realized_loss_fraction
+
+        halted = False
+        halt_reason = ""
+        if daily_triggered:
+            halted = True
+            halt_reason = (
+                "daily loss limit hit "
+                f"({limits.max_daily_loss_fraction * 100:.1f}%)"
+            )
+        elif intraday_triggered:
+            halted = True
+            halt_reason = (
+                "intraday drawdown limit hit "
+                f"({limits.max_intraday_drawdown_fraction * 100:.1f}%)"
+            )
+        elif realized_triggered:
+            halted = True
+            halt_reason = (
+                "self-defense hard realized loss hit "
+                f"({limits.hard_realized_loss_fraction * 100:.2f}%)"
+            )
+        elif not fresh_day and prior_halted:
+            halted = True
+            halt_reason = prior_reason
+
+        state = RiskStateSnapshot(
+            date=risk_date,
+            day_start_equity=start,
+            day_peak_equity=peak,
+            daily_loss_fraction=daily_loss,
+            intraday_drawdown_fraction=intraday_drawdown,
+            halted=halted,
+            halt_reason=halt_reason,
+        )
+        return RiskEvaluation(
+            state=state,
+            day_pnl_fraction=day_pnl,
+            realized_loss_fraction=realized_loss,
+            daily_loss_triggered=daily_triggered,
+            intraday_drawdown_triggered=intraday_triggered,
+            realized_loss_triggered=realized_triggered,
+            fresh_day=fresh_day,
+            valuation_version=valuation.version,
+        )
+
+    @classmethod
+    def compare_legacy(
+        cls,
+        *,
+        evaluation: RiskEvaluation,
+        legacy: Mapping[str, Any],
+        tolerance: float = 1e-9,
+    ) -> Mapping[str, Any]:
+        """Compare canonical fields against legacy percentage-point telemetry."""
+        tol = _finite(tolerance, name="tolerance")
+        if tol < 0.0:
+            raise RiskInvariantError("tolerance cannot be negative")
+
+        def legacy_number(name: str, *, percentage_points: bool = False) -> float:
+            value = _finite(legacy.get(name), name=f"legacy.{name}")
+            return value / 100.0 if percentage_points else value
+
+        checks = {
+            "day_start_equity": abs(
+                evaluation.state.day_start_equity - legacy_number("day_start_equity")
+            )
+            <= tol,
+            "day_peak_equity": abs(
+                evaluation.state.day_peak_equity - legacy_number("day_peak_equity")
+            )
+            <= tol,
+            "daily_loss_fraction": abs(
+                evaluation.state.daily_loss_fraction
+                - legacy_number("daily_loss_pct", percentage_points=True)
+            )
+            <= tol,
+            "intraday_drawdown_fraction": abs(
+                evaluation.state.intraday_drawdown_fraction
+                - legacy_number("intraday_drawdown_pct", percentage_points=True)
+            )
+            <= tol,
+            "halted": evaluation.state.halted == bool(legacy.get("halted")),
+            "halt_reason": evaluation.state.halt_reason
+            == str(legacy.get("halt_reason") or ""),
+        }
+        return MappingProxyType(
+            {
+                "authority": AUTHORITY,
+                "overall": "pass" if all(checks.values()) else "fail",
+                "checks": MappingProxyType(checks),
+            }
+        )
+
+    @classmethod
+    def descriptor(cls) -> Mapping[str, Any]:
+        return MappingProxyType(
+            {
+                "target_interface": "trading.risk.ShadowRiskEngine",
+                "authority": cls.authority,
+                "fetches_market_data": cls.fetches_market_data,
+                "reads_environment": cls.reads_environment,
+                "reads_state_file": cls.reads_state_file,
+                "writes_state_file": cls.writes_state_file,
+                "mutates_legacy_risk": cls.mutates_legacy_risk,
+                "places_orders": cls.places_orders,
+                "version": VERSION,
+            }
+        )


### PR DESCRIPTION
## Purpose
Implement Issue #84 Stage C as a shadow-only deterministic daily-risk lifecycle. This does not change runtime trading authority.

## What it adds
- `trading/risk.py`: pure shadow risk engine consuming Stage B protected valuation snapshots.
- `stable_paper_core_v3_stage_c_contract.json`: machine-readable Stage C invariants and promotion constraints.
- `test_architecture_stage_c.py`: fresh-day, same-day peak, daily-loss, intraday-drawdown, realized-loss, halt-latch, invalid-valuation, explicit-unit, parity, and authority-boundary regressions.
- dedicated Stage C CI workflow.

## Key invariants
- A fresh day can initialize only from a positive Stage B protected valuation.
- `day_start_equity` and `day_peak_equity` are initialized from the same protected snapshot.
- Prior-day halt state does not carry forward automatically.
- Same-day hard halt remains latched.
- Thresholds are supplied explicitly in fraction units; this module does not read environment variables or become a second configuration owner.
- Trigger precedence mirrors the current app owner: daily loss, intraday drawdown, realized hard loss.

## Safety
- shadow-only;
- no market-data fetches;
- no environment reads;
- no state-file I/O;
- no runtime registration;
- no legacy risk mutation;
- no halt clearing in production;
- no orders;
- no strategy, sizing, threshold, live-authority, ML-authority, or historical-ledger changes;
- authoritative cutover remains blocked by Issue #82 prospective acceptance.

Do not merge unless Stage C tests, repository validation, architecture-debt regression, refactor/ownership/startup audit, and exact Gunicorn startup smoke all pass.