### PR TITLE
Mandatory exact-head change safety audit gate

### DIFF
--- a/.github/workflows/change-safety-audit.yml
+++ b/.github/workflows/change-safety-audit.yml
@@ -1,0 +1,235 @@
+name: Change Safety Audit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  change-safety-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Resolve exact base and head
+        id: refs
+        shell: bash
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha || github.event.before }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            BASE_SHA=$(git rev-parse HEAD^)
+          fi
+          ACTUAL_SHA=$(git rev-parse HEAD)
+          test "$ACTUAL_SHA" = "$HEAD_SHA"
+          echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Test the audit gate itself
+        id: gate_tests
+        continue-on-error: true
+        run: python -m unittest -v test_change_safety_audit.py
+
+      - name: Install declared runtime dependencies
+        id: dependencies
+        continue-on-error: true
+        run: |
+          python -m pip install --disable-pip-version-check --upgrade pip
+          python -m pip install --disable-pip-version-check -r requirements.txt
+
+      - name: Run impact-aware regression plus canonical invariant suite
+        id: regressions
+        continue-on-error: true
+        run: |
+          python change_safety_audit.py \
+            --base "${{ steps.refs.outputs.base_sha }}" \
+            --head "${{ steps.refs.outputs.head_sha }}" \
+            --expected-head "${{ steps.refs.outputs.head_sha }}" \
+            --run-regressions \
+            --component regression_execution=success \
+            --json change_safety_regression_plan.json
+
+      - name: Repository-wide safety validation
+        id: repository_validation
+        continue-on-error: true
+        run: |
+          python repository_validation.py \
+            --base "${{ steps.refs.outputs.base_sha }}" \
+            --report repository_validation_report.json
+          python railway_config_validation.py
+
+      - name: Structural architecture audit
+        id: structural_audit
+        continue-on-error: true
+        run: |
+          python refactor_audit_cli.py \
+            --base "${{ steps.refs.outputs.base_sha }}" \
+            --json refactor_audit_report.json \
+            --markdown refactor_audit_report.md \
+            --fail-on-new-critical
+
+      - name: Architecture ownership validation
+        id: architecture_contract
+        continue-on-error: true
+        run: |
+          test -f refactor_audit_report.json
+          python architecture_contract_validation.py \
+            --audit refactor_audit_report.json \
+            --registry architecture_ownership_registry.json \
+            --json architecture_contract_report.json \
+            --markdown architecture_contract_report.md
+
+      - name: Typed configuration parity
+        id: typed_configuration
+        continue-on-error: true
+        run: |
+          test -f refactor_audit_report.json
+          python typed_configuration_snapshot.py \
+            --audit refactor_audit_report.json \
+            --contract typed_configuration_contract.json \
+            --json typed_configuration_report.json \
+            --markdown typed_configuration_report.md
+
+      - name: Block architecture debt growth
+        id: architecture_debt
+        continue-on-error: true
+        run: |
+          test -f refactor_audit_report.json
+          python architecture_debt_regression_gate.py \
+            --audit refactor_audit_report.json \
+            --json architecture_debt_regression_report.json
+
+      - name: Exact Gunicorn bootstrap startup smoke
+        id: startup_smoke
+        continue-on-error: true
+        env:
+          PORT: "8765"
+          DEFERRED_WSGI_BOOTSTRAP: "true"
+          WEB_WORKER_ALLOW_HEAVY_RESEARCH: "false"
+          PERFORMANCE_AUDIT_AUTO_BACKTEST_ENABLED: "false"
+          PERFORMANCE_AUDIT_V2_AUTO_BACKTEST_ENABLED: "false"
+          PERFORMANCE_AUDIT_V2_ENABLED: "false"
+        run: |
+          rm -f startup_gunicorn.log bootstrap_status.json bootstrap_root.json
+          PYTHONPATH=bootstrap:. gunicorn bootstrap_wsgi:app \
+            --bind 127.0.0.1:$PORT \
+            --workers 1 \
+            --threads 4 \
+            --timeout 180 \
+            >startup_gunicorn.log 2>&1 &
+          GUNICORN_PID=$!
+          cleanup() {
+            kill "$GUNICORN_PID" 2>/dev/null || true
+            wait "$GUNICORN_PID" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+          for _ in $(seq 1 30); do
+            if curl --silent --show-error --fail "http://127.0.0.1:$PORT/bootstrap-status" >bootstrap_status.json; then
+              break
+            fi
+            kill -0 "$GUNICORN_PID" 2>/dev/null || { cat startup_gunicorn.log; exit 1; }
+            sleep 2
+          done
+          test -s bootstrap_status.json || { cat startup_gunicorn.log; exit 1; }
+          ready=false
+          for _ in $(seq 1 45); do
+            state=$(python - <<'PY'
+          import json
+          from pathlib import Path
+          print(json.loads(Path("bootstrap_status.json").read_text()).get("status", "unknown"))
+          PY
+          )
+            if [ "$state" = "ready" ]; then ready=true; break; fi
+            if [ "$state" = "error" ]; then cat bootstrap_status.json; cat startup_gunicorn.log; exit 1; fi
+            sleep 2
+            curl --silent --show-error --fail "http://127.0.0.1:$PORT/bootstrap-status" >bootstrap_status.json
+          done
+          test "$ready" = "true" || { cat bootstrap_status.json; cat startup_gunicorn.log; exit 1; }
+          curl --silent --show-error --fail "http://127.0.0.1:$PORT/" >bootstrap_root.json
+
+      - name: Final exact-head change safety decision
+        id: final_gate
+        if: always()
+        shell: bash
+        run: |
+          NEW_CRITICAL=$(python - <<'PY'
+          import json
+          from pathlib import Path
+          path = Path("refactor_audit_report.json")
+          if not path.exists():
+              print(999)
+          else:
+              report = json.loads(path.read_text())
+              print(len(report.get("comparison", {}).get("new_critical", [])))
+          PY
+          )
+          python change_safety_audit.py \
+            --base "${{ steps.refs.outputs.base_sha }}" \
+            --head "${{ steps.refs.outputs.head_sha }}" \
+            --expected-head "${{ steps.refs.outputs.head_sha }}" \
+            --new-critical "$NEW_CRITICAL" \
+            --component gate_tests=${{ steps.gate_tests.outcome }} \
+            --component dependencies=${{ steps.dependencies.outcome }} \
+            --component targeted_regressions=${{ steps.regressions.outcome }} \
+            --component repository_validation=${{ steps.repository_validation.outcome }} \
+            --component structural_audit=${{ steps.structural_audit.outcome }} \
+            --component architecture_contract=${{ steps.architecture_contract.outcome }} \
+            --component typed_configuration=${{ steps.typed_configuration.outcome }} \
+            --component architecture_debt=${{ steps.architecture_debt.outcome }} \
+            --component startup_smoke=${{ steps.startup_smoke.outcome }} \
+            --json change_safety_audit_report.json
+
+      - name: Upload exact-head audit evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: change-safety-audit-${{ steps.refs.outputs.head_sha }}
+          path: |
+            change_safety_audit_report.json
+            change_safety_regression_plan.json
+            repository_validation_report.json
+            railway_config_validation_report.json
+            refactor_audit_report.json
+            refactor_audit_report.md
+            architecture_contract_report.json
+            architecture_contract_report.md
+            typed_configuration_report.json
+            typed_configuration_report.md
+            architecture_debt_regression_report.json
+            startup_gunicorn.log
+            bootstrap_status.json
+            bootstrap_root.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Publish exact-head status on main pushes
+        if: always() && github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const passed = '${{ steps.final_gate.outcome }}' === 'success';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ steps.refs.outputs.head_sha }}',
+              state: passed ? 'success' : 'failure',
+              context: 'change-safety-audit',
+              description: passed
+                ? 'Exact-head regression and architecture safety audit passed'
+                : 'Change safety audit failed; merge/deploy must remain blocked',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });

--- a/VALIDATION_POLICY.md
+++ b/VALIDATION_POLICY.md
@@ -18,6 +18,27 @@ A trading-behavior change must pass:
 
 "Forward test" means observation on data and market cycles that were not available when the change was designed. It does not mean predicting future prices.
 
+## Mandatory Exact-Head Change Safety Audit
+
+Every future pull request that can affect Python code, runtime behavior, configuration, persistence, workflows, startup, diagnostics, strategy, accounting, valuation, risk, execution, or repository validation must pass the canonical `Change Safety Audit` on the exact pull-request head SHA before merge or deployment.
+
+A local unit test or stage-specific check is never sufficient by itself. The mandatory audit must:
+
+- classify the changed surface and affected authority boundaries;
+- run targeted/impact-aware regression tests selected from the changed paths;
+- always run the canonical state, valuation, accounting, risk, and canary invariant suite;
+- run repository-wide safety validation and Railway configuration validation;
+- run the structural refactor audit with no new critical findings;
+- validate architecture ownership and typed configuration parity;
+- block any architecture-debt increase;
+- run the exact Gunicorn/bootstrap startup smoke;
+- verify the checked-out commit SHA exactly matches the pull-request head SHA;
+- emit a machine-readable `change_safety_audit_report.json` tied to that SHA.
+
+The audit fails closed when any required component is missing, stale, skipped, incomplete, or failing. A passing audit on an older commit does not satisfy a newer pull-request head. Repository rules/branch protection must require the `Change Safety Audit` check before merge where repository permissions support enforcement.
+
+The gate itself must retain regression proof that a seeded breaking condition is rejected and an all-green safe change is accepted. No alternate workflow or path-only change may bypass the canonical audit.
+
 ## Validation by Change Type
 
 ### Documentation, comments, formatting, and non-runtime workflow edits
@@ -127,3 +148,5 @@ Until the architecture audit and shadow-decision path are complete:
 - allow only urgent operational repairs and the testing/refactor foundation;
 - treat the existing performance audit V2 as advisory research;
 - do not promote new policy values from the research lab without forward paper evidence.
+
+The mandatory exact-head Change Safety Audit applies in addition to these temporary rebuild constraints. It does not authorize any cutover otherwise blocked by Issue #82 or the architecture migration plan.

--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Mandatory exact-head change safety audit for future Trading-bot changes.
+
+The gate is governance/test-only. It never imports the trading runtime, reads or
+writes production state, places orders, or changes runtime authority.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Iterable
+
+VERSION = "change-safety-audit-2026-08-20-v1"
+
+CORE_TESTS = (
+    "test_architecture_stage_b.py",
+    "test_architecture_stage_c.py",
+    "test_architecture_stage_d_state_store.py",
+    "test_architecture_stage_e_accounting.py",
+    "test_architecture_stage_f_canary.py",
+)
+RUNTIME_TESTS = (
+    "test_runtime_shadow_capture.py",
+    "test_self_check_runtime_classification.py",
+)
+STATE_TESTS = ("test_state_store_stage_c.py",)
+DECISION_TESTS = ("test_shadow_decision_stage_d.py",)
+CONFIG_TESTS = ("test_architecture_stage_b.py",)
+
+
+@dataclass(frozen=True)
+class AuditDecision:
+    status: str
+    exact_head_match: bool
+    changed_files: tuple[str, ...]
+    impact_categories: tuple[str, ...]
+    authority_boundaries: tuple[str, ...]
+    regression_tests: tuple[str, ...]
+    component_results: dict[str, str]
+    failures: tuple[str, ...]
+
+
+def _git(*args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args], capture_output=True, text=True, check=True
+    )
+    return proc.stdout.strip()
+
+
+def changed_files(base: str, head: str) -> tuple[str, ...]:
+    text = _git("diff", "--name-only", f"{base}...{head}")
+    return tuple(sorted({line.strip() for line in text.splitlines() if line.strip()}))
+
+
+def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    categories: set[str] = set()
+    boundaries: set[str] = set()
+    for raw in paths:
+        path = raw.lower()
+        name = Path(path).name
+        if path.endswith(".md") or path.startswith("docs/"):
+            categories.add("documentation")
+        if path.startswith(".github/workflows/"):
+            categories.add("workflow")
+        if path.endswith(".py"):
+            categories.add("python")
+        if name.startswith("test_") or "/test_" in path:
+            categories.add("tests")
+        if any(token in path for token in ("bootstrap", "wsgi", "sitecustomize", "usercustomize", "app.py")):
+            categories.add("runtime_composition")
+            boundaries.add("startup_runtime")
+        if any(token in path for token in ("state", "persistence", "journal")):
+            categories.add("state_persistence")
+            boundaries.add("state")
+        if any(token in path for token in ("valuation", "price_integrity", "market_data")):
+            categories.add("valuation_market_data")
+            boundaries.add("valuation")
+        if any(token in path for token in ("accounting", "ledger", "execution")):
+            categories.add("accounting_execution")
+            boundaries.update(("accounting", "execution"))
+        if "risk" in path:
+            categories.add("risk")
+            boundaries.add("risk")
+        if any(token in path for token in ("signal", "scanner", "decision", "entry", "exit", "sizing")):
+            categories.add("strategy_decision")
+            boundaries.add("decision")
+        if any(token in path for token in ("config", "contract", "railway", "procfile")):
+            categories.add("configuration")
+            boundaries.add("configuration")
+    if not categories:
+        categories.add("other")
+    return tuple(sorted(categories)), tuple(sorted(boundaries))
+
+
+def planned_regressions(paths: Iterable[str]) -> tuple[str, ...]:
+    categories, _ = classify_paths(paths)
+    tests: list[str] = list(CORE_TESTS)
+    if "runtime_composition" in categories or "workflow" in categories:
+        tests.extend(RUNTIME_TESTS)
+    if "state_persistence" in categories:
+        tests.extend(STATE_TESTS)
+    if "strategy_decision" in categories:
+        tests.extend(DECISION_TESTS)
+    if "configuration" in categories:
+        tests.extend(CONFIG_TESTS)
+    existing = []
+    seen = set()
+    for test in tests:
+        if test not in seen and Path(test).exists():
+            existing.append(test)
+            seen.add(test)
+    return tuple(existing)
+
+
+def run_regressions(paths: Iterable[str]) -> tuple[str, ...]:
+    tests = planned_regressions(paths)
+    if not tests:
+        return tests
+    subprocess.run([sys.executable, "-m", "unittest", "-v", *tests], check=True)
+    return tests
+
+
+def evaluate_gate(
+    *,
+    expected_head: str,
+    actual_head: str,
+    paths: Iterable[str],
+    component_results: dict[str, str],
+    new_critical: int = 0,
+) -> AuditDecision:
+    paths_tuple = tuple(sorted(paths))
+    categories, boundaries = classify_paths(paths_tuple)
+    tests = planned_regressions(paths_tuple)
+    failures: list[str] = []
+    exact = bool(expected_head) and expected_head == actual_head
+    if not exact:
+        failures.append(
+            f"audit head mismatch: expected={expected_head!r} actual={actual_head!r}"
+        )
+    for name, status in sorted(component_results.items()):
+        if status != "success":
+            failures.append(f"component {name} is {status!r}, not success")
+    if int(new_critical) != 0:
+        failures.append(f"architecture debt regression: new_critical={int(new_critical)}")
+    return AuditDecision(
+        status="pass" if not failures else "fail",
+        exact_head_match=exact,
+        changed_files=paths_tuple,
+        impact_categories=categories,
+        authority_boundaries=boundaries,
+        regression_tests=tests,
+        component_results=dict(sorted(component_results.items())),
+        failures=tuple(failures),
+    )
+
+
+def _parse_component(rows: list[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for row in rows:
+        if "=" not in row:
+            raise ValueError(f"component must be NAME=STATUS: {row!r}")
+        key, value = row.split("=", 1)
+        out[key.strip()] = value.strip()
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--expected-head")
+    parser.add_argument("--component", action="append", default=[])
+    parser.add_argument("--new-critical", type=int, default=0)
+    parser.add_argument("--run-regressions", action="store_true")
+    parser.add_argument("--json", default="change_safety_audit_report.json")
+    args = parser.parse_args()
+
+    paths = changed_files(args.base, args.head)
+    tests = run_regressions(paths) if args.run_regressions else planned_regressions(paths)
+
+    components = _parse_component(args.component)
+    expected_head = args.expected_head or args.head
+    actual_head = _git("rev-parse", "HEAD")
+    decision = evaluate_gate(
+        expected_head=expected_head,
+        actual_head=actual_head,
+        paths=paths,
+        component_results=components,
+        new_critical=args.new_critical,
+    )
+    payload = {
+        "version": VERSION,
+        "status": decision.status,
+        "base_sha": args.base,
+        "requested_head_sha": args.head,
+        "actual_checkout_sha": actual_head,
+        "exact_head_match": decision.exact_head_match,
+        "changed_files": list(decision.changed_files),
+        "impact_categories": list(decision.impact_categories),
+        "authority_boundaries": list(decision.authority_boundaries),
+        "regression_tests": list(tests),
+        "component_results": decision.component_results,
+        "new_critical": args.new_critical,
+        "failures": list(decision.failures),
+        "policy": {
+            "mandatory_for_relevant_prs": True,
+            "stale_head_fails_closed": True,
+            "architecture_debt_growth_allowed": False,
+            "changes_live_authority": False,
+            "changes_ml_authority": False,
+            "places_orders": False,
+            "reads_or_writes_production_state": False,
+        },
+    }
+    Path(args.json).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if decision.status == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test_change_safety_audit.py
+++ b/test_change_safety_audit.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import unittest
+
+from change_safety_audit import classify_paths, evaluate_gate
+
+
+class ChangeSafetyAuditTests(unittest.TestCase):
+    def test_seeded_breaking_regression_is_blocked(self) -> None:
+        decision = evaluate_gate(
+            expected_head="abc123",
+            actual_head="abc123",
+            paths=("trading/risk.py", "app.py"),
+            component_results={
+                "targeted_regressions": "success",
+                "repository_validation": "success",
+                "architecture_contract": "success",
+                "typed_configuration": "success",
+                "architecture_debt": "failure",
+                "startup_smoke": "success",
+            },
+            new_critical=1,
+        )
+        self.assertEqual(decision.status, "fail")
+        self.assertTrue(any("architecture_debt" in row for row in decision.failures))
+        self.assertTrue(any("new_critical=1" in row for row in decision.failures))
+
+    def test_safe_change_passes_when_all_evidence_is_exact_and_green(self) -> None:
+        decision = evaluate_gate(
+            expected_head="def456",
+            actual_head="def456",
+            paths=("docs/architecture_notes.md",),
+            component_results={
+                "targeted_regressions": "success",
+                "repository_validation": "success",
+                "architecture_contract": "success",
+                "typed_configuration": "success",
+                "architecture_debt": "success",
+                "startup_smoke": "success",
+            },
+            new_critical=0,
+        )
+        self.assertEqual(decision.status, "pass")
+        self.assertEqual(decision.failures, ())
+
+    def test_stale_audit_head_fails_closed(self) -> None:
+        decision = evaluate_gate(
+            expected_head="new-head",
+            actual_head="old-head",
+            paths=("trading/state_store.py",),
+            component_results={"startup_smoke": "success"},
+            new_critical=0,
+        )
+        self.assertEqual(decision.status, "fail")
+        self.assertFalse(decision.exact_head_match)
+
+    def test_authority_boundary_classification(self) -> None:
+        categories, boundaries = classify_paths(
+            (
+                "app.py",
+                "trading/state_store.py",
+                "trading/valuation.py",
+                "trading/accounting.py",
+                "trading/risk.py",
+            )
+        )
+        self.assertIn("runtime_composition", categories)
+        for boundary in ("startup_runtime", "state", "valuation", "accounting", "risk"):
+            self.assertIn(boundary, boundaries)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose
Implement Issue #94 governance now, without changing trading/runtime authority. Every future relevant PR gets one canonical exact-head regression/architecture safety audit.

## What it adds
- `change_safety_audit.py`: exact-head verification, change-surface/authority classification, impact-aware regression selection, machine-readable PASS/FAIL report, and fail-closed aggregation of required checks.
- `test_change_safety_audit.py`: seeded breaking-regression proof, safe-change proof, stale-head rejection, and authority-boundary classification.
- `.github/workflows/change-safety-audit.yml`: runs on every PR (no path bypass), checks out the exact PR head SHA, runs core canonical invariants plus impact-aware regressions, repository/Railway validation, structural audit, ownership/config parity, architecture-debt blocking, and exact Gunicorn/bootstrap startup smoke.
- `VALIDATION_POLICY.md`: makes the exact-head audit mandatory and documents stale/missing/failing evidence as a merge blocker.

## Safety boundary
Governance/CI only. No production state reads/writes, account mutation, halt clearing, historical ledger rewrite, strategy/sizing/risk-threshold change, order placement, live authority, or ML execution authority.

## Enforcement note
The workflow/check is implemented in-repository. Repository rules/branch protection should require `Change Safety Audit` where repository settings permissions support that configuration. Connector support for repository-rule mutation must be checked separately; lack of settings mutation capability does not weaken the workflow's fail-closed semantics.

## Merge rule
Do not merge unless the new Change Safety Audit itself, existing repository validation, architecture-debt regression, refactor/ownership/configuration audit, and exact Gunicorn startup smoke are all green on this exact head.