### PR TITLE
Stable Paper Core v3 Stage D shadow StateStore

### DIFF
--- a/.github/workflows/stable-paper-core-stage-d.yml
+++ b/.github/workflows/stable-paper-core-stage-d.yml
@@ -1,0 +1,33 @@
+name: Stable Paper Core v3 Stage D StateStore Validation
+
+on:
+  pull_request:
+    paths:
+      - "trading/state_store.py"
+      - "trading/state.py"
+      - "stable_paper_core_v3_stage_d_contract.json"
+      - "test_architecture_stage_d_state_store.py"
+      - ".github/workflows/stable-paper-core-stage-d.yml"
+  push:
+    branches: [main]
+    paths:
+      - "trading/state_store.py"
+      - "trading/state.py"
+      - "stable_paper_core_v3_stage_d_contract.json"
+      - "test_architecture_stage_d_state_store.py"
+      - ".github/workflows/stable-paper-core-stage-d.yml"
+  workflow_dispatch:
+
+jobs:
+  stage-d-state-store:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run Stage D StateStore regressions
+        run: python -m unittest -v test_architecture_stage_d_state_store.py

--- a/stable_paper_core_v3_stage_d_contract.json
+++ b/stable_paper_core_v3_stage_d_contract.json
@@ -1,0 +1,46 @@
+{
+  "version": "stable-paper-core-v3-stage-d-state-store-2026-08-20-v1",
+  "stage": "D",
+  "authority": "shadow_only",
+  "target_interface": "trading.state_store.CanonicalStateStore",
+  "production_write_enabled": false,
+  "runtime_registered": false,
+  "constraints": {
+    "explicit_path_only": true,
+    "reads_environment": false,
+    "production_state_file_access": false,
+    "sandbox_io_requires_explicit_opt_in": true,
+    "canonical_payload_digest_required": true,
+    "monotonic_revision_required": true,
+    "atomic_same_directory_replace_required": true,
+    "file_fsync_required": true,
+    "directory_fsync_attempt_required": true,
+    "prewrite_backup_required_after_first_revision": true,
+    "post_commit_readback_required": true,
+    "restart_round_trip_parity_required": true,
+    "accounting_epoch_preserved": true,
+    "execution_ledger_rows_preserved": true,
+    "execution_chain_validity_preserved": true
+  },
+  "promotion_blockers": [
+    "issue_82_prospective_fresh_day_acceptance",
+    "normal_forward_paper_session",
+    "clean_active_accounting_audit",
+    "ledger_accounting_projection_stage_complete",
+    "single_production_write_owner_cutover_review"
+  ],
+  "forbidden_authority": [
+    "runtime_registration",
+    "production_state_path_resolution",
+    "legacy_save_state_replacement",
+    "legacy_load_state_replacement",
+    "risk_mutation",
+    "order_placement",
+    "strategy_change",
+    "sizing_change",
+    "threshold_change",
+    "live_authority_change",
+    "ml_execution_authority_change",
+    "historical_ledger_rewrite"
+  ]
+}

--- a/test_architecture_stage_d_state_store.py
+++ b/test_architecture_stage_d_state_store.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from trading.state import (
+    AccountingEpochSnapshot,
+    CanonicalStateSnapshot,
+    PortfolioSnapshot,
+    PositionSnapshot,
+    RiskStateSnapshot,
+)
+from trading.state_store import (
+    CanonicalStateEnvelope,
+    CanonicalStateStore,
+    StateStoreInvariantError,
+)
+
+ROOT = Path(__file__).resolve().parent
+
+
+def _snapshot() -> CanonicalStateSnapshot:
+    epoch = AccountingEpochSnapshot(
+        epoch_id="stable-paper-v3-test",
+        baseline_type="verified_snapshot",
+        historical_evidence_archived=True,
+        validation_hold=False,
+    )
+    portfolio = PortfolioSnapshot(
+        cash=8000.0,
+        equity=10050.0,
+        realized_total=50.0,
+        realized_today=10.0,
+        unrealized_pnl=50.0,
+        positions=(
+            PositionSnapshot(
+                symbol="QQQ",
+                side="long",
+                quantity=2.0,
+                entry_price=1000.0,
+                mark_price=1025.0,
+            ),
+        ),
+        accounting_epoch=epoch,
+    )
+    risk = RiskStateSnapshot(
+        date="2026-08-20",
+        day_start_equity=10000.0,
+        day_peak_equity=10100.0,
+        daily_loss_fraction=0.0,
+        intraday_drawdown_fraction=(10100.0 - 10050.0) / 10100.0,
+        halted=False,
+        halt_reason="",
+    )
+    return CanonicalStateSnapshot(
+        portfolio=portfolio,
+        risk=risk,
+        execution_ledger_rows=303,
+        execution_chain_valid=True,
+    )
+
+
+class StablePaperCoreStageDStateStoreTests(unittest.TestCase):
+    def test_contract_remains_shadow_only(self) -> None:
+        contract = json.loads(
+            (ROOT / "stable_paper_core_v3_stage_d_contract.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(contract["authority"], "shadow_only")
+        self.assertFalse(contract["production_write_enabled"])
+        self.assertFalse(contract["runtime_registered"])
+        self.assertTrue(contract["constraints"]["restart_round_trip_parity_required"])
+        self.assertIn(
+            "issue_82_prospective_fresh_day_acceptance",
+            contract["promotion_blockers"],
+        )
+
+    def test_envelope_round_trip_preserves_canonical_economics(self) -> None:
+        snapshot = _snapshot()
+        envelope = CanonicalStateStore.prepare(
+            snapshot=snapshot,
+            revision=7,
+            created_at="2026-08-20 17:05:00 CDT",
+        )
+        rebuilt = envelope.snapshot()
+        self.assertEqual(rebuilt.portfolio.cash, snapshot.portfolio.cash)
+        self.assertEqual(rebuilt.portfolio.equity, snapshot.portfolio.equity)
+        self.assertEqual(rebuilt.risk.day_start_equity, snapshot.risk.day_start_equity)
+        self.assertEqual(rebuilt.risk.day_peak_equity, snapshot.risk.day_peak_equity)
+        self.assertEqual(rebuilt.execution_ledger_rows, 303)
+        self.assertTrue(rebuilt.execution_chain_valid)
+        self.assertIsNotNone(rebuilt.portfolio.accounting_epoch)
+        self.assertEqual(
+            rebuilt.portfolio.accounting_epoch.epoch_id,
+            "stable-paper-v3-test",
+        )
+
+    def test_digest_tampering_fails_closed(self) -> None:
+        envelope = CanonicalStateStore.prepare(
+            snapshot=_snapshot(), revision=1, created_at="2026-08-20 17:05:00 CDT"
+        )
+        raw = dict(envelope.to_dict())
+        payload = dict(raw["payload"])
+        portfolio = dict(payload["portfolio"])
+        portfolio["equity"] = 1.0
+        payload["portfolio"] = portfolio
+        with self.assertRaises(StateStoreInvariantError):
+            CanonicalStateEnvelope(
+                schema_version=raw["schema_version"],
+                authority=raw["authority"],
+                version=raw["version"],
+                revision=raw["revision"],
+                created_at=raw["created_at"],
+                payload_sha256=raw["payload_sha256"],
+                payload=payload,
+            )
+
+    def test_production_io_is_disabled_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = CanonicalStateStore(Path(tmp) / "state.json")
+            envelope = store.prepare(
+                snapshot=_snapshot(), revision=1, created_at="2026-08-20 17:05:00 CDT"
+            )
+            with self.assertRaises(PermissionError):
+                store.commit_sandbox(envelope)
+            with self.assertRaises(PermissionError):
+                store.read_sandbox()
+            self.assertFalse((Path(tmp) / "state.json").exists())
+
+    def test_atomic_sandbox_commit_and_restart_parity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "canonical_state.json"
+            store = CanonicalStateStore(path, sandbox_io_enabled=True)
+            envelope = store.prepare(
+                snapshot=_snapshot(), revision=1, created_at="2026-08-20 17:05:00 CDT"
+            )
+            store.commit_sandbox(envelope)
+            self.assertTrue(path.exists())
+
+            restarted = CanonicalStateStore(path, sandbox_io_enabled=True)
+            loaded = restarted.read_sandbox()
+            self.assertEqual(loaded.revision, 1)
+            self.assertEqual(loaded.payload_sha256, envelope.payload_sha256)
+            self.assertEqual(loaded.snapshot().portfolio.equity, 10050.0)
+            self.assertEqual(loaded.snapshot().execution_ledger_rows, 303)
+            self.assertTrue(loaded.snapshot().execution_chain_valid)
+
+    def test_revision_must_increase_and_backup_preserves_prior_revision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "canonical_state.json"
+            store = CanonicalStateStore(path, sandbox_io_enabled=True)
+            first = store.prepare(
+                snapshot=_snapshot(), revision=1, created_at="2026-08-20 17:05:00 CDT"
+            )
+            store.commit_sandbox(first)
+            with self.assertRaises(StateStoreInvariantError):
+                store.commit_sandbox(first)
+
+            second = store.prepare(
+                snapshot=_snapshot(), revision=2, created_at="2026-08-20 17:06:00 CDT"
+            )
+            store.commit_sandbox(second)
+            self.assertEqual(store.read_sandbox().revision, 2)
+            self.assertTrue(store.backup_path.exists())
+            backup_raw = json.loads(store.backup_path.read_text(encoding="utf-8"))
+            self.assertEqual(backup_raw["revision"], 1)
+
+    def test_descriptor_denies_runtime_authority(self) -> None:
+        descriptor = CanonicalStateStore.descriptor()
+        self.assertEqual(descriptor["authority"], "shadow_only")
+        self.assertFalse(descriptor["production_write_enabled"])
+        self.assertFalse(descriptor["runtime_registered"])
+        self.assertFalse(descriptor["reads_environment"])
+        self.assertFalse(descriptor["places_orders"])
+
+    def test_module_has_no_runtime_registration_or_environment_reads(self) -> None:
+        path = ROOT / "trading" / "state_store.py"
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        forbidden_imports = {
+            "app",
+            "state_io_hardening",
+            "alpaca_trade_api",
+            "yfinance",
+        }
+        forbidden_calls = {
+            "submit_order",
+            "place_order",
+            "execute_order",
+            "enter_position",
+            "exit_position",
+            "save_state",
+            "load_state",
+            "register_routes",
+            "install",
+            "apply",
+        }
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    self.assertNotIn(alias.name.split(".", 1)[0], forbidden_imports)
+            elif isinstance(node, ast.ImportFrom):
+                self.assertNotIn((node.module or "").split(".", 1)[0], forbidden_imports)
+            elif isinstance(node, ast.Call):
+                func = node.func
+                name = (
+                    func.id
+                    if isinstance(func, ast.Name)
+                    else func.attr
+                    if isinstance(func, ast.Attribute)
+                    else ""
+                )
+                self.assertNotIn(name, forbidden_calls)
+                if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                    self.assertFalse(
+                        func.value.id == "os" and func.attr in {"getenv"},
+                        "Stage D StateStore must not read environment configuration",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trading/state_store.py
+++ b/trading/state_store.py
@@ -1,0 +1,330 @@
+"""Shadow-only canonical StateStore for Stable Paper Core v3 Stage D.
+
+This module defines the future single persistence boundary without registering it
+with the production runtime. Production writes remain disabled. The store can be
+exercised only against an explicit caller-provided sandbox path so restart and
+atomic-commit invariants can be proven before any authoritative cutover.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+import threading
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from trading.state import (
+    AccountingEpochSnapshot,
+    CanonicalStateSnapshot,
+    PortfolioSnapshot,
+    PositionSnapshot,
+    RiskStateSnapshot,
+)
+
+VERSION = "stable-paper-core-v3-stage-d-state-store-2026-08-20-v1"
+AUTHORITY = "shadow_only"
+SCHEMA_VERSION = 1
+
+
+class StateStoreInvariantError(ValueError):
+    """Raised when a canonical state envelope cannot be trusted."""
+
+
+def _plain(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _plain(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_plain(item) for item in value]
+    if isinstance(value, list):
+        return [_plain(item) for item in value]
+    return value
+
+
+def _canonical_bytes(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        _plain(payload),
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest_payload(payload: Mapping[str, Any]) -> str:
+    return sha256(_canonical_bytes(payload)).hexdigest()
+
+
+def _snapshot_payload(snapshot: CanonicalStateSnapshot) -> dict[str, Any]:
+    epoch = snapshot.portfolio.accounting_epoch
+    return {
+        "portfolio": {
+            "cash": snapshot.portfolio.cash,
+            "equity": snapshot.portfolio.equity,
+            "realized_total": snapshot.portfolio.realized_total,
+            "realized_today": snapshot.portfolio.realized_today,
+            "unrealized_pnl": snapshot.portfolio.unrealized_pnl,
+            "positions": [
+                {
+                    "symbol": row.symbol,
+                    "side": row.side,
+                    "quantity": row.quantity,
+                    "entry_price": row.entry_price,
+                    "mark_price": row.mark_price,
+                }
+                for row in snapshot.portfolio.positions
+            ],
+            "accounting_epoch": (
+                {
+                    "epoch_id": epoch.epoch_id,
+                    "baseline_type": epoch.baseline_type,
+                    "historical_evidence_archived": epoch.historical_evidence_archived,
+                    "validation_hold": epoch.validation_hold,
+                }
+                if epoch is not None
+                else None
+            ),
+        },
+        "risk": {
+            "date": snapshot.risk.date,
+            "day_start_equity": snapshot.risk.day_start_equity,
+            "day_peak_equity": snapshot.risk.day_peak_equity,
+            "daily_loss_fraction": snapshot.risk.daily_loss_fraction,
+            "intraday_drawdown_fraction": snapshot.risk.intraday_drawdown_fraction,
+            "halted": snapshot.risk.halted,
+            "halt_reason": snapshot.risk.halt_reason,
+        },
+        "execution_ledger_rows": snapshot.execution_ledger_rows,
+        "execution_chain_valid": bool(snapshot.execution_chain_valid),
+        "source_version": snapshot.source_version,
+    }
+
+
+def _snapshot_from_payload(payload: Mapping[str, Any]) -> CanonicalStateSnapshot:
+    portfolio_raw = payload.get("portfolio")
+    risk_raw = payload.get("risk")
+    if not isinstance(portfolio_raw, Mapping) or not isinstance(risk_raw, Mapping):
+        raise StateStoreInvariantError("canonical payload requires portfolio and risk mappings")
+
+    positions_raw = portfolio_raw.get("positions", [])
+    if not isinstance(positions_raw, list):
+        raise StateStoreInvariantError("positions must be a list")
+    positions = tuple(
+        PositionSnapshot(
+            symbol=row.get("symbol"),
+            side=row.get("side"),
+            quantity=row.get("quantity"),
+            entry_price=row.get("entry_price"),
+            mark_price=row.get("mark_price"),
+        )
+        for row in positions_raw
+        if isinstance(row, Mapping)
+    )
+    if len(positions) != len(positions_raw):
+        raise StateStoreInvariantError("every position row must be a mapping")
+
+    epoch_raw = portfolio_raw.get("accounting_epoch")
+    epoch = None
+    if epoch_raw is not None:
+        if not isinstance(epoch_raw, Mapping):
+            raise StateStoreInvariantError("accounting_epoch must be a mapping or null")
+        epoch = AccountingEpochSnapshot(
+            epoch_id=epoch_raw.get("epoch_id"),
+            baseline_type=epoch_raw.get("baseline_type"),
+            historical_evidence_archived=bool(epoch_raw.get("historical_evidence_archived")),
+            validation_hold=bool(epoch_raw.get("validation_hold")),
+        )
+
+    portfolio = PortfolioSnapshot(
+        cash=portfolio_raw.get("cash"),
+        equity=portfolio_raw.get("equity"),
+        realized_total=portfolio_raw.get("realized_total"),
+        realized_today=portfolio_raw.get("realized_today"),
+        unrealized_pnl=portfolio_raw.get("unrealized_pnl"),
+        positions=positions,
+        accounting_epoch=epoch,
+    )
+    risk = RiskStateSnapshot(
+        date=risk_raw.get("date"),
+        day_start_equity=risk_raw.get("day_start_equity"),
+        day_peak_equity=risk_raw.get("day_peak_equity"),
+        daily_loss_fraction=risk_raw.get("daily_loss_fraction"),
+        intraday_drawdown_fraction=risk_raw.get("intraday_drawdown_fraction"),
+        halted=bool(risk_raw.get("halted")),
+        halt_reason=str(risk_raw.get("halt_reason") or ""),
+    )
+    return CanonicalStateSnapshot(
+        portfolio=portfolio,
+        risk=risk,
+        execution_ledger_rows=int(payload.get("execution_ledger_rows", -1)),
+        execution_chain_valid=bool(payload.get("execution_chain_valid")),
+        source_version=str(payload.get("source_version") or ""),
+    )
+
+
+@dataclass(frozen=True)
+class CanonicalStateEnvelope:
+    revision: int
+    created_at: str
+    payload: Mapping[str, Any]
+    payload_sha256: str
+    schema_version: int = SCHEMA_VERSION
+    authority: str = AUTHORITY
+    version: str = VERSION
+
+    def __post_init__(self) -> None:
+        if int(self.revision) < 0:
+            raise StateStoreInvariantError("revision must be non-negative")
+        if int(self.schema_version) != SCHEMA_VERSION:
+            raise StateStoreInvariantError("unexpected state schema version")
+        if self.authority != AUTHORITY:
+            raise StateStoreInvariantError("Stage D envelope must remain shadow-only")
+        if not str(self.created_at or "").strip():
+            raise StateStoreInvariantError("created_at is required")
+        plain_payload = _plain(self.payload)
+        expected = _digest_payload(plain_payload)
+        if str(self.payload_sha256) != expected:
+            raise StateStoreInvariantError("payload digest mismatch")
+        object.__setattr__(self, "revision", int(self.revision))
+        object.__setattr__(self, "payload", MappingProxyType(plain_payload))
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        snapshot: CanonicalStateSnapshot,
+        revision: int,
+        created_at: str,
+    ) -> "CanonicalStateEnvelope":
+        payload = _snapshot_payload(snapshot)
+        return cls(
+            revision=revision,
+            created_at=created_at,
+            payload=payload,
+            payload_sha256=_digest_payload(payload),
+        )
+
+    def to_dict(self) -> Mapping[str, Any]:
+        return MappingProxyType(
+            {
+                "schema_version": self.schema_version,
+                "authority": self.authority,
+                "version": self.version,
+                "revision": self.revision,
+                "created_at": self.created_at,
+                "payload_sha256": self.payload_sha256,
+                "payload": _plain(self.payload),
+            }
+        )
+
+    def snapshot(self) -> CanonicalStateSnapshot:
+        return _snapshot_from_payload(self.payload)
+
+
+class CanonicalStateStore:
+    """Future single-owner StateStore; production authority is intentionally off."""
+
+    authority = AUTHORITY
+    production_write_enabled = False
+    runtime_registered = False
+    reads_environment = False
+    places_orders = False
+
+    def __init__(self, path: Path | str, *, sandbox_io_enabled: bool = False):
+        self.path = Path(path)
+        self.backup_path = self.path.with_suffix(self.path.suffix + ".bak")
+        self.sandbox_io_enabled = bool(sandbox_io_enabled)
+        self._lock = threading.RLock()
+
+    @staticmethod
+    def prepare(
+        *, snapshot: CanonicalStateSnapshot, revision: int, created_at: str
+    ) -> CanonicalStateEnvelope:
+        return CanonicalStateEnvelope.build(
+            snapshot=snapshot,
+            revision=revision,
+            created_at=created_at,
+        )
+
+    def _assert_sandbox(self) -> None:
+        if not self.sandbox_io_enabled:
+            raise PermissionError(
+                "Stage D production writes are disabled; explicit sandbox_io_enabled=True is required"
+            )
+
+    def _read_envelope_file(self, path: Path) -> CanonicalStateEnvelope:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise StateStoreInvariantError("state envelope root must be an object")
+        return CanonicalStateEnvelope(
+            schema_version=raw.get("schema_version"),
+            authority=raw.get("authority"),
+            version=raw.get("version"),
+            revision=raw.get("revision"),
+            created_at=raw.get("created_at"),
+            payload_sha256=raw.get("payload_sha256"),
+            payload=raw.get("payload") if isinstance(raw.get("payload"), Mapping) else {},
+        )
+
+    def read_sandbox(self) -> CanonicalStateEnvelope:
+        self._assert_sandbox()
+        with self._lock:
+            return self._read_envelope_file(self.path)
+
+    def commit_sandbox(self, envelope: CanonicalStateEnvelope) -> None:
+        self._assert_sandbox()
+        with self._lock:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            if self.path.exists():
+                current = self._read_envelope_file(self.path)
+                if envelope.revision <= current.revision:
+                    raise StateStoreInvariantError(
+                        "canonical revision must increase monotonically"
+                    )
+                backup_tmp = self.backup_path.with_name(
+                    f".{self.backup_path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
+                )
+                backup_tmp.write_bytes(self.path.read_bytes())
+                with backup_tmp.open("rb") as handle:
+                    os.fsync(handle.fileno())
+                os.replace(backup_tmp, self.backup_path)
+
+            temp_path = self.path.with_name(
+                f".{self.path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
+            )
+            with temp_path.open("wb") as handle:
+                handle.write(_canonical_bytes(envelope.to_dict()))
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_path, self.path)
+            try:
+                directory_fd = os.open(str(self.path.parent), os.O_DIRECTORY)
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
+            except (AttributeError, OSError):
+                pass
+
+            persisted = self._read_envelope_file(self.path)
+            if persisted.payload_sha256 != envelope.payload_sha256:
+                raise StateStoreInvariantError("post-commit digest mismatch")
+            if persisted.revision != envelope.revision:
+                raise StateStoreInvariantError("post-commit revision mismatch")
+
+    @classmethod
+    def descriptor(cls) -> Mapping[str, Any]:
+        return MappingProxyType(
+            {
+                "target_interface": "trading.state_store.CanonicalStateStore",
+                "authority": cls.authority,
+                "production_write_enabled": cls.production_write_enabled,
+                "runtime_registered": cls.runtime_registered,
+                "reads_environment": cls.reads_environment,
+                "places_orders": cls.places_orders,
+                "schema_version": SCHEMA_VERSION,
+                "version": VERSION,
+            }
+        )


### PR DESCRIPTION
## Purpose
Implement Issue #84 Stage D as the future single canonical StateStore boundary while keeping production persistence authority disabled.

## What it adds
- `trading/state_store.py`: canonical state envelope, SHA-256 integrity, deterministic serialization/reconstruction, monotonic revisions, atomic same-directory replacement, fsync, prewrite backup, and post-commit readback.
- `stable_paper_core_v3_stage_d_contract.json`: machine-readable Stage D invariants and promotion blockers.
- `test_architecture_stage_d_state_store.py`: restart parity, digest tamper, production-write-disabled, monotonic revision, backup, accounting epoch, ledger-row/chain preservation, and authority-boundary regressions.
- dedicated Stage D CI workflow.

## Safety boundary
This is still shadow-only. `CanonicalStateStore` requires an explicit caller-provided path and refuses all I/O unless `sandbox_io_enabled=True`; it is not registered with the runtime, does not read environment configuration, does not replace `load_state`/`save_state`, does not mutate risk, and cannot place orders. Existing production state I/O remains unchanged.

## Why Stage D is structured this way
The target is one authoritative persistence owner, but Issue #82 has not yet produced a clean prospective fresh-day/forward-session acceptance. This PR therefore proves the future transaction and restart invariants in isolated sandbox I/O without touching `/data/state.json`. Authoritative persistence cutover remains blocked until stabilization and the ledger/accounting projection stage are complete.

Do not merge unless the dedicated Stage D suite, repository validation, architecture-debt regression, refactor/ownership audit, and exact Gunicorn startup smoke all pass.