### PR TITLE
Add shadow self-diagnosing system sentinel

### DIFF
--- a/.github/workflows/system-sentinel-validation.yml
+++ b/.github/workflows/system-sentinel-validation.yml
@@ -1,0 +1,35 @@
+name: System Sentinel Shadow Validation
+
+on:
+  pull_request:
+    paths:
+      - "system_sentinel.py"
+      - "system_sentinel_contract.json"
+      - "test_system_sentinel.py"
+      - ".github/workflows/system-sentinel-validation.yml"
+  workflow_dispatch:
+
+jobs:
+  sentinel-validation:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run seeded incident and safety-boundary tests
+        run: python -m unittest -v test_system_sentinel.py
+      - name: Verify contract is advisory-only
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          row = json.loads(Path("system_sentinel_contract.json").read_text())
+          assert row["authority"] == "advisory_only"
+          assert row["policy"]["mandatory_core_tests_never_skipped"] is True
+          assert row["policy"]["auto_merges"] is False
+          assert row["policy"]["writes_production_state"] is False
+          assert row["self_healing"]["enabled"] is False
+          PY

--- a/system_sentinel.py
+++ b/system_sentinel.py
@@ -7,8 +7,9 @@ change strategy/risk/live/ML authority.
 """
 from __future__ import annotations
 
+import hashlib
 from dataclasses import asdict, dataclass
-from typing import Any, Iterable, Mapping
+from typing import Any, Mapping
 
 from change_safety_audit import CORE_TESTS, CONFIG_TESTS, RUNTIME_TESTS, STATE_TESTS
 
@@ -51,33 +52,15 @@ BOUNDARY_TESTS = {
 }
 
 FIX_LIBRARY = {
-    "invalid_protected_valuation": (
-        "Trace the protected-mark/valuation input that violated the canonical invariant; repair only the proven source path and keep risk baseline initialization fail-closed."
-    ),
-    "accounting_integrity_failure": (
-        "Trace the exact execution lifecycle producing the unmatched/duplicate/economic issue; preserve the append-only ledger and repair the prospective execution/accounting boundary only."
-    ),
-    "execution_chain_invalid": (
-        "Stop promotion/cutover, verify append-only ledger ordering and integrity provenance, and repair the prospective ledger writer without rewriting historical rows."
-    ),
-    "invalid_risk_baseline": (
-        "Trace the protected valuation used to seed day_start/day_peak; keep the halt/risk state unchanged and repair only the fresh-day initialization path."
-    ),
-    "startup_failure": (
-        "Reproduce the exact bootstrap/Gunicorn failure and repair the smallest startup ownership or dependency defect without adding a second runtime owner."
-    ),
-    "configuration_drift": (
-        "Reconcile the drift to the canonical typed-configuration owner; do not add another environment/default owner."
-    ),
-    "architecture_ownership_regression": (
-        "Remove or consolidate the newly introduced duplicate owner/route/mutation path and preserve the canonical ownership boundary."
-    ),
-    "runner_active_error": (
-        "Reproduce the active runner exception from its compact evidence, fix the narrow failing path, and retain the non-overlapping cycle guard."
-    ),
-    "market_data_incomplete": (
-        "Trace the incomplete provider request lifecycle and repair request accounting/terminal classification without changing strategy thresholds."
-    ),
+    "invalid_protected_valuation": "Trace the protected-mark/valuation input that violated the canonical invariant; repair only the proven source path and keep risk baseline initialization fail-closed.",
+    "accounting_integrity_failure": "Trace the exact execution lifecycle producing the unmatched/duplicate/economic issue; preserve the append-only ledger and repair the prospective execution/accounting boundary only.",
+    "execution_chain_invalid": "Stop promotion/cutover, verify append-only ledger ordering and integrity provenance, and repair the prospective ledger writer without rewriting historical rows.",
+    "invalid_risk_baseline": "Trace the protected valuation used to seed day_start/day_peak; keep the halt/risk state unchanged and repair only the fresh-day initialization path.",
+    "startup_failure": "Reproduce the exact bootstrap/Gunicorn failure and repair the smallest startup ownership or dependency defect without adding a second runtime owner.",
+    "configuration_drift": "Reconcile the drift to the canonical typed-configuration owner; do not add another environment/default owner.",
+    "architecture_ownership_regression": "Remove or consolidate the newly introduced duplicate owner/route/mutation path and preserve the canonical ownership boundary.",
+    "runner_active_error": "Reproduce the active runner exception from its compact evidence, fix the narrow failing path, and retain the non-overlapping cycle guard.",
+    "market_data_incomplete": "Trace the incomplete provider request lifecycle and repair request accounting/terminal classification without changing strategy thresholds.",
 }
 
 
@@ -101,20 +84,11 @@ def _tests(boundary: str, *, full: bool) -> tuple[str, ...]:
     return tuple(out)
 
 
-def _incident(
-    *,
-    boundary: str,
-    severity: str,
-    reason: str,
-    evidence: Mapping[str, Any],
-    cause: str,
-    confidence: float,
-    full: bool,
-) -> Incident:
+def _incident(*, boundary: str, severity: str, reason: str, evidence: Mapping[str, Any], cause: str, confidence: float, full: bool) -> Incident:
     normalized = "|".join(f"{k}={evidence[k]!r}" for k in sorted(evidence))
-    suffix = abs(hash((boundary, reason, normalized))) % 10_000_000
+    digest = hashlib.sha256(f"{boundary}|{reason}|{normalized}".encode("utf-8")).hexdigest()[:12]
     return Incident(
-        incident_id=f"{boundary}:{reason}:{suffix:07d}",
+        incident_id=f"{boundary}:{reason}:{digest}",
         severity=severity,
         boundary=boundary,
         reason_code=reason,
@@ -135,35 +109,19 @@ def diagnose(snapshot: Mapping[str, Any]) -> tuple[Incident, ...]:
     valuation = _d(s.get("valuation"))
     equity = valuation.get("equity")
     eligible = valuation.get("risk_baseline_eligible")
-    if valuation and (
-        valuation.get("status") in {"fail", "error"}
-        or eligible is False
-        or isinstance(equity, (int, float)) and equity <= 0
-    ):
-        incidents.append(_incident(
-            boundary="valuation", severity="critical", reason="invalid_protected_valuation",
-            evidence={"status": valuation.get("status"), "equity": equity, "risk_baseline_eligible": eligible},
-            cause="Protected valuation is invalid or ineligible to seed canonical risk state.", confidence=0.98, full=True,
-        ))
+    if valuation and (valuation.get("status") in {"fail", "error"} or eligible is False or isinstance(equity, (int, float)) and equity <= 0):
+        incidents.append(_incident(boundary="valuation", severity="critical", reason="invalid_protected_valuation", evidence={"status": valuation.get("status"), "equity": equity, "risk_baseline_eligible": eligible}, cause="Protected valuation is invalid or ineligible to seed canonical risk state.", confidence=0.98, full=True))
 
     accounting = _d(s.get("accounting"))
     coverage = accounting.get("coverage_complete")
     economic_count = int(accounting.get("economic_issue_count") or 0)
     coverage_count = int(accounting.get("coverage_issue_count") or 0)
     if accounting and (accounting.get("status") in {"fail", "partial", "error"} or coverage is False or economic_count or coverage_count):
-        incidents.append(_incident(
-            boundary="accounting", severity="critical", reason="accounting_integrity_failure",
-            evidence={"status": accounting.get("status"), "coverage_complete": coverage, "economic_issue_count": economic_count, "coverage_issue_count": coverage_count},
-            cause="Canonical execution projection cannot prove complete economic/accounting coverage.", confidence=0.99, full=True,
-        ))
+        incidents.append(_incident(boundary="accounting", severity="critical", reason="accounting_integrity_failure", evidence={"status": accounting.get("status"), "coverage_complete": coverage, "economic_issue_count": economic_count, "coverage_issue_count": coverage_count}, cause="Canonical execution projection cannot prove complete economic/accounting coverage.", confidence=0.99, full=True))
 
     ledger = _d(s.get("execution_ledger"))
     if ledger and ledger.get("chain_valid") is False:
-        incidents.append(_incident(
-            boundary="execution", severity="critical", reason="execution_chain_invalid",
-            evidence={"chain_valid": False, "row_count": ledger.get("row_count"), "epoch_id": ledger.get("current_epoch_id")},
-            cause="Canonical append-only execution chain integrity failed.", confidence=1.0, full=True,
-        ))
+        incidents.append(_incident(boundary="execution", severity="critical", reason="execution_chain_invalid", evidence={"chain_valid": False, "row_count": ledger.get("row_count"), "epoch_id": ledger.get("current_epoch_id")}, cause="Canonical append-only execution chain integrity failed.", confidence=1.0, full=True))
 
     risk = _d(s.get("risk"))
     start = risk.get("day_start_equity")
@@ -174,54 +132,30 @@ def diagnose(snapshot: Mapping[str, Any]) -> tuple[Incident, ...]:
     except (TypeError, ValueError):
         invalid_risk = bool(risk) and (start is not None or peak is not None)
     if risk and invalid_risk:
-        incidents.append(_incident(
-            boundary="risk", severity="critical", reason="invalid_risk_baseline",
-            evidence={"day_start_equity": start, "day_peak_equity": peak, "halted": risk.get("halted")},
-            cause="Canonical daily-risk baseline violates positive/monotonic initialization invariants.", confidence=0.99, full=True,
-        ))
+        incidents.append(_incident(boundary="risk", severity="critical", reason="invalid_risk_baseline", evidence={"day_start_equity": start, "day_peak_equity": peak, "halted": risk.get("halted")}, cause="Canonical daily-risk baseline violates positive/monotonic initialization invariants.", confidence=0.99, full=True))
 
     startup = _d(s.get("startup"))
     if startup and startup.get("status") in {"error", "fail", "failed"}:
-        incidents.append(_incident(
-            boundary="startup_runtime", severity="critical", reason="startup_failure",
-            evidence={"status": startup.get("status"), "error": startup.get("error"), "phase": startup.get("phase")},
-            cause="Application bootstrap did not reach the canonical ready/delegating state.", confidence=0.97, full=True,
-        ))
+        incidents.append(_incident(boundary="startup_runtime", severity="critical", reason="startup_failure", evidence={"status": startup.get("status"), "error": startup.get("error"), "phase": startup.get("phase")}, cause="Application bootstrap did not reach the canonical ready/delegating state.", confidence=0.97, full=True))
 
     config = _d(s.get("configuration"))
     config_violations = config.get("violations") or []
     if config and config_violations:
-        incidents.append(_incident(
-            boundary="configuration", severity="high", reason="configuration_drift",
-            evidence={"violation_count": len(config_violations), "first_violation": config_violations[0]},
-            cause="Observed configuration no longer matches the canonical typed owner/units contract.", confidence=0.95, full=True,
-        ))
+        incidents.append(_incident(boundary="configuration", severity="high", reason="configuration_drift", evidence={"violation_count": len(config_violations), "first_violation": config_violations[0]}, cause="Observed configuration no longer matches the canonical typed owner/units contract.", confidence=0.95, full=True))
 
     architecture = _d(s.get("architecture"))
     new_critical = architecture.get("new_critical") or []
     ownership = architecture.get("ownership_violations") or []
     if architecture and (new_critical or ownership):
-        incidents.append(_incident(
-            boundary="architecture", severity="high", reason="architecture_ownership_regression",
-            evidence={"new_critical_count": len(new_critical), "ownership_violation_count": len(ownership)},
-            cause="A change introduced structural debt or duplicated an authoritative ownership boundary.", confidence=0.98, full=True,
-        ))
+        incidents.append(_incident(boundary="architecture", severity="high", reason="architecture_ownership_regression", evidence={"new_critical_count": len(new_critical), "ownership_violation_count": len(ownership)}, cause="A change introduced structural debt or duplicated an authoritative ownership boundary.", confidence=0.98, full=True))
 
     runner = _d(s.get("runner"))
     if runner and runner.get("active_error"):
-        incidents.append(_incident(
-            boundary="runner", severity="high", reason="runner_active_error",
-            evidence={"active_error": True, "last_error": runner.get("last_error"), "last_attempt": runner.get("last_attempt")},
-            cause="The canonical cycle/runner reports an active exception after its most recent attempt.", confidence=0.94, full=False,
-        ))
+        incidents.append(_incident(boundary="runner", severity="high", reason="runner_active_error", evidence={"active_error": True, "last_error": runner.get("last_error"), "last_attempt": runner.get("last_attempt")}, cause="The canonical cycle/runner reports an active exception after its most recent attempt.", confidence=0.94, full=False))
 
     market = _d(s.get("market_data"))
     if market and (market.get("status") in {"fail", "error"} or market.get("accounting_complete_at_snapshot") is False or int(market.get("in_flight_or_unclassified_requests") or 0) > 0):
-        incidents.append(_incident(
-            boundary="market_data", severity="high", reason="market_data_incomplete",
-            evidence={"status": market.get("status"), "accounting_complete_at_snapshot": market.get("accounting_complete_at_snapshot"), "in_flight_or_unclassified_requests": market.get("in_flight_or_unclassified_requests")},
-            cause="Market-data request accounting has unresolved or unclassified terminal outcomes.", confidence=0.92, full=False,
-        ))
+        incidents.append(_incident(boundary="market_data", severity="high", reason="market_data_incomplete", evidence={"status": market.get("status"), "accounting_complete_at_snapshot": market.get("accounting_complete_at_snapshot"), "in_flight_or_unclassified_requests": market.get("in_flight_or_unclassified_requests")}, cause="Market-data request accounting has unresolved or unclassified terminal outcomes.", confidence=0.92, full=False))
 
     order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
     return tuple(sorted(incidents, key=lambda row: (order.get(row.severity, 9), row.boundary, row.reason_code)))

--- a/system_sentinel.py
+++ b/system_sentinel.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Read-only incident triage for Trading-bot post-rebuild diagnostics.
+
+This module consumes already-produced diagnostic dictionaries. It does not import
+the trading runtime, read/write production state, clear halts, place orders, or
+change strategy/risk/live/ML authority.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Mapping
+
+from change_safety_audit import CORE_TESTS, CONFIG_TESTS, RUNTIME_TESTS, STATE_TESTS
+
+VERSION = "system-sentinel-shadow-2026-08-20-v1"
+AUTHORITY = "advisory_only"
+
+
+@dataclass(frozen=True)
+class Incident:
+    incident_id: str
+    severity: str
+    boundary: str
+    reason_code: str
+    evidence: Mapping[str, Any]
+    suspected_cause: str
+    confidence: float
+    proposed_fix: str
+    selected_tests: tuple[str, ...]
+    full_audit_required: bool
+    authority: str = AUTHORITY
+
+    def to_dict(self) -> dict[str, Any]:
+        row = asdict(self)
+        row["evidence"] = dict(self.evidence)
+        row["selected_tests"] = list(self.selected_tests)
+        return row
+
+
+BOUNDARY_TESTS = {
+    "state": STATE_TESTS,
+    "valuation": ("test_architecture_stage_b.py",),
+    "accounting": ("test_architecture_stage_e_accounting.py",),
+    "execution": ("test_architecture_stage_e_accounting.py",),
+    "risk": ("test_architecture_stage_c.py",),
+    "startup_runtime": RUNTIME_TESTS,
+    "configuration": CONFIG_TESTS,
+    "architecture": (),
+    "runner": RUNTIME_TESTS,
+    "market_data": ("test_architecture_stage_b.py",),
+}
+
+FIX_LIBRARY = {
+    "invalid_protected_valuation": (
+        "Trace the protected-mark/valuation input that violated the canonical invariant; repair only the proven source path and keep risk baseline initialization fail-closed."
+    ),
+    "accounting_integrity_failure": (
+        "Trace the exact execution lifecycle producing the unmatched/duplicate/economic issue; preserve the append-only ledger and repair the prospective execution/accounting boundary only."
+    ),
+    "execution_chain_invalid": (
+        "Stop promotion/cutover, verify append-only ledger ordering and integrity provenance, and repair the prospective ledger writer without rewriting historical rows."
+    ),
+    "invalid_risk_baseline": (
+        "Trace the protected valuation used to seed day_start/day_peak; keep the halt/risk state unchanged and repair only the fresh-day initialization path."
+    ),
+    "startup_failure": (
+        "Reproduce the exact bootstrap/Gunicorn failure and repair the smallest startup ownership or dependency defect without adding a second runtime owner."
+    ),
+    "configuration_drift": (
+        "Reconcile the drift to the canonical typed-configuration owner; do not add another environment/default owner."
+    ),
+    "architecture_ownership_regression": (
+        "Remove or consolidate the newly introduced duplicate owner/route/mutation path and preserve the canonical ownership boundary."
+    ),
+    "runner_active_error": (
+        "Reproduce the active runner exception from its compact evidence, fix the narrow failing path, and retain the non-overlapping cycle guard."
+    ),
+    "market_data_incomplete": (
+        "Trace the incomplete provider request lifecycle and repair request accounting/terminal classification without changing strategy thresholds."
+    ),
+}
+
+
+def _d(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _tests(boundary: str, *, full: bool) -> tuple[str, ...]:
+    selected = list(CORE_TESTS)
+    selected.extend(BOUNDARY_TESTS.get(boundary, ()))
+    if full:
+        selected.extend(RUNTIME_TESTS)
+        selected.extend(STATE_TESTS)
+        selected.extend(CONFIG_TESTS)
+    out: list[str] = []
+    seen: set[str] = set()
+    for row in selected:
+        if row not in seen:
+            out.append(row)
+            seen.add(row)
+    return tuple(out)
+
+
+def _incident(
+    *,
+    boundary: str,
+    severity: str,
+    reason: str,
+    evidence: Mapping[str, Any],
+    cause: str,
+    confidence: float,
+    full: bool,
+) -> Incident:
+    normalized = "|".join(f"{k}={evidence[k]!r}" for k in sorted(evidence))
+    suffix = abs(hash((boundary, reason, normalized))) % 10_000_000
+    return Incident(
+        incident_id=f"{boundary}:{reason}:{suffix:07d}",
+        severity=severity,
+        boundary=boundary,
+        reason_code=reason,
+        evidence=dict(evidence),
+        suspected_cause=cause,
+        confidence=max(0.0, min(1.0, float(confidence))),
+        proposed_fix=FIX_LIBRARY[reason],
+        selected_tests=_tests(boundary, full=full),
+        full_audit_required=bool(full),
+    )
+
+
+def diagnose(snapshot: Mapping[str, Any]) -> tuple[Incident, ...]:
+    """Classify a compact diagnostic snapshot deterministically and read-only."""
+    s = dict(snapshot)
+    incidents: list[Incident] = []
+
+    valuation = _d(s.get("valuation"))
+    equity = valuation.get("equity")
+    eligible = valuation.get("risk_baseline_eligible")
+    if valuation and (
+        valuation.get("status") in {"fail", "error"}
+        or eligible is False
+        or isinstance(equity, (int, float)) and equity <= 0
+    ):
+        incidents.append(_incident(
+            boundary="valuation", severity="critical", reason="invalid_protected_valuation",
+            evidence={"status": valuation.get("status"), "equity": equity, "risk_baseline_eligible": eligible},
+            cause="Protected valuation is invalid or ineligible to seed canonical risk state.", confidence=0.98, full=True,
+        ))
+
+    accounting = _d(s.get("accounting"))
+    coverage = accounting.get("coverage_complete")
+    economic_count = int(accounting.get("economic_issue_count") or 0)
+    coverage_count = int(accounting.get("coverage_issue_count") or 0)
+    if accounting and (accounting.get("status") in {"fail", "partial", "error"} or coverage is False or economic_count or coverage_count):
+        incidents.append(_incident(
+            boundary="accounting", severity="critical", reason="accounting_integrity_failure",
+            evidence={"status": accounting.get("status"), "coverage_complete": coverage, "economic_issue_count": economic_count, "coverage_issue_count": coverage_count},
+            cause="Canonical execution projection cannot prove complete economic/accounting coverage.", confidence=0.99, full=True,
+        ))
+
+    ledger = _d(s.get("execution_ledger"))
+    if ledger and ledger.get("chain_valid") is False:
+        incidents.append(_incident(
+            boundary="execution", severity="critical", reason="execution_chain_invalid",
+            evidence={"chain_valid": False, "row_count": ledger.get("row_count"), "epoch_id": ledger.get("current_epoch_id")},
+            cause="Canonical append-only execution chain integrity failed.", confidence=1.0, full=True,
+        ))
+
+    risk = _d(s.get("risk"))
+    start = risk.get("day_start_equity")
+    peak = risk.get("day_peak_equity")
+    invalid_risk = False
+    try:
+        invalid_risk = float(start) <= 0 or float(peak) <= 0 or float(peak) < float(start)
+    except (TypeError, ValueError):
+        invalid_risk = bool(risk) and (start is not None or peak is not None)
+    if risk and invalid_risk:
+        incidents.append(_incident(
+            boundary="risk", severity="critical", reason="invalid_risk_baseline",
+            evidence={"day_start_equity": start, "day_peak_equity": peak, "halted": risk.get("halted")},
+            cause="Canonical daily-risk baseline violates positive/monotonic initialization invariants.", confidence=0.99, full=True,
+        ))
+
+    startup = _d(s.get("startup"))
+    if startup and startup.get("status") in {"error", "fail", "failed"}:
+        incidents.append(_incident(
+            boundary="startup_runtime", severity="critical", reason="startup_failure",
+            evidence={"status": startup.get("status"), "error": startup.get("error"), "phase": startup.get("phase")},
+            cause="Application bootstrap did not reach the canonical ready/delegating state.", confidence=0.97, full=True,
+        ))
+
+    config = _d(s.get("configuration"))
+    config_violations = config.get("violations") or []
+    if config and config_violations:
+        incidents.append(_incident(
+            boundary="configuration", severity="high", reason="configuration_drift",
+            evidence={"violation_count": len(config_violations), "first_violation": config_violations[0]},
+            cause="Observed configuration no longer matches the canonical typed owner/units contract.", confidence=0.95, full=True,
+        ))
+
+    architecture = _d(s.get("architecture"))
+    new_critical = architecture.get("new_critical") or []
+    ownership = architecture.get("ownership_violations") or []
+    if architecture and (new_critical or ownership):
+        incidents.append(_incident(
+            boundary="architecture", severity="high", reason="architecture_ownership_regression",
+            evidence={"new_critical_count": len(new_critical), "ownership_violation_count": len(ownership)},
+            cause="A change introduced structural debt or duplicated an authoritative ownership boundary.", confidence=0.98, full=True,
+        ))
+
+    runner = _d(s.get("runner"))
+    if runner and runner.get("active_error"):
+        incidents.append(_incident(
+            boundary="runner", severity="high", reason="runner_active_error",
+            evidence={"active_error": True, "last_error": runner.get("last_error"), "last_attempt": runner.get("last_attempt")},
+            cause="The canonical cycle/runner reports an active exception after its most recent attempt.", confidence=0.94, full=False,
+        ))
+
+    market = _d(s.get("market_data"))
+    if market and (market.get("status") in {"fail", "error"} or market.get("accounting_complete_at_snapshot") is False or int(market.get("in_flight_or_unclassified_requests") or 0) > 0):
+        incidents.append(_incident(
+            boundary="market_data", severity="high", reason="market_data_incomplete",
+            evidence={"status": market.get("status"), "accounting_complete_at_snapshot": market.get("accounting_complete_at_snapshot"), "in_flight_or_unclassified_requests": market.get("in_flight_or_unclassified_requests")},
+            cause="Market-data request accounting has unresolved or unclassified terminal outcomes.", confidence=0.92, full=False,
+        ))
+
+    order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+    return tuple(sorted(incidents, key=lambda row: (order.get(row.severity, 9), row.boundary, row.reason_code)))
+
+
+def report(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    incidents = diagnose(snapshot)
+    return {
+        "version": VERSION,
+        "authority": AUTHORITY,
+        "status": "quiet" if not incidents else "incident",
+        "incident_count": len(incidents),
+        "incidents": [row.to_dict() for row in incidents],
+        "policy": {
+            "advisory_only": True,
+            "mandatory_core_tests_never_skipped": True,
+            "auto_merges": False,
+            "writes_production_state": False,
+            "clears_halts": False,
+            "rewrites_execution_history": False,
+            "changes_strategy_or_sizing": False,
+            "changes_hard_risk_limits": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }

--- a/system_sentinel_contract.json
+++ b/system_sentinel_contract.json
@@ -1,0 +1,48 @@
+{
+  "version": "system-sentinel-contract-2026-08-20-v1",
+  "authority": "advisory_only",
+  "required_boundaries": [
+    "valuation",
+    "accounting",
+    "execution",
+    "risk",
+    "startup_runtime",
+    "configuration",
+    "architecture",
+    "runner",
+    "market_data"
+  ],
+  "incident_schema": [
+    "incident_id",
+    "severity",
+    "boundary",
+    "reason_code",
+    "evidence",
+    "suspected_cause",
+    "confidence",
+    "proposed_fix",
+    "selected_tests",
+    "full_audit_required",
+    "authority"
+  ],
+  "policy": {
+    "advisory_only": true,
+    "mandatory_core_tests_never_skipped": true,
+    "deterministic_test_selection": true,
+    "deterministic_incident_ids": true,
+    "auto_merges": false,
+    "writes_production_state": false,
+    "clears_halts": false,
+    "rewrites_execution_history": false,
+    "changes_strategy_or_sizing": false,
+    "changes_hard_risk_limits": false,
+    "changes_live_or_ml_authority": false,
+    "issue_94_remains_final_merge_gate": true
+  },
+  "self_healing": {
+    "enabled": false,
+    "authoritative_paths_allowed": false,
+    "future_non_authoritative_actions_require_allowlist": true,
+    "future_actions_must_be_reversible_idempotent": true
+  }
+}

--- a/test_system_sentinel.py
+++ b/test_system_sentinel.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import ast
+import json
+import unittest
+from pathlib import Path
+
+from change_safety_audit import CORE_TESTS
+from system_sentinel import diagnose, report
+
+ROOT = Path(__file__).resolve().parent
+
+
+class SystemSentinelTests(unittest.TestCase):
+    def test_normal_runtime_is_quiet(self) -> None:
+        snapshot = {
+            "valuation": {"status": "ok", "equity": 12000.0, "risk_baseline_eligible": True},
+            "accounting": {"status": "ok", "coverage_complete": True, "economic_issue_count": 0, "coverage_issue_count": 0},
+            "execution_ledger": {"chain_valid": True, "row_count": 3},
+            "risk": {"day_start_equity": 12000.0, "day_peak_equity": 12100.0, "halted": False},
+            "startup": {"status": "ready"},
+            "configuration": {"violations": []},
+            "architecture": {"new_critical": [], "ownership_violations": []},
+            "runner": {"active_error": False},
+            "market_data": {"status": "pass", "accounting_complete_at_snapshot": True, "in_flight_or_unclassified_requests": 0},
+        }
+        payload = report(snapshot)
+        self.assertEqual(payload["status"], "quiet")
+        self.assertEqual(payload["incident_count"], 0)
+
+    def test_seeded_faults_are_classified(self) -> None:
+        snapshot = {
+            "valuation": {"status": "fail", "equity": -1.0, "risk_baseline_eligible": False},
+            "accounting": {"status": "partial", "coverage_complete": False, "economic_issue_count": 1, "coverage_issue_count": 1},
+            "execution_ledger": {"chain_valid": False, "row_count": 4},
+            "risk": {"day_start_equity": -1.0, "day_peak_equity": 100.0, "halted": True},
+            "startup": {"status": "error", "error": "boom"},
+            "configuration": {"violations": ["STATE_FILE drift"]},
+            "architecture": {"new_critical": ["save_state owner"], "ownership_violations": []},
+            "runner": {"active_error": True, "last_error": "dictionary changed size"},
+            "market_data": {"status": "fail", "accounting_complete_at_snapshot": False, "in_flight_or_unclassified_requests": 1},
+        }
+        rows = diagnose(snapshot)
+        reasons = {row.reason_code for row in rows}
+        self.assertEqual(reasons, {
+            "invalid_protected_valuation", "accounting_integrity_failure", "execution_chain_invalid",
+            "invalid_risk_baseline", "startup_failure", "configuration_drift",
+            "architecture_ownership_regression", "runner_active_error", "market_data_incomplete",
+        })
+
+    def test_mandatory_core_tests_are_never_skipped(self) -> None:
+        rows = diagnose({"runner": {"active_error": True, "last_error": "x"}})
+        self.assertEqual(len(rows), 1)
+        selected = set(rows[0].selected_tests)
+        self.assertTrue(set(CORE_TESTS).issubset(selected))
+
+    def test_high_severity_cross_boundary_faults_require_full_audit(self) -> None:
+        rows = diagnose({"execution_ledger": {"chain_valid": False}})
+        self.assertTrue(rows[0].full_audit_required)
+
+    def test_incident_id_and_test_selection_are_deterministic(self) -> None:
+        snapshot = {"runner": {"active_error": True, "last_error": "repeatable", "last_attempt": "t"}}
+        first = diagnose(snapshot)[0]
+        second = diagnose(snapshot)[0]
+        self.assertEqual(first.incident_id, second.incident_id)
+        self.assertEqual(first.selected_tests, second.selected_tests)
+
+    def test_contract_matches_read_only_policy(self) -> None:
+        contract = json.loads((ROOT / "system_sentinel_contract.json").read_text())
+        policy = contract["policy"]
+        self.assertEqual(contract["authority"], "advisory_only")
+        self.assertTrue(policy["mandatory_core_tests_never_skipped"])
+        self.assertFalse(policy["auto_merges"])
+        self.assertFalse(policy["writes_production_state"])
+        self.assertFalse(policy["clears_halts"])
+        self.assertFalse(contract["self_healing"]["enabled"])
+
+    def test_module_has_no_runtime_or_authoritative_mutation_calls(self) -> None:
+        path = ROOT / "system_sentinel.py"
+        tree = ast.parse(path.read_text(), filename=str(path))
+        forbidden_imports = {"app", "state_io_hardening", "alpaca_trade_api", "yfinance"}
+        forbidden_calls = {
+            "save_state", "load_state", "atomic_json_write", "enter_position", "exit_position",
+            "submit_order", "place_order", "execute_order", "clear_halt", "update_ref", "merge_pull_request",
+        }
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    self.assertNotIn(alias.name.split(".", 1)[0], forbidden_imports)
+            elif isinstance(node, ast.ImportFrom):
+                self.assertNotIn((node.module or "").split(".", 1)[0], forbidden_imports)
+            elif isinstance(node, ast.Call):
+                name = node.func.id if isinstance(node.func, ast.Name) else node.func.attr if isinstance(node.func, ast.Attribute) else ""
+                self.assertNotIn(name, forbidden_calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose
Implement Issue #96 as a bounded read-only/advisory self-diagnosing incident triage layer while authoritative Stage G cutover remains blocked by Issue #82.

## What it adds
- `system_sentinel.py`: deterministic incident classification across valuation, accounting, execution ledger, risk, startup, configuration, architecture ownership, runner, and market-data diagnostics.
- `system_sentinel_contract.json`: machine-readable authority/safety/test-selection contract.
- `test_system_sentinel.py`: seeded fault classification, quiet-runtime false-positive control, deterministic IDs/test selection, mandatory-core-test preservation, and AST authority-boundary tests.
- dedicated shadow validation workflow.

## Safety boundary
- advisory only; no runtime registration;
- consumes supplied diagnostic dictionaries only;
- no production state reads/writes;
- no halt clearing;
- no execution-history edits;
- no orders;
- no strategy/sizing/risk-threshold/live/ML authority changes;
- no self-healing enabled;
- no GitHub auto-merge behavior;
- Issue #94 remains the final merge gate.

## Test-selection rule
Every incident always retains the Issue #94 canonical core test suite. Boundary-specific regressions are added deterministically; critical/cross-boundary faults escalate to the broader relevant audit rather than suppressing tests.

Do not merge unless the dedicated sentinel validation, Change Safety Audit, repository safety validation, architecture-debt regression, refactor/ownership/configuration audit, and exact Gunicorn startup smoke all pass.