### PR TITLE
Stable Paper Core v3 Stage F shadow canary readiness

### DIFF
--- a/.github/workflows/stable-paper-core-stage-f.yml
+++ b/.github/workflows/stable-paper-core-stage-f.yml
@@ -1,0 +1,31 @@
+name: Stable Paper Core v3 Stage F Canary Readiness Validation
+
+on:
+  pull_request:
+    paths:
+      - "trading/canary.py"
+      - "stable_paper_core_v3_stage_f_contract.json"
+      - "test_architecture_stage_f_canary.py"
+      - ".github/workflows/stable-paper-core-stage-f.yml"
+  push:
+    branches: [main]
+    paths:
+      - "trading/canary.py"
+      - "stable_paper_core_v3_stage_f_contract.json"
+      - "test_architecture_stage_f_canary.py"
+      - ".github/workflows/stable-paper-core-stage-f.yml"
+  workflow_dispatch:
+
+jobs:
+  stage-f-canary-readiness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run Stage F canary readiness regressions
+        run: python -m unittest -v test_architecture_stage_f_canary.py

--- a/stable_paper_core_v3_stage_f_contract.json
+++ b/stable_paper_core_v3_stage_f_contract.json
@@ -1,0 +1,52 @@
+{
+  "version": "stable-paper-core-v3-stage-f-canary-readiness-2026-08-20-v1",
+  "stage": "F",
+  "authority": "shadow_only",
+  "target_interface": "trading.canary.CanaryReadinessPlanner",
+  "constraints": {
+    "max_canary_fraction": 0.05,
+    "rollback_switch_required": true,
+    "rollback_default_armed": true,
+    "runtime_registration": false,
+    "production_state_writes": false,
+    "order_authority": false,
+    "risk_mutation_authority": false,
+    "live_authority": false,
+    "ml_execution_authority": false
+  },
+  "required_evidence": [
+    "issue_82_fresh_risk_day_pass",
+    "issue_82_forward_session_pass",
+    "clean_active_accounting_audit",
+    "canonical_ledger_chain_valid",
+    "protected_valuation_sane",
+    "stage_b_valuation_parity",
+    "stage_c_risk_parity",
+    "stage_d_restart_parity",
+    "stage_e_accounting_parity",
+    "repository_validation_green",
+    "architecture_debt_gate_green",
+    "refactor_startup_audit_green"
+  ],
+  "promotion_blockers": [
+    "issue_82_open",
+    "missing_prospective_fresh_day_evidence",
+    "missing_normal_forward_session_evidence",
+    "missing_clean_active_accounting_audit",
+    "missing_stage_e_runtime_shadow_parity",
+    "authoritative_cutover_review_not_completed"
+  ],
+  "forbidden_authority": [
+    "production_canary_activation",
+    "runtime_registration",
+    "production_state_mutation",
+    "halt_clearing",
+    "order_placement",
+    "strategy_change",
+    "sizing_change",
+    "threshold_change",
+    "historical_ledger_rewrite",
+    "live_authority_change",
+    "ml_execution_authority_change"
+  ]
+}

--- a/test_architecture_stage_f_canary.py
+++ b/test_architecture_stage_f_canary.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+import unittest
+
+from trading.canary import (
+    CanaryEvidence,
+    CanaryInvariantError,
+    CanaryReadinessPlanner,
+)
+
+ROOT = Path(__file__).resolve().parent
+
+
+class StablePaperCoreStageFCanaryTests(unittest.TestCase):
+    def _all_green(self) -> CanaryEvidence:
+        return CanaryEvidence(
+            issue_82_fresh_risk_day_pass=True,
+            issue_82_forward_session_pass=True,
+            clean_active_accounting_audit=True,
+            canonical_ledger_chain_valid=True,
+            protected_valuation_sane=True,
+            stage_b_valuation_parity=True,
+            stage_c_risk_parity=True,
+            stage_d_restart_parity=True,
+            stage_e_accounting_parity=True,
+            repository_validation_green=True,
+            architecture_debt_gate_green=True,
+            refactor_startup_audit_green=True,
+        )
+
+    def test_contract_remains_shadow_only(self) -> None:
+        contract = json.loads((ROOT / "stable_paper_core_v3_stage_f_contract.json").read_text())
+        self.assertEqual(contract["authority"], "shadow_only")
+        constraints = contract["constraints"]
+        self.assertFalse(constraints["runtime_registration"])
+        self.assertFalse(constraints["production_state_writes"])
+        self.assertFalse(constraints["order_authority"])
+        self.assertTrue(constraints["rollback_switch_required"])
+        self.assertTrue(constraints["rollback_default_armed"])
+
+    def test_current_issue_82_missing_proof_blocks_canary(self) -> None:
+        evidence = CanaryEvidence(
+            issue_82_fresh_risk_day_pass=False,
+            issue_82_forward_session_pass=False,
+            clean_active_accounting_audit=False,
+            canonical_ledger_chain_valid=True,
+            protected_valuation_sane=True,
+            stage_b_valuation_parity=True,
+            stage_c_risk_parity=True,
+            stage_d_restart_parity=True,
+            stage_e_accounting_parity=False,
+            repository_validation_green=True,
+            architecture_debt_gate_green=True,
+            refactor_startup_audit_green=True,
+        )
+        plan = CanaryReadinessPlanner.plan(evidence=evidence, requested_fraction=0.01)
+        self.assertFalse(plan.eligible_for_future_canary)
+        self.assertIn("issue_82_fresh_risk_day_pass", plan.blockers)
+        self.assertIn("issue_82_forward_session_pass", plan.blockers)
+        self.assertIn("clean_active_accounting_audit", plan.blockers)
+        self.assertIn("stage_e_accounting_parity", plan.blockers)
+        self.assertTrue(plan.rollback_default_armed)
+        self.assertFalse(plan.production_state_writes)
+        self.assertFalse(plan.order_authority)
+
+    def test_all_required_evidence_only_marks_future_eligibility(self) -> None:
+        plan = CanaryReadinessPlanner.plan(evidence=self._all_green(), requested_fraction=0.01)
+        self.assertTrue(plan.eligible_for_future_canary)
+        self.assertEqual(plan.blockers, ())
+        self.assertFalse(plan.runtime_registration)
+        self.assertFalse(plan.production_state_writes)
+        self.assertFalse(plan.order_authority)
+        self.assertFalse(plan.risk_mutation_authority)
+
+    def test_canary_fraction_is_bounded(self) -> None:
+        with self.assertRaises(CanaryInvariantError):
+            CanaryReadinessPlanner.plan(evidence=self._all_green(), requested_fraction=0.0)
+        with self.assertRaises(CanaryInvariantError):
+            CanaryReadinessPlanner.plan(evidence=self._all_green(), requested_fraction=0.051)
+        self.assertEqual(
+            CanaryReadinessPlanner.plan(evidence=self._all_green(), requested_fraction=0.05).requested_fraction,
+            0.05,
+        )
+
+    def test_module_has_no_runtime_or_write_authority(self) -> None:
+        path = ROOT / "trading" / "canary.py"
+        tree = ast.parse(path.read_text(), filename=str(path))
+        forbidden_imports = {
+            "app",
+            "state_io_hardening",
+            "alpaca_trade_api",
+            "yfinance",
+            "flask",
+            "os",
+            "threading",
+        }
+        forbidden_calls = {
+            "save_state",
+            "load_state",
+            "submit_order",
+            "place_order",
+            "enter_position",
+            "exit_position",
+            "install",
+            "apply",
+            "register_routes",
+            "open",
+        }
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    self.assertNotIn(alias.name.split(".", 1)[0], forbidden_imports)
+            elif isinstance(node, ast.ImportFrom):
+                self.assertNotIn((node.module or "").split(".", 1)[0], forbidden_imports)
+            elif isinstance(node, ast.Call):
+                func = node.func
+                name = func.id if isinstance(func, ast.Name) else func.attr if isinstance(func, ast.Attribute) else ""
+                self.assertNotIn(name, forbidden_calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trading/canary.py
+++ b/trading/canary.py
@@ -1,0 +1,152 @@
+"""Shadow-only canary readiness planner for Stable Paper Core v3 Stage F.
+
+This module does not register with the trading runtime and cannot mutate state,
+place orders, clear risk halts, or switch production authority. It only evaluates
+explicitly supplied acceptance evidence and emits an immutable canary plan.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping, Tuple
+
+VERSION = "stable-paper-core-v3-stage-f-canary-readiness-2026-08-20-v1"
+AUTHORITY = "shadow_only"
+MAX_CANARY_FRACTION = 0.05
+
+
+class CanaryInvariantError(ValueError):
+    """Raised when a canary-readiness request violates the Stage F contract."""
+
+
+@dataclass(frozen=True)
+class CanaryEvidence:
+    issue_82_fresh_risk_day_pass: bool
+    issue_82_forward_session_pass: bool
+    clean_active_accounting_audit: bool
+    canonical_ledger_chain_valid: bool
+    protected_valuation_sane: bool
+    stage_b_valuation_parity: bool
+    stage_c_risk_parity: bool
+    stage_d_restart_parity: bool
+    stage_e_accounting_parity: bool
+    repository_validation_green: bool
+    architecture_debt_gate_green: bool
+    refactor_startup_audit_green: bool
+
+    def blockers(self) -> Tuple[str, ...]:
+        checks = (
+            ("issue_82_fresh_risk_day_pass", self.issue_82_fresh_risk_day_pass),
+            ("issue_82_forward_session_pass", self.issue_82_forward_session_pass),
+            ("clean_active_accounting_audit", self.clean_active_accounting_audit),
+            ("canonical_ledger_chain_valid", self.canonical_ledger_chain_valid),
+            ("protected_valuation_sane", self.protected_valuation_sane),
+            ("stage_b_valuation_parity", self.stage_b_valuation_parity),
+            ("stage_c_risk_parity", self.stage_c_risk_parity),
+            ("stage_d_restart_parity", self.stage_d_restart_parity),
+            ("stage_e_accounting_parity", self.stage_e_accounting_parity),
+            ("repository_validation_green", self.repository_validation_green),
+            ("architecture_debt_gate_green", self.architecture_debt_gate_green),
+            ("refactor_startup_audit_green", self.refactor_startup_audit_green),
+        )
+        return tuple(name for name, passed in checks if not bool(passed))
+
+
+@dataclass(frozen=True)
+class CanaryPlan:
+    requested_fraction: float
+    eligible_for_future_canary: bool
+    blockers: Tuple[str, ...]
+    rollback_switch_required: bool = True
+    rollback_default_armed: bool = True
+    runtime_registration: bool = False
+    production_state_writes: bool = False
+    order_authority: bool = False
+    risk_mutation_authority: bool = False
+    live_authority: bool = False
+    ml_execution_authority: bool = False
+    authority: str = AUTHORITY
+    version: str = VERSION
+
+    def __post_init__(self) -> None:
+        fraction = float(self.requested_fraction)
+        if not 0.0 < fraction <= MAX_CANARY_FRACTION:
+            raise CanaryInvariantError(
+                f"requested canary fraction must be > 0 and <= {MAX_CANARY_FRACTION}"
+            )
+        if self.authority != AUTHORITY:
+            raise CanaryInvariantError("Stage F planner must remain shadow-only")
+        if any(
+            (
+                self.runtime_registration,
+                self.production_state_writes,
+                self.order_authority,
+                self.risk_mutation_authority,
+                self.live_authority,
+                self.ml_execution_authority,
+            )
+        ):
+            raise CanaryInvariantError("Stage F readiness plan cannot hold runtime authority")
+        if self.eligible_for_future_canary != (len(self.blockers) == 0):
+            raise CanaryInvariantError("eligibility must exactly match blocker state")
+        object.__setattr__(self, "requested_fraction", fraction)
+        object.__setattr__(self, "blockers", tuple(self.blockers))
+
+    def to_dict(self) -> Mapping[str, Any]:
+        return MappingProxyType(
+            {
+                "authority": self.authority,
+                "version": self.version,
+                "requested_fraction": self.requested_fraction,
+                "eligible_for_future_canary": self.eligible_for_future_canary,
+                "blockers": self.blockers,
+                "rollback_switch_required": self.rollback_switch_required,
+                "rollback_default_armed": self.rollback_default_armed,
+                "runtime_registration": self.runtime_registration,
+                "production_state_writes": self.production_state_writes,
+                "order_authority": self.order_authority,
+                "risk_mutation_authority": self.risk_mutation_authority,
+                "live_authority": self.live_authority,
+                "ml_execution_authority": self.ml_execution_authority,
+            }
+        )
+
+
+class CanaryReadinessPlanner:
+    """Pure readiness evaluation; never performs a production canary cutover."""
+
+    authority = AUTHORITY
+    max_canary_fraction = MAX_CANARY_FRACTION
+    runtime_registration = False
+    production_state_writes = False
+    order_authority = False
+    risk_mutation_authority = False
+
+    @classmethod
+    def plan(
+        cls,
+        *,
+        evidence: CanaryEvidence,
+        requested_fraction: float = 0.01,
+    ) -> CanaryPlan:
+        blockers = evidence.blockers()
+        return CanaryPlan(
+            requested_fraction=requested_fraction,
+            eligible_for_future_canary=not blockers,
+            blockers=blockers,
+        )
+
+    @classmethod
+    def descriptor(cls) -> Mapping[str, Any]:
+        return MappingProxyType(
+            {
+                "target_interface": "trading.canary.CanaryReadinessPlanner",
+                "authority": cls.authority,
+                "max_canary_fraction": cls.max_canary_fraction,
+                "runtime_registration": cls.runtime_registration,
+                "production_state_writes": cls.production_state_writes,
+                "order_authority": cls.order_authority,
+                "risk_mutation_authority": cls.risk_mutation_authority,
+                "version": VERSION,
+            }
+        )


### PR DESCRIPTION
## Purpose
Implement the shadow/parity-first portion of Issue #84 Stage F without activating a production canary. This PR only evaluates whether future bounded canary cutover prerequisites are satisfied.

## What it adds
- `trading/canary.py`: immutable shadow-only canary evidence and readiness planner.
- `stable_paper_core_v3_stage_f_contract.json`: machine-readable Stage F blockers, maximum 5% canary bound, and rollback requirements.
- `test_architecture_stage_f_canary.py`: current Issue #82 blocker behavior, all-green eligibility, strict canary bound, rollback defaults, and authority-boundary regressions.
- dedicated Stage F CI workflow.

## Current gate behavior
Issue #82 is still open. Missing fresh-risk-day proof, normal forward-session proof, clean active accounting audit, and Stage E runtime shadow parity therefore keep authoritative canary activation blocked. This PR encodes those blockers rather than bypassing them.

## Safety
- shadow-only;
- no runtime registration;
- no production state-file I/O;
- no risk mutation or halt clearing;
- no order placement;
- no historical ledger rewrite;
- no strategy, sizing, threshold, live-authority, or ML-authority changes;
- even all-green evidence marks only `eligible_for_future_canary`; this module has no activation method or production authority;
- rollback switch remains required and armed by default.

Do not merge unless dedicated Stage F tests, repository validation, architecture-debt regression, refactor/ownership/configuration audit, and exact Gunicorn startup smoke all pass.