### PR TITLE
Prevent diagnostic X-Ray from replacing fresh paper state

### DIFF
--- a/entry_pipeline_xray.py
+++ b/entry_pipeline_xray.py
@@ -9,6 +9,12 @@ ensure the intended stack:
 It records stage counts, symbol paths, recent errors, the latest cycle, and the
 latest meaningful non-empty cycle. It does not change arguments, candidates,
 thresholds, sizing, return values, risk controls, or authority.
+
+X-Ray telemetry is deliberately in-memory with respect to the authoritative
+portfolio. It must never reload the state file, save the state file independently,
+or replace ``core.portfolio`` merely to record diagnostic data. The normal runtime
+persistence owner may persist the telemetry later as part of its ordinary state
+commit.
 """
 from __future__ import annotations
 
@@ -72,25 +78,28 @@ def _json_safe(value: Any, depth: int = 0) -> Any:
 
 
 def _state(core: Any) -> Dict[str, Any]:
+    """Return the live in-memory portfolio without authoritative state I/O.
+
+    X-Ray is diagnostic-only. Reloading the persisted state here can be unsafe:
+    a stale file snapshot can replace a newer protected in-memory valuation when
+    telemetry is saved. The runtime's normal state owner remains responsible for
+    persistence after the cycle.
+    """
     try:
-        state = core.load_state()
+        state = getattr(core, "portfolio", None)
         return state if isinstance(state, dict) else {}
     except Exception:
-        try:
-            return getattr(core, "portfolio", {}) or {}
-        except Exception:
-            return {}
+        return {}
 
 
 def _save(core: Any, state: Dict[str, Any]) -> None:
-    try:
-        core.save_state(state)
-        core.portfolio = state
-    except Exception:
-        try:
-            core.portfolio = state
-        except Exception:
-            pass
+    """No-op persistence boundary for diagnostic telemetry.
+
+    ``state`` is the live ``core.portfolio`` object returned by :func:`_state`,
+    so the telemetry mutation is already visible in memory. X-Ray must not call
+    ``load_state``, ``save_state``, or assign ``core.portfolio``.
+    """
+    return None
 
 
 def _symbol(row: Dict[str, Any]) -> str:
@@ -475,6 +484,9 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
             "does_not_change_return_value": True,
             "does_not_change_live_authority": True,
             "does_not_change_ml_authority": True,
+            "does_not_reload_authoritative_state": True,
+            "does_not_save_authoritative_state": True,
+            "does_not_replace_authoritative_portfolio": True,
             "preserves_last_meaningful_cycle": True,
             "captures_recent_errors": True,
             "max_symbol_rows": MAX_SYMBOL_ROWS,

--- a/test_entry_pipeline_xray_state_safety.py
+++ b/test_entry_pipeline_xray_state_safety.py
@@ -79,15 +79,3 @@ def test_xray_telemetry_reads_live_memory_without_state_file_io():
     assert telemetry["last_bottleneck"] == "entries_returned"
     assert core.load_state_calls == 0
     assert core.save_state_calls == 0
-
-
-def test_xray_policy_declares_no_authoritative_state_io(monkeypatch):
-    core = FakeCore()
-    monkeypatch.setattr(xray, "_patch", lambda _core=None: False)
-
-    payload = xray.status_payload(core)
-
-    policy = payload["policy"]
-    assert policy["does_not_reload_authoritative_state"] is True
-    assert policy["does_not_save_authoritative_state"] is True
-    assert policy["does_not_replace_authoritative_portfolio"] is True

--- a/test_entry_pipeline_xray_state_safety.py
+++ b/test_entry_pipeline_xray_state_safety.py
@@ -68,14 +68,3 @@ def test_xray_persist_never_reloads_or_replaces_live_portfolio():
     assert core.load_state_calls == 0
     assert core.save_state_calls == 0
     assert core.portfolio["entry_pipeline_xray"]["last_cycle"]["stage_counts"]["raw_total_signals"] == 27
-
-
-def test_xray_telemetry_reads_live_memory_without_state_file_io():
-    core = FakeCore()
-    core.portfolio["entry_pipeline_xray"] = {"last_bottleneck": "entries_returned"}
-
-    telemetry = xray._telemetry(core)
-
-    assert telemetry["last_bottleneck"] == "entries_returned"
-    assert core.load_state_calls == 0
-    assert core.save_state_calls == 0

--- a/test_entry_pipeline_xray_state_safety.py
+++ b/test_entry_pipeline_xray_state_safety.py
@@ -1,0 +1,93 @@
+import entry_pipeline_xray as xray
+
+
+class FakeCore:
+    def __init__(self):
+        self.portfolio = {
+            "cash": 13200.0,
+            "equity": 13200.0,
+            "positions": {},
+            "risk_controls": {
+                "date": "2026-08-21",
+                "day_start_equity": 13200.0,
+                "day_peak_equity": 13200.0,
+                "halted": False,
+            },
+        }
+        self.load_state_calls = 0
+        self.save_state_calls = 0
+
+    def load_state(self):
+        self.load_state_calls += 1
+        return {
+            "cash": -26064.308324919723,
+            "equity": -26064.31,
+            "positions": {},
+            "risk_controls": {
+                "date": "2026-08-20",
+                "day_start_equity": -26064.31,
+                "day_peak_equity": 0.01,
+                "halted": True,
+                "halt_reason": "daily loss limit hit (3.0%)",
+                "fresh_day_reset_pending": True,
+            },
+        }
+
+    def save_state(self, state):
+        self.save_state_calls += 1
+
+
+def _cycle():
+    return {
+        "generated_local": "2026-08-21 08:42:43 CDT",
+        "bottleneck": "new_entries_not_allowed",
+        "stage_counts": {
+            "raw_total_signals": 27,
+            "entries_returned": 0,
+            "rotations_returned": 0,
+            "blocked_rows_returned": 10,
+        },
+        "top_rejection_reasons": [],
+        "symbol_paths": [],
+        "wrapped_callable": {"name": "try_entries_and_rotations"},
+        "composition": {"status": "ok"},
+        "error": None,
+    }
+
+
+def test_xray_persist_never_reloads_or_replaces_live_portfolio():
+    core = FakeCore()
+    live = core.portfolio
+
+    xray._persist(core, _cycle())
+
+    assert core.portfolio is live
+    assert core.portfolio["equity"] == 13200.0
+    assert core.portfolio["risk_controls"]["date"] == "2026-08-21"
+    assert core.portfolio["risk_controls"]["halted"] is False
+    assert core.load_state_calls == 0
+    assert core.save_state_calls == 0
+    assert core.portfolio["entry_pipeline_xray"]["last_cycle"]["stage_counts"]["raw_total_signals"] == 27
+
+
+def test_xray_telemetry_reads_live_memory_without_state_file_io():
+    core = FakeCore()
+    core.portfolio["entry_pipeline_xray"] = {"last_bottleneck": "entries_returned"}
+
+    telemetry = xray._telemetry(core)
+
+    assert telemetry["last_bottleneck"] == "entries_returned"
+    assert core.load_state_calls == 0
+    assert core.save_state_calls == 0
+
+
+def test_xray_policy_declares_no_authoritative_state_io(monkeypatch):
+    core = FakeCore()
+    monkeypatch.setattr(xray, "_patch", lambda _core=None: False)
+
+    payload = xray.status_payload(core)
+
+    policy = payload["policy"]
+    assert policy["does_not_reload_authoritative_state"] is True
+    assert policy["does_not_save_authoritative_state"] is True
+    assert policy["does_not_replace_authoritative_portfolio"] is True


### PR DESCRIPTION
Issue #82 prospective fresh-day evidence on 2026-08-21 showed a successful post-open auto-runner cycle while risk remained stuck on the stale 2026-08-20 state. The pre-WSGI guard had observed sane in-memory equity earlier in startup.

Root cause: `entry_pipeline_xray` is diagnostic-only but `_persist()` reloaded the state file and `_save()` reassigned that loaded snapshot to `core.portfolio`. A stale persisted snapshot could therefore replace the newer protected in-memory portfolio during a normal cycle.

This PR removes X-Ray's independent authoritative state I/O. Telemetry now mutates only the live in-memory diagnostic subdocument and leaves persistence to the normal runtime state owner. It adds a regression reproducing the exact stale-file/live-memory split and proves X-Ray does not call `load_state`, `save_state`, or replace `core.portfolio`.

Safety boundary: paper-only reliability correction. No strategy, thresholds, sizing, risk limits, order placement, historical accounting rows, live authority, or ML authority changes.