### PR TITLE
Add read-only verified snapshot provenance probe

### DIFF
--- a/PROJECT_HANDOFF_CURRENT.md
+++ b/PROJECT_HANDOFF_CURRENT.md
@@ -1,103 +1,98 @@
 # Project Handoff — Authoritative Current Runtime
 
-Last updated: 2026-08-21 10:15 CDT  
+Last updated: 2026-08-21 11:06 CDT  
 Repository: `sterlingfancher-cmyk/Trading-bot`  
-Current `main` before this handoff-only PR: `0874368ad5bf303337b8c94ed1c9ae967c2231b5` (`Update authoritative handoff through Aug 21 (#99)`)  
+Current `main`: `69ec3d39a565a8c9068d0a088f441723e6883c3e` (`Update handoff for current-chat continuity and clean-epoch provenance (#100)`)  
+Active provenance PR: #101, branch `agent/verified-snapshot-provenance-20260821`  
 Canonical Railway paper service: `https://trading-bot-clean.up.railway.app`
 
 ## Communication / Continuity Rule
 
-Keep Trading-bot progress communication in the **currently active ChatGPT project conversation**. This is not permanently tied to one specific thread. When the project intentionally moves to a new ChatGPT conversation, update this handoff first, use the continuation command at the bottom, and treat the new conversation as the active project chat.
+Keep Trading-bot progress communication in the **currently active ChatGPT project conversation**. This is not permanently tied to one thread. When the project intentionally moves to a new ChatGPT conversation, update this handoff first and treat the new conversation as the active project chat.
 
-Do not let project-specific monitoring tasks continue posting into an old/stale project conversation. On 2026-08-21 the `Trading System Completion` and `QQQ Repair Watch` monitoring tasks were disabled; `Trading Architecture Builder` was already disabled. They should remain disabled unless a future current project chat intentionally re-establishes monitoring in that active conversation.
+Project-specific monitoring tasks that could post into stale chats remain disabled unless a future active project conversation intentionally re-establishes them. Repository handoff maintenance is mandatory so a new conversation can recover exact state without relying on prior-chat memory.
 
-Repository handoff maintenance remains mandatory so a new conversation can recover exact state without relying on prior-chat memory.
+When the active conversation is becoming too large for reliable continuation, warn the user **before** a testing/update sequence is started, finish or stop at a clean boundary, refresh this handoff with all material evidence and the exact next action, then move conversations. Do not force a chat switch in the middle of an avoidable test sequence.
 
 ## Executive Status
 
-Operational stabilization is still blocked by GitHub Issue #82. Runtime remains paper-only. Rules remain the sole execution authority. Live authority is disabled. ML/AI remains shadow-only for execution.
+Operational stabilization is still blocked by Issue #82. Runtime remains paper-only. Rules remain sole execution authority. Live authority is disabled. ML/AI remains shadow-only for execution.
 
-The fresh-day protection is now behaving fail-closed, but the authoritative paper account snapshot is corrupted and cannot seed a new risk day. Current live/on-disk state is approximately:
+The fresh-day protection is now correctly fail-closed, but the authoritative paper account snapshot is corrupted and cannot seed a new risk day. Current live/on-disk state is approximately:
 - `cash=-26064.308325`
 - `equity=-26064.31`
 - no open positions
 - `realized_total=-94929.16`
 
-The risk state remains stale from 2026-08-20 with:
+Risk remains stale from 2026-08-20:
 - `day_start_equity=-26064.31`
 - `day_peak_equity=0.01`
 - `halted=true`
 - `halt_reason='daily loss limit hit (3.0%)'`
 - `fresh_day_reset_pending=true`
 
-Do not clear the halt, rewrite the risk peak, force a fresh-day baseline, rewrite canonical ledger rows, or overwrite the account from an incomplete reconstruction merely to make an audit pass.
+Do not clear the halt, rewrite the risk peak, force a baseline, rewrite/relabel canonical ledger rows, or overwrite the account from an incomplete reconstruction merely to make an audit pass.
 
-## 2026-08-21 Settled Runtime Evidence After PR #98
+## Current Runtime Evidence — 2026-08-21
 
 ### Fresh-day guard
 
 `/paper/fresh-day-check`:
 - `baseline_status=pending`
-- risk date remains `2026-08-20`
+- risk date still `2026-08-20`
 - `day_start_equity=-26064.31`
 - `day_peak_equity=0.01`
 - `fresh_day_reset_pending=true`
 - `halted=true`
-- `intraday_drawdown_pct=0.0`
 
 `/paper/fresh-risk-day-baseline-guard-status`:
-- guard installed / overall pass
+- installed / overall pass
 - `current_equity_sane=false`
-- `day_start_equity_sane=false`
-- `day_peak_equity_sane=false`
+- start/peak both not sane
 - `fresh_day_reset_pending=true`
-- prospective only; no current-day rewrite, halt clear, peak rewrite, historical-accounting edit, order placement, strategy/sizing/threshold/live/ML authority change
+- prospective only; no halt clear/current-day rewrite/peak rewrite/history edit/order/strategy/sizing/threshold/live/ML authority change
 
-Interpretation: the guard is functioning correctly and refusing to manufacture a 2026-08-21 risk baseline from invalid active equity.
+Interpretation: PR #83/#87 protection is functioning and refusing to manufacture a 2026-08-21 risk baseline from invalid equity.
 
 ### Compact self-check
 
-`/paper/self-check` at `2026-08-21 09:51:12 CDT`:
-- overall `warn`, response/status `ok`
-- account: cash `-26064.308324919723`, equity `-26064.31`, positions `[]`, realized today `0.0`, realized total `-94929.16`, unrealized `0.0`
-- auto runner enabled and observed active; no current runner error
-- all 9 bounded runtime component checks pass
-- scanner/entry composition ownership checks pass
-- runtime shadow capture parity passes
-- risk remains halted/self-defense-active because of the stale daily-loss halt state
+`/paper/self-check` at 09:51 CDT:
+- overall `warn`, status `ok`
+- account cash/equity `-26064.31`, no positions, realized total `-94929.16`
+- auto runner healthy; no active runner error
+- all 9 bounded component checks pass
+- scanner/entry ownership and runtime shadow parity pass
+- entries remain blocked by the stale risk halt
 
 ### Full daily audit
 
-`/paper/daily-audit?full=1` at `2026-08-21 09:52:32 CDT`:
-- overall `fail` because risk remains halted and accounting integrity is not reconciled
-- runner liveness passes; no active recursion/runtime error
-- market-data/provider accounting is complete and clean at snapshot
-- persistent volume is healthy; `/data/state.json` exists; in-memory/on-disk richness match; no detected JSON corruption
-- PR #98 therefore appears to have stopped the diagnostic X-Ray overwrite path, but the state now being faithfully persisted is already contaminated
-- accounting reconstruction reports approximately `cash/equity=10724.779592`, `realized_total=724.779592`, zero positions
-- reconstruction coverage is incomplete with 193 ignored/unmatched exit rows, mostly legacy rows beginning 2026-08-07
+`/paper/daily-audit?full=1` at 09:52 CDT:
+- overall `fail` because risk is halted and accounting is unreconciled
+- runner and market-data/provider accounting pass
+- persistent volume healthy; in-memory/on-disk richness matched
+- accounting reconstruction estimates `cash/equity=10724.779592`, `realized_total=724.779592`, zero positions
+- reconstruction coverage is incomplete: 193 ignored/unmatched legacy exit rows, beginning 2026-08-07
 - separate ledger-economic integrity also fails
-- therefore `$10,724.779592` is evidence only and **must not be promoted automatically into authoritative state**
+
+Therefore `$10,724.779592` is forensic evidence only and **must not be promoted automatically into authoritative state**.
 
 ### Canonical execution ledger
 
 `/paper/canonical-execution-ledger-status`:
-- `status=ok`, `overall=pass`
-- `append_only=true`
-- `hook_applied=true`
-- `authoritative_for_new_executions=true`
-- `chain_valid=true`
-- `parse_error_count=0`, `chain_error_count=0`, `errors=[]`
+- status/overall pass
+- append-only/hash-chain enabled
+- hook applied; authoritative for new executions
+- `chain_valid=true`, no parse/hash errors
 - `row_count=55`
 - `current_epoch_id=legacy-pre-stable-core`
 - `current_epoch_rows=55`
 - last execution id `e746b3e674654f9199402c8904df1f43`
 
-The hash chain is healthy and must remain untouched. The active portfolio no longer exposes `stable-paper-v2-20260812-verified01`; all 55 surviving canonical rows are currently classified by the runtime under `legacy-pre-stable-core`. Do not relabel or rewrite them.
+The ledger is healthy and immutable. Do not edit/relabel these rows. The active runtime no longer exposes `stable-paper-v2-20260812-verified01`.
 
-### Clean accounting epoch status — latest provenance evidence
+### Clean accounting epoch status
 
-`/paper/clean-accounting-epoch-status` at approximately 10:15 CDT returned:
+`/paper/clean-accounting-epoch-status`:
 - `status=blocked`, `overall=warn`
 - `marker_status=null`
 - `forensic_archive_dir=null`
@@ -107,169 +102,197 @@ The hash chain is healthy and must remain untouched. The active portfolio no lon
 - `zero_trade_baseline=false`
 - `validation_hold=false`
 
-Important interpretation: the returned `epoch_id=stable-paper-v1-20260810-clean01` is **not proof that the clean epoch is active**. In `clean_accounting_epoch.status_payload()`, when the target epoch is not active, the endpoint reports the target constant as `epoch_id` while `clean_start`, `zero_trade_baseline`, recovery decision, archive flag, and marker reveal the real inactive state. The null marker/archive plus false clean/zero-trade flags mean the current active state does not contain a valid active clean-epoch record and the expected clean-epoch completion marker is not present at the configured marker path.
+The endpoint's displayed `epoch_id=stable-paper-v1-20260810-clean01` is a target constant when inactive, not proof of an active clean epoch. Active clean metadata/marker is absent from this status path.
 
-Combined with the canonical ledger reporting `legacy-pre-stable-core`, this strengthens the hypothesis that an older pre-stable-core snapshot was resurrected before PR #98 stopped X-Ray from replacing live state. It does **not** yet prove which backup/file did it.
+### State recovery guard — decisive current-startup evidence
+
+`/paper/state-recovery-status` at approximately 10:54 CDT:
+- `restored=false`
+- `pre_restore_backup_file=null`
+- current state valid, score 39, 303 trades, 0 positions, 500 history rows
+- largest backup valid, score 39, 280 trades, 19 positions, 500 history rows
+- decision `should_restore=false`
+- reason `backup_has_fewer_trades_than_current`
+- current runner timestamp rank is materially newer than the largest backup
+- monotonic trade and runner timestamp guards enabled
+
+Interpretation: `state_guard` did **not** resurrect the old snapshot during this startup. Restoring `state_backup_largest.json` would roll execution history backward and is prohibited.
+
+### State I/O hardening — latest evidence
+
+`/paper/state-io-status` at 10:59 CDT:
+- installed / status ok
+- `last_status_event=atomic_save_state`
+- current state valid with 303 trades, 0 positions, 500 history rows
+- `state.json` about 25.8 MB
+- latest/prewrite backups about 25.4 MB; largest backup about 38.3 MB
+- atomic writes, retry reads, backup fallback reads, thread/file locking, and non-overlapping cycle protections are enabled
+- run state inactive at snapshot, no run error, zero overlap blocks
+
+Interpretation: there is no evidence in the **current** State I/O status of a fallback backup read; the latest recorded event is a normal atomic save. This status does not preserve a complete historical event log, so it cannot by itself prove that no fallback read ever occurred before PR #98. Combined with `state_guard.restored=false`, the corrupted `/data/state.json` existed before the current startup recovery decision. The pre-PR #98 X-Ray independent state I/O remains the leading known resurrection mechanism, but final provenance still needs durable marker/archive evidence.
+
+## PR #101 — Read-only verified-snapshot provenance probe
+
+PR #101 was opened from main specifically to answer the remaining provenance question without touching paper state.
+
+Head at PR creation: `62edf2d4f74259b1a728e7d06a8387638a2c1755` before the handoff refresh commit.
+
+It adds `/paper/verified-snapshot-provenance-status` with these boundaries:
+- reads only exact small clean/verified recovery marker files, bounded forensic archive manifests, and the already-loaded in-memory portfolio;
+- does **not** read the 25–38 MB state/backup files;
+- does not import or call either one-shot recovery implementation;
+- no file writes, backup restore, state repair, halt clear, ledger rewrite/relabel, order placement, strategy/sizing/risk-threshold/live/ML change;
+- bounded archive directory scan and bounded returned matches;
+- focused regression added to Change Safety Audit while preserving the mandatory core invariant suite.
+
+Do not merge #101 unless exact-head Change Safety Audit, repository validation, architecture debt/ownership/config checks, focused provenance tests, and exact Gunicorn startup smoke are green.
 
 ## Issue #82 — Stabilization Exit Gate
 
 Issue #82 remains open and authoritative.
 
-Already protected prospectively:
-- PR #56 source terminal-price plausibility guard
-- PR #79 fresh cached-price provenance/plausibility validation
-- PR #80 catastrophic persisted `last_price` valuation fallback guard
-- PR #81 canonical pre-mutation duplicate-full-exit guard
-- PR #83 fresh-day baseline sanity guard
-- PR #87 pre-WSGI fresh-day guard installation order
-- PR #98 removal of diagnostic X-Ray independent authoritative state I/O
+Prospective protections already merged:
+- #56 source terminal-price plausibility guard
+- #79 fresh cached quote provenance/plausibility
+- #80 catastrophic persisted `last_price` fallback guard
+- #81 pre-mutation duplicate full-exit guard
+- #83 fresh-day baseline sanity guard
+- #87 fresh-day guard installed before full WSGI composition
+- #98 diagnostic X-Ray independent authoritative state I/O removed
 
 Remaining acceptance:
-1. sane fresh-day risk initialization from a protected authoritative valuation;
-2. one normal forward paper market session after that clean reset;
-3. evidence-based historical-accounting disposition without rewriting immutable execution history;
-4. clean active audit with sane valuation, healthy runner/market data, valid canonical chain, no new active coverage/economic issue, and risk reflecting real economics.
+1. authoritative economic state recovered from mechanically proven provenance, not inference;
+2. sane fresh-day risk initialization from protected positive valuation;
+3. one normal forward paper market session after clean reset;
+4. evidence-based historical-accounting disposition without rewriting immutable execution history;
+5. clean active audit with sane valuation, healthy runner/market data, valid canonical chain, no new active economic/coverage issue, and risk reflecting real economics.
 
-The current fresh-day state is `pending`, which is the correct fail-closed behavior while authoritative equity is invalid.
+Current fresh-day status is `pending`, which is the correct fail-closed state while authoritative equity is invalid.
 
 ## This Week's Reliability / Architecture / Governance Changes
 
 ### 2026-08-18
-
-- PR #79 merged: validate fresh cached quotes before `latest_price` return; exact poisoned-cache regression.
-- PR #80 merged: fail closed on catastrophic persisted `last_price` valuation fallback.
-- PR #81 merged: block duplicate full exits at the canonical pre-mutation boundary using the existing append-only ledger semantics; historical TEM evidence remains immutable.
+- #79 merged — validate fresh cached quotes before `latest_price` return.
+- #80 merged — fail closed on catastrophic persisted `last_price` valuation fallback.
+- #81 merged — block duplicate full exits at canonical pre-mutation boundary; historical TEM evidence remains immutable.
 
 ### 2026-08-19
-
-- PR #83 merged: prospective fresh-risk-day baseline sanity guard. Invalid/non-positive equity defers reset.
-- Issue #84 opened: Stable Paper Core v3 architecture consolidation.
-- PR #85 merged: Stage A immutable canonical shadow state models and ownership contract.
+- #83 merged — prospective fresh-risk-day baseline sanity guard.
+- Issue #84 opened — Stable Paper Core v3 consolidation.
+- #85 merged — Stage A immutable canonical shadow state models/ownership contract.
 
 ### 2026-08-20
-
-- PR #86 merged: compact observational `/paper/fresh-day-check` endpoint.
-- PR #87 merged: install fresh-day guard immediately after core `app` import and before full WSGI runtime composition; exact Gunicorn startup validation passed.
-- PR #88 merged: `MASTER_SYSTEM_AUDIT_2026-08-20.md` plus architecture-debt regression gate.
-  - 250 Python files / 90,409 lines at audit creation
-  - 34 runtime mutation overlaps
-  - 5 environment conflicts
-  - 5 route overlaps
-  - 80 duplicate-function groups
-  - 540 broad exception-pass sites
-  - 8 watchdog loops
-  - 32 critical findings
-  - fragmented ownership included `save_state` 17 owners, `scan_signals` 14, `try_entries_and_rotations` 13, `entry_quality_check` 10, `enter_position` 9
-- PR #89 merged: Stage B deterministic shadow valuation service.
-- PR #90 merged: Stage C deterministic shadow risk engine.
-- PR #91 merged: Stage D shadow canonical StateStore with integrity hashing, atomic-write/backup/readback/restart invariants; no production I/O authority.
-- PR #92 merged: Stage E shadow ledger-derived bidirectional accounting projection.
+- #86 merged — compact observational `/paper/fresh-day-check`.
+- #87 merged — install fresh-day guard before full WSGI composition; Gunicorn smoke passed.
+- #88 merged — master system audit + architecture-debt regression gate. Audit baseline: 250 Python files / 90,409 lines; 34 runtime mutation overlaps; 5 env conflicts; 5 route overlaps; 80 duplicate-function groups; 540 broad exception-pass sites; 8 watchdog loops; 32 critical findings; fragmented ownership included `save_state` 17, `scan_signals` 14, `try_entries_and_rotations` 13, `entry_quality_check` 10, `enter_position` 9.
+- #89 merged — Stage B deterministic shadow valuation.
+- #90 merged — Stage C deterministic shadow risk lifecycle.
+- #91 merged — Stage D shadow canonical StateStore.
+- #92 merged — Stage E shadow ledger-derived bidirectional accounting.
 
 ### 2026-08-21
-
-- PR #93 merged: Stage F shadow canary-readiness planner; authoritative activation remains blocked by Issue #82.
-- Issue #94 created for mandatory per-change regression/impact auditing.
-- PR #95 merged: exact-head `Change Safety Audit` workflow/policy. Relevant future PRs must pass impact-aware regressions, core invariants, architecture/config/ownership/debt checks, and exact startup smoke; stale/missing/failing evidence blocks merge.
-- Issue #96 created for self-diagnosing incident triage/recommendation.
-- PR #97 merged: shadow-only `system_sentinel` foundation with deterministic incident classification and impact-aware test selection; no production state mutation or self-healing authority.
-- PR #98 merged as `c6ef7958a247ae88ba9a5c3670ed756ac0d06426`: `entry_pipeline_xray` no longer loads/saves authoritative state or reassigns `core.portfolio`; regression reproduces stale-file/live-memory split and proves X-Ray does not replace live state.
-- PR #98 passed Repository Safety and Performance Audit Validation, Architecture Debt Regression Gate, Refactor/Ownership/Configuration/State/Decision/Runtime/Startup/Research Audit including exact Gunicorn startup smoke, and Change Safety Audit. Railway deployment succeeded.
-- PR #99 merged as `0874368ad5bf303337b8c94ed1c9ae967c2231b5`: authoritative handoff refreshed through Aug 21. It was documentation-only and did not change runtime behavior.
+- #93 merged — Stage F shadow canary-readiness planner; no authoritative cutover.
+- Issue #94 created — mandatory per-change regression/impact auditing.
+- #95 merged — exact-head Change Safety Audit with core invariants, impact-aware tests, architecture/config/ownership/debt checks, and exact startup smoke.
+- Issue #96 created — self-diagnosing incident triage/recommendation engine.
+- #97 merged — shadow-only `system_sentinel` foundation; no production mutation/self-healing authority.
+- #98 merged as `c6ef7958a247ae88ba9a5c3670ed756ac0d06426` — `entry_pipeline_xray` no longer loads/saves authoritative state or reassigns `core.portfolio`; regression proves stale-file/live-memory split cannot replace live state. Required CI passed and Railway deployed.
+- #99 merged as `0874368ad5bf303337b8c94ed1c9ae967c2231b5` — authoritative handoff refresh.
+- #100 merged as `69ec3d39a565a8c9068d0a088f441723e6883c3e` — current-chat continuity + clean-epoch provenance handoff update.
+- #101 open — bounded read-only durable recovery provenance probe and focused Change Safety regression selection.
 
 ## Stable Paper Core v3 / Issue #84
 
-Issue #84 remains open. Shadow/parity status:
-- Stage A — merged (#85): immutable canonical state models
-- Stage B — merged (#89): deterministic valuation
-- Stage C — merged (#90): deterministic risk lifecycle
-- Stage D — merged (#91): shadow StateStore
-- Stage E — merged (#92): ledger/accounting projection
-- Stage F — merged (#93): canary readiness only; no authoritative activation
-- Stage G — not accepted; legacy mutation wrappers cannot be removed until authoritative cutover and parity evidence are clean
+Issue #84 remains open. Shadow/parity stages:
+- A #85 — immutable state models
+- B #89 — deterministic valuation
+- C #90 — deterministic risk
+- D #91 — shadow StateStore
+- E #92 — ledger/accounting projection
+- F #93 — canary readiness only
+- G — blocked until authoritative cutover/parity/prospective evidence
 
-Authoritative cutover remains blocked by Issue #82. Do not use the shadow core to bypass the current corrupted state.
+Do not use shadow core to bypass Issue #82.
 
-## Mandatory Future Change Safety / Issue #94
+## Mandatory Change Safety / Issue #94
 
-PR #95 implemented the in-repository exact-head audit. Every relevant future PR must be reviewed against the exact PR head and pass the Change Safety Audit plus the required overlapping regressions/core invariants. A local unit test is not sufficient. Missing, stale, incomplete, or failing audit evidence is a merge blocker.
+PR #95 implemented the in-repository exact-head audit. Every relevant PR must pass Change Safety Audit plus overlapping regressions and the mandatory core suite. Missing/stale/failing evidence blocks merge. PR #101 additionally routes verified-snapshot provenance changes to their focused regression, demonstrating the intended impact-aware model instead of indiscriminately expanding all tests.
 
 Final post-rebuild completion still includes repository-rule/branch-protection enforcement where permissions support it and acceptance/closure of Issue #94.
 
 ## Self-Diagnosing Sentinel / Issue #96
 
-PR #97 provides the shadow diagnostic foundation. It can classify supplied evidence across valuation, accounting, execution ledger, risk, startup, configuration, ownership, runner, and market-data boundaries and select deterministic affected tests while retaining mandatory core tests.
+PR #97 provides the shadow diagnostic foundation across valuation, accounting, ledger, risk, startup, configuration, ownership, runner, and market-data boundaries. It may recommend bounded fixes and select affected tests, but must not rewrite state, clear halts, alter execution history, change strategy/sizing/hard-risk/live/ML authority, or auto-merge authoritative repairs.
 
-It must not automatically rewrite portfolio/accounting/risk state, clear halts, alter execution history, change strategy/sizing/hard-risk/live/ML authority, or auto-merge authoritative fixes. Production advisory activation waits for stable canonical ownership.
+## Prior Verified Accounting Recovery — Forensic Evidence Only
 
-## Prior Verified Accounting Recovery — Preserve as Forensic Evidence
+Existing recovery code documents the previously verified Aug. 12 recovery design:
+- old epoch `stable-paper-v1-20260810-clean01`
+- target `stable-paper-v2-20260812-verified01`
+- decision `verified-bad-tick-and-ledger-divergence-2026-08-12`
+- exact LRCX bad execution id `5ca38922916e4612ae3cda8d9801107d`
+- expected recovery marker path under the persistent state directory: `verified_snapshot_verified-bad-tick-and-ledger-divergence-2026-08-12.json`
+- forensic archives under `/data/forensic_archives` with `verified_snapshot_recovery_manifest.json`
 
-The previously established recovery architecture created `stable-paper-v2-20260812-verified01` from a verified snapshot with an open LRCX lot and archived the prior contaminated epoch. Recovery code and forensic markers are evidence sources only; do not re-run the one-shot recovery blindly.
-
-The active 2026-08-21 runtime no longer exposes that verified epoch. The canonical ledger reports `legacy-pre-stable-core`, and the clean-epoch status now also reports no active clean metadata or clean completion marker at the expected path. The next task is therefore provenance discovery, not account repair.
+Do **not** call `verified_snapshot_epoch_recovery.status_payload()` as a diagnostic route: in the legacy module it delegates to `apply()`, which is the one-shot recovery entry point. PR #101's provenance probe intentionally avoids importing/calling that module.
 
 ## Historical TEM Duplicate Exit
 
-Historical TEM sequence remains immutable evidence:
-1. entry long `29.640567 @ 54.885`, execution `d647d8a0580b44edbab0224e6c339bfd`;
+Immutable TEM evidence:
+1. long entry `29.640567 @ 54.885`, execution `d647d8a0580b44edbab0224e6c339bfd`;
 2. first full exit `29.640567 @ 53.105`, execution `7b13d9194a23407f926667b2f48d4057`;
 3. duplicate full exit `@ 52.905`, execution `3530dbf965db4894ba93b7098cec3696`.
 
-PR #81 prospectively blocks a future duplicate full exit before cash/P&L/position/ledger mutation. Never delete, rewrite, fabricate, or relabel the historical TEM row.
+PR #81 prospectively prevents recurrence. Never delete/rewrite/fabricate/relabel the historical row.
 
 ## Canonical Runtime / Validation Links
 
-Use the clean service only:
+Use only the clean service:
 - bootstrap: `https://trading-bot-clean.up.railway.app/bootstrap-status`
 - compact fresh-day: `https://trading-bot-clean.up.railway.app/paper/fresh-day-check`
 - fresh-day guard: `https://trading-bot-clean.up.railway.app/paper/fresh-risk-day-baseline-guard-status`
-- routine self-check: `https://trading-bot-clean.up.railway.app/paper/self-check`
-- targeted full diagnostics: `https://trading-bot-clean.up.railway.app/paper/full-self-check`
-- routine daily audit: `https://trading-bot-clean.up.railway.app/paper/daily-audit`
+- self-check: `https://trading-bot-clean.up.railway.app/paper/self-check`
+- full diagnostics: `https://trading-bot-clean.up.railway.app/paper/full-self-check`
 - full daily audit: `https://trading-bot-clean.up.railway.app/paper/daily-audit?full=1`
 - canonical ledger: `https://trading-bot-clean.up.railway.app/paper/canonical-execution-ledger-status`
-- clean epoch status: `https://trading-bot-clean.up.railway.app/paper/clean-accounting-epoch-status`
-- state recovery status: `https://trading-bot-clean.up.railway.app/paper/state-recovery-status`
-- state I/O status: `https://trading-bot-clean.up.railway.app/paper/state-io-status`
+- clean epoch: `https://trading-bot-clean.up.railway.app/paper/clean-accounting-epoch-status`
+- state recovery: `https://trading-bot-clean.up.railway.app/paper/state-recovery-status`
+- state I/O: `https://trading-bot-clean.up.railway.app/paper/state-io-status`
+- verified snapshot provenance after #101 deploy: `https://trading-bot-clean.up.railway.app/paper/verified-snapshot-provenance-status`
 - quote/exit integrity: `https://trading-bot-clean.up.railway.app/paper/exit-price-integrity-status`
 
-Do not manually call `/paper/run` unless a specific future validation plan explicitly requires it.
+Do not manually call `/paper/run` unless a future validation plan explicitly requires it.
 
-Known ops debt: `.github/workflows/refactor-audit.yml` still contains the older hard-coded `https://web-production-e1796.up.railway.app` runtime-research target even though `runtime_research_snapshot.py` defaults to `trading-bot-clean`. Do not treat the old-domain automated snapshot as clean-service acceptance evidence.
+Known ops debt: `.github/workflows/refactor-audit.yml` still contains the older `https://web-production-e1796.up.railway.app` runtime-research target. Do not treat that old-domain snapshot as clean-service acceptance evidence.
 
 ## Risk / Authority Boundaries — Preserve
 
-- soft daily-loss pause: `1.0%`
-- hard realized-loss halt: `2.5%`
-- hard intraday drawdown halt: `2.5%`
-- absolute daily-loss ceiling: `3.0%`
-- maximum configured account risk per trade at stop: `2.0%`
-- terminal-price plausibility: `0.40x` minimum / `2.50x` maximum
+- soft daily-loss pause 1.0%
+- hard realized-loss halt 2.5%
+- hard intraday drawdown halt 2.5%
+- absolute daily-loss ceiling 3.0%
+- max configured account risk per trade at stop 2.0%
+- terminal-price plausibility 0.40x minimum / 2.50x maximum
 - paper-only until explicit live-readiness approval
-- rules remain sole execution authority
-- ML remains shadow-only for execution
-- no fabricated/deleted/rewritten historical ledger rows
-- no manual account-state repair merely to pass an audit
+- rules sole execution authority
+- ML shadow-only for execution
+- no historical ledger fabrication/deletion/rewrite/relabel
+- no manual state repair merely to pass an audit
 
 ## Exact Next Action
 
-The clean-epoch endpoint now proves the expected clean completion marker/archive pointer is absent from the active status path, while the canonical ledger remains healthy under `legacy-pre-stable-core`.
-
-Continue with **read-mostly provenance**, not account mutation:
-
-1. inspect `/paper/state-recovery-status` to determine whether `state_guard` restored any backup at startup and compare current-state quality versus the largest backup (`decision`, `restored`, current/backup trade counts, runner timestamp ranks, size/quality);
-2. if a backup restoration occurred, identify which backup and whether that restoration predates the verified-snapshot epoch; do not restore another backup manually;
-3. if no restoration occurred, add a bounded observational provenance probe that reads only exact recovery marker files and forensic archive manifests/directories, with no state write/restore/relabel authority, then validate it through the mandatory Change Safety Audit;
-4. use that evidence to identify the earliest point at which `paper_accounting_epoch` / `accounting_epoch_id` disappeared and whether the pre-PR #98 X-Ray stale-file path is the exact source;
-5. only after provenance is mechanically proven, design a bounded successor recovery that preserves all 55 canonical ledger rows/hash chain and all historical evidence;
-6. after authoritative state is safely restored from proven evidence, require a new fresh-day reset from sane equity, then forward-session and clean-active-audit proof before closing Issue #82 or activating Stage F/G authority.
-
-Do not use the incomplete `$10,724.779592` reconstruction as an automatic state repair.
+1. Re-fetch PR #101 exact head and CI after this handoff commit.
+2. Inspect the exact PR diff for accidental write/recovery authority.
+3. Merge only if Change Safety Audit, focused provenance regression, repository safety, architecture debt/ownership/config, and exact Gunicorn startup smoke all pass at the exact head.
+4. Wait for Railway to deploy the merge and settle to `delegate_ready:true`.
+5. Run only `https://trading-bot-clean.up.railway.app/paper/verified-snapshot-provenance-status`.
+6. If the exact verified marker or matching forensic manifest survives, use that mechanically proven durable evidence to design the bounded successor recovery without rewriting the 55-row canonical ledger.
+7. If neither survives, do not guess. Build the next bounded read-only discriminator for recovery metadata in specific backups/archive inventory without promoting the incomplete `$10,724.779592` reconstruction.
+8. After proven authoritative recovery, require sane fresh-day reset, forward paper session, and clean active audit before Issue #82 closure or Stage F/G authority.
 
 ## Conversation Continuity Protocol
 
-Keep updates in the **current active project chat**, whichever ChatGPT conversation is presently designated for this project. If that conversation becomes too long for safe continuation, update this handoff with all material PR/commit/deployment/runtime evidence and the exact next action before moving. Then use the continuation command in the new conversation; the new conversation becomes the active project chat. Do not rely on an old monitoring thread for status.
-
-Continuation command if required:
+Stay in the current active project chat through a coherent testing/update sequence. The assistant cannot rely on a UI meter, so it must use conversation size/complexity judgment and proactively warn the user before continuation becomes unsafe. When a move is needed, stop at a clean boundary, refresh this handoff, then use:
 
 ```text
 Use the direct @GitHub connector and continue the Trading-bot project from sterlingfancher-cmyk/Trading-bot. Read PROJECT_HANDOFF_CURRENT.md first and treat it as the authoritative continuation state. Treat this conversation as the current active project chat and keep project-status communication here. Verify current main/PR/CI and the canonical Railway clean-service read-only evidence before changing code. Continue from the Exact Next Action. Preserve paper-only authority, hard risk thresholds, canonical ledger history, rules-only execution authority, ML shadow-only execution, and the Issue #82/#84/#94/#96 gates. Do not manually repair account state or clear halts from inference.

--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Iterable
 
-VERSION = "change-safety-audit-2026-08-20-v1"
+VERSION = "change-safety-audit-2026-08-21-v2-provenance"
 
 CORE_TESTS = (
     "test_architecture_stage_b.py",
@@ -30,6 +30,7 @@ RUNTIME_TESTS = (
 STATE_TESTS = ("test_state_store_stage_c.py",)
 DECISION_TESTS = ("test_shadow_decision_stage_d.py",)
 CONFIG_TESTS = ("test_architecture_stage_b.py",)
+PROVENANCE_TESTS = ("test_verified_snapshot_provenance_status.py",)
 
 
 @dataclass(frozen=True)
@@ -82,6 +83,9 @@ def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ..
         if any(token in path for token in ("accounting", "ledger", "execution")):
             categories.add("accounting_execution")
             boundaries.update(("accounting", "execution"))
+        if "verified_snapshot_provenance" in path:
+            categories.add("state_persistence")
+            boundaries.update(("state", "accounting"))
         if "risk" in path:
             categories.add("risk")
             boundaries.add("risk")
@@ -97,7 +101,8 @@ def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ..
 
 
 def planned_regressions(paths: Iterable[str]) -> tuple[str, ...]:
-    categories, _ = classify_paths(paths)
+    path_tuple = tuple(paths)
+    categories, _ = classify_paths(path_tuple)
     tests: list[str] = list(CORE_TESTS)
     if "runtime_composition" in categories or "workflow" in categories:
         tests.extend(RUNTIME_TESTS)
@@ -107,6 +112,8 @@ def planned_regressions(paths: Iterable[str]) -> tuple[str, ...]:
         tests.extend(DECISION_TESTS)
     if "configuration" in categories:
         tests.extend(CONFIG_TESTS)
+    if any("verified_snapshot_provenance" in path.lower() for path in path_tuple):
+        tests.extend(PROVENANCE_TESTS)
     existing = []
     seen = set()
     for test in tests:

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-19-v27-fresh-risk-day-baseline"
+VERSION = "data-integrity-startup-bridge-2026-08-21-v28-verified-snapshot-provenance"
 MODULES = (
     "final_daily_audit_compactor",
     "daily_audit_entry_count_bridge",
@@ -32,6 +32,9 @@ MODULES = (
     "clean_accounting_epoch",
     "paper_bidirectional_accounting_guard",
     "paper_execution_timestamp_semantics",
+    # Read-only forensic probe.  It deliberately runs before the exact one-shot
+    # recovery module and does not import/call either recovery implementation.
+    "verified_snapshot_provenance_status",
     # Patch the exact one-shot recovery's journal rotation before the recovery
     # runs. The migration already owns the journal lock, so it must not call the
     # journal mirror recursively from inside that critical section.

--- a/test_change_safety_audit.py
+++ b/test_change_safety_audit.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import unittest
 
-from change_safety_audit import classify_paths, evaluate_gate
+from change_safety_audit import classify_paths, evaluate_gate, planned_regressions
 
 
 class ChangeSafetyAuditTests(unittest.TestCase):
@@ -67,6 +67,24 @@ class ChangeSafetyAuditTests(unittest.TestCase):
         self.assertIn("runtime_composition", categories)
         for boundary in ("startup_runtime", "state", "valuation", "accounting", "risk"):
             self.assertIn(boundary, boundaries)
+
+    def test_verified_snapshot_provenance_change_selects_focused_regression(self) -> None:
+        paths = ("verified_snapshot_provenance_status.py",)
+        categories, boundaries = classify_paths(paths)
+        tests = planned_regressions(paths)
+
+        self.assertIn("state_persistence", categories)
+        self.assertIn("state", boundaries)
+        self.assertIn("accounting", boundaries)
+        self.assertIn("test_verified_snapshot_provenance_status.py", tests)
+        for core_test in (
+            "test_architecture_stage_b.py",
+            "test_architecture_stage_c.py",
+            "test_architecture_stage_d_state_store.py",
+            "test_architecture_stage_e_accounting.py",
+            "test_architecture_stage_f_canary.py",
+        ):
+            self.assertIn(core_test, tests)
 
 
 if __name__ == "__main__":

--- a/test_verified_snapshot_provenance_status.py
+++ b/test_verified_snapshot_provenance_status.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import verified_snapshot_provenance_status as probe
+
+
+class DummyCore:
+    def __init__(self, portfolio=None):
+        self.portfolio = portfolio or {}
+
+    def local_ts_text(self):
+        return "2026-08-21 11:00:00 CDT"
+
+
+class VerifiedSnapshotProvenanceStatusTests(unittest.TestCase):
+    def _paths(self, root: str):
+        archive_root = os.path.join(root, "forensic_archives")
+        clean_marker = os.path.join(
+            root, f"clean_epoch_{probe.CLEAN_DECISION_ID}.json"
+        )
+        verified_marker = os.path.join(
+            root, f"verified_snapshot_{probe.VERIFIED_DECISION_ID}.json"
+        )
+        return archive_root, clean_marker, verified_marker
+
+    def _patch_paths(self, root: str):
+        archive_root, clean_marker, verified_marker = self._paths(root)
+        return mock.patch.multiple(
+            probe,
+            STATE_DIR=root,
+            ARCHIVE_ROOT=archive_root,
+            CLEAN_MARKER_FILE=clean_marker,
+            VERIFIED_MARKER_FILE=verified_marker,
+        )
+
+    def test_absent_provenance_is_warn_and_read_only(self):
+        with tempfile.TemporaryDirectory() as root, self._patch_paths(root):
+            before = sorted(str(p.relative_to(root)) for p in Path(root).rglob("*"))
+            payload = probe.status_payload(DummyCore({"cash": -10.0, "equity": -10.0}))
+            after = sorted(str(p.relative_to(root)) for p in Path(root).rglob("*"))
+
+            self.assertEqual(payload["status"], "ok")
+            self.assertEqual(payload["overall"], "warn")
+            self.assertEqual(
+                payload["diagnosis"], "recovery_markers_and_verified_archive_not_found"
+            )
+            self.assertFalse(payload["durable_verified_evidence_found"])
+            self.assertEqual(before, after)
+            self.assertFalse(payload["authority"]["writes_files"])
+            self.assertFalse(payload["authority"]["restores_backups"])
+            self.assertFalse(payload["authority"]["rewrites_canonical_ledger"])
+
+    def test_exact_verified_marker_is_durable_provenance(self):
+        with tempfile.TemporaryDirectory() as root, self._patch_paths(root):
+            _, _, verified_marker = self._paths(root)
+            Path(verified_marker).write_text(
+                json.dumps(
+                    {
+                        "status": "completed",
+                        "decision_id": probe.VERIFIED_DECISION_ID,
+                        "target_epoch_id": probe.VERIFIED_EPOCH_ID,
+                        "archive_dir": "/data/forensic_archives/example",
+                        "started_local": "2026-08-12 10:00:00 CDT",
+                        "completed_local": "2026-08-12 10:01:00 CDT",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            payload = probe.status_payload(DummyCore())
+
+            self.assertEqual(payload["overall"], "pass")
+            self.assertEqual(
+                payload["diagnosis"], "verified_snapshot_durable_provenance_found"
+            )
+            self.assertTrue(payload["verified_snapshot_marker_found"])
+            self.assertTrue(payload["durable_verified_evidence_found"])
+
+    def test_exact_verified_archive_manifest_is_durable_provenance(self):
+        with tempfile.TemporaryDirectory() as root, self._patch_paths(root):
+            archive_root, _, _ = self._paths(root)
+            archive_dir = Path(archive_root) / "20260812_100000_verified"
+            archive_dir.mkdir(parents=True)
+            (archive_dir / probe.MANIFEST_NAME).write_text(
+                json.dumps(
+                    {
+                        "status": "ok",
+                        "decision_id": probe.VERIFIED_DECISION_ID,
+                        "old_epoch_id": probe.CLEAN_EPOCH_ID,
+                        "target_epoch_id": probe.VERIFIED_EPOCH_ID,
+                        "created_local": "2026-08-12 10:00:00 CDT",
+                        "bad_execution_id": "5ca38922916e4612ae3cda8d9801107d",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            payload = probe.status_payload(DummyCore())
+
+            self.assertEqual(payload["overall"], "pass")
+            self.assertTrue(payload["verified_snapshot_archive_found"])
+            self.assertEqual(
+                payload["verified_snapshot_archives"]["matching_manifest_count"], 1
+            )
+            match = payload["verified_snapshot_archives"]["matching_manifests"][0]
+            self.assertEqual(match["target_epoch_id"], probe.VERIFIED_EPOCH_ID)
+
+    def test_clean_marker_without_verified_evidence_is_not_overstated(self):
+        with tempfile.TemporaryDirectory() as root, self._patch_paths(root):
+            _, clean_marker, _ = self._paths(root)
+            Path(clean_marker).write_text(
+                json.dumps(
+                    {
+                        "status": "completed",
+                        "decision_id": probe.CLEAN_DECISION_ID,
+                        "target_epoch_id": probe.CLEAN_EPOCH_ID,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            payload = probe.status_payload(DummyCore())
+
+            self.assertEqual(payload["overall"], "warn")
+            self.assertTrue(payload["clean_epoch_marker_found"])
+            self.assertFalse(payload["durable_verified_evidence_found"])
+            self.assertEqual(
+                payload["diagnosis"],
+                "clean_epoch_provenance_found_verified_snapshot_missing",
+            )
+
+    def test_active_epoch_summary_uses_memory_and_does_not_read_state_file(self):
+        portfolio = {
+            "cash": 10768.49,
+            "equity": 11915.69,
+            "positions": {"LRCX": {"qty": 3.4}},
+            "trades": [],
+            "accounting_epoch_id": probe.VERIFIED_EPOCH_ID,
+            "paper_accounting_epoch": {
+                "id": probe.VERIFIED_EPOCH_ID,
+                "decision_id": probe.VERIFIED_DECISION_ID,
+                "baseline_type": "verified_snapshot_with_open_position",
+                "historical_recovery_decision": "verified_snapshot_rollforward",
+                "historical_evidence_archived": True,
+                "forensic_archive_dir": "/data/forensic_archives/example",
+                "validation_hold": True,
+            },
+        }
+        with tempfile.TemporaryDirectory() as root, self._patch_paths(root):
+            payload = probe.status_payload(DummyCore(portfolio))
+            active = payload["active_runtime"]
+
+            self.assertEqual(active["paper_accounting_epoch_id"], probe.VERIFIED_EPOCH_ID)
+            self.assertEqual(active["positions_count"], 1)
+            self.assertEqual(
+                active["baseline_type"], "verified_snapshot_with_open_position"
+            )
+            self.assertFalse(payload["performance_contract"]["reads_large_state_or_backup_files"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verified_snapshot_provenance_status.py
+++ b/verified_snapshot_provenance_status.py
@@ -1,0 +1,275 @@
+"""Read-only provenance status for the Stable Paper accounting recoveries.
+
+This module exists only to answer a forensic question: did the durable clean-epoch
+or verified-snapshot recovery evidence survive on the persistent volume after the
+active paper state lost its accounting-epoch identity?
+
+It never imports or calls either one-shot recovery module, never writes files,
+never restores a backup, never changes the portfolio/risk/ledger, and never
+places orders.  The route intentionally inspects only small marker/manifest
+metadata plus the already-loaded in-memory portfolio so normal status reads stay
+bounded.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+from typing import Any, Dict, List
+
+VERSION = "verified-snapshot-provenance-status-2026-08-21-v1"
+
+CLEAN_DECISION_ID = "journal-recovery-incomplete-2026-08-10"
+CLEAN_EPOCH_ID = "stable-paper-v1-20260810-clean01"
+VERIFIED_DECISION_ID = "verified-bad-tick-and-ledger-divergence-2026-08-12"
+VERIFIED_EPOCH_ID = "stable-paper-v2-20260812-verified01"
+
+STATE_DIR = (
+    os.environ.get("STATE_DIR")
+    or os.environ.get("PERSISTENT_STATE_DIR")
+    or os.environ.get("RAILWAY_VOLUME_MOUNT_PATH")
+    or "."
+)
+ARCHIVE_ROOT = os.path.join(STATE_DIR, "forensic_archives")
+CLEAN_MARKER_FILE = os.path.join(STATE_DIR, f"clean_epoch_{CLEAN_DECISION_ID}.json")
+VERIFIED_MARKER_FILE = os.path.join(STATE_DIR, f"verified_snapshot_{VERIFIED_DECISION_ID}.json")
+MANIFEST_NAME = "verified_snapshot_recovery_manifest.json"
+MAX_ARCHIVE_DIRS_SCANNED = 128
+MAX_MATCHES_RETURNED = 16
+
+_REGISTERED_APP_IDS: set[int] = set()
+
+
+def _now(core: Any = None) -> str:
+    try:
+        return str(core.local_ts_text())
+    except Exception:
+        return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _load_small_json(path: str) -> tuple[Dict[str, Any], str | None]:
+    """Read marker/manifest JSON only; callers never point this at state.json."""
+    try:
+        if not os.path.isfile(path):
+            return {}, None
+        # Markers/manifests are expected to be tiny.  Fail closed on an
+        # unexpectedly large file rather than turning a status route into a
+        # heavyweight state reader.
+        size = int(os.path.getsize(path))
+        if size > 2_000_000:
+            return {}, "metadata_file_too_large"
+        with open(path, "r", encoding="utf-8") as handle:
+            value = json.load(handle)
+        if not isinstance(value, dict):
+            return {}, "metadata_not_object"
+        return value, None
+    except Exception as exc:
+        return {}, f"{type(exc).__name__}: {exc}"
+
+
+def _marker_summary(path: str, expected_decision: str, expected_epoch: str) -> Dict[str, Any]:
+    payload, error = _load_small_json(path)
+    exists = os.path.isfile(path)
+    decision_id = str(payload.get("decision_id") or "") if payload else ""
+    epoch_id = str(
+        payload.get("target_epoch_id")
+        or payload.get("epoch_id")
+        or payload.get("accounting_epoch_id")
+        or ""
+    ) if payload else ""
+    return {
+        "path": path,
+        "exists": exists,
+        "size_bytes": int(os.path.getsize(path)) if exists else 0,
+        "read_error": error,
+        "status": payload.get("status") if payload else None,
+        "decision_id": decision_id or None,
+        "target_epoch_id": epoch_id or None,
+        "archive_dir": payload.get("archive_dir") if payload else None,
+        "started_local": payload.get("started_local") if payload else None,
+        "completed_local": payload.get("completed_local") if payload else None,
+        "decision_matches": bool(payload) and decision_id == expected_decision,
+        "epoch_matches": bool(payload) and epoch_id == expected_epoch,
+    }
+
+
+def _archive_manifest_summaries() -> Dict[str, Any]:
+    matches: List[Dict[str, Any]] = []
+    scanned = 0
+    errors: List[str] = []
+    if not os.path.isdir(ARCHIVE_ROOT):
+        return {
+            "archive_root": ARCHIVE_ROOT,
+            "root_exists": False,
+            "directories_scanned": 0,
+            "scan_truncated": False,
+            "matching_manifest_count": 0,
+            "matching_manifests": [],
+            "errors": [],
+        }
+
+    try:
+        names = sorted(os.listdir(ARCHIVE_ROOT), reverse=True)
+    except Exception as exc:
+        return {
+            "archive_root": ARCHIVE_ROOT,
+            "root_exists": True,
+            "directories_scanned": 0,
+            "scan_truncated": False,
+            "matching_manifest_count": 0,
+            "matching_manifests": [],
+            "errors": [f"{type(exc).__name__}: {exc}"],
+        }
+
+    candidates = [name for name in names if os.path.isdir(os.path.join(ARCHIVE_ROOT, name))]
+    for name in candidates[:MAX_ARCHIVE_DIRS_SCANNED]:
+        scanned += 1
+        manifest_path = os.path.join(ARCHIVE_ROOT, name, MANIFEST_NAME)
+        if not os.path.isfile(manifest_path):
+            continue
+        payload, error = _load_small_json(manifest_path)
+        if error:
+            errors.append(f"{name}: {error}")
+            continue
+        decision_id = str(payload.get("decision_id") or "")
+        target_epoch_id = str(payload.get("target_epoch_id") or "")
+        if decision_id != VERIFIED_DECISION_ID and target_epoch_id != VERIFIED_EPOCH_ID:
+            continue
+        if len(matches) < MAX_MATCHES_RETURNED:
+            matches.append({
+                "archive_dir": os.path.join(ARCHIVE_ROOT, name),
+                "manifest_path": manifest_path,
+                "status": payload.get("status"),
+                "decision_id": decision_id or None,
+                "old_epoch_id": payload.get("old_epoch_id"),
+                "target_epoch_id": target_epoch_id or None,
+                "created_local": payload.get("created_local"),
+                "bad_execution_id": payload.get("bad_execution_id"),
+            })
+
+    return {
+        "archive_root": ARCHIVE_ROOT,
+        "root_exists": True,
+        "directories_scanned": scanned,
+        "scan_truncated": len(candidates) > MAX_ARCHIVE_DIRS_SCANNED,
+        "matching_manifest_count": len(matches),
+        "matching_manifests": matches,
+        "errors": errors[:MAX_MATCHES_RETURNED],
+    }
+
+
+def _active_epoch_summary(core: Any = None) -> Dict[str, Any]:
+    pf = getattr(core, "portfolio", None) if core is not None else None
+    pf = pf if isinstance(pf, dict) else {}
+    epoch = _d(pf.get("paper_accounting_epoch"))
+    return {
+        "portfolio_available": bool(pf),
+        "cash": pf.get("cash"),
+        "equity": pf.get("equity"),
+        "positions_count": len(_d(pf.get("positions"))),
+        "trades_count": len(pf.get("trades") or []) if isinstance(pf.get("trades"), list) else 0,
+        "accounting_epoch_id": pf.get("accounting_epoch_id"),
+        "paper_accounting_epoch_id": epoch.get("id"),
+        "decision_id": epoch.get("decision_id"),
+        "baseline_type": epoch.get("baseline_type"),
+        "historical_recovery_decision": epoch.get("historical_recovery_decision"),
+        "historical_evidence_archived": epoch.get("historical_evidence_archived"),
+        "forensic_archive_dir": epoch.get("forensic_archive_dir"),
+        "validation_hold": epoch.get("validation_hold"),
+    }
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    clean_marker = _marker_summary(CLEAN_MARKER_FILE, CLEAN_DECISION_ID, CLEAN_EPOCH_ID)
+    verified_marker = _marker_summary(
+        VERIFIED_MARKER_FILE, VERIFIED_DECISION_ID, VERIFIED_EPOCH_ID
+    )
+    archives = _archive_manifest_summaries()
+    active = _active_epoch_summary(core)
+
+    verified_marker_proves = bool(
+        verified_marker.get("exists")
+        and verified_marker.get("decision_matches")
+        and verified_marker.get("epoch_matches")
+        and not verified_marker.get("read_error")
+    )
+    verified_archive_proves = bool(archives.get("matching_manifest_count"))
+    clean_marker_proves = bool(
+        clean_marker.get("exists")
+        and clean_marker.get("decision_matches")
+        and clean_marker.get("epoch_matches")
+        and not clean_marker.get("read_error")
+    )
+    durable_verified_evidence = verified_marker_proves or verified_archive_proves
+
+    if durable_verified_evidence:
+        diagnosis = "verified_snapshot_durable_provenance_found"
+        overall = "pass"
+    elif clean_marker_proves:
+        diagnosis = "clean_epoch_provenance_found_verified_snapshot_missing"
+        overall = "warn"
+    else:
+        diagnosis = "recovery_markers_and_verified_archive_not_found"
+        overall = "warn"
+
+    return {
+        "status": "ok",
+        "overall": overall,
+        "type": "verified_snapshot_provenance_status",
+        "version": VERSION,
+        "generated_local": _now(core),
+        "diagnosis": diagnosis,
+        "durable_verified_evidence_found": durable_verified_evidence,
+        "clean_epoch_marker_found": clean_marker_proves,
+        "verified_snapshot_marker_found": verified_marker_proves,
+        "verified_snapshot_archive_found": verified_archive_proves,
+        "active_runtime": active,
+        "clean_epoch_marker": clean_marker,
+        "verified_snapshot_marker": verified_marker,
+        "verified_snapshot_archives": archives,
+        "performance_contract": {
+            "reads_large_state_or_backup_files": False,
+            "archive_directories_scan_limit": MAX_ARCHIVE_DIRS_SCANNED,
+            "manifest_matches_return_limit": MAX_MATCHES_RETURNED,
+        },
+        "authority": {
+            "reporting_only": True,
+            "places_orders": False,
+            "writes_files": False,
+            "restores_backups": False,
+            "repairs_historical_state": False,
+            "rewrites_canonical_ledger": False,
+            "clears_hard_halt": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    return status_payload(core)
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    if flask_app is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "flask_app_missing"}
+    if id(flask_app) not in _REGISTERED_APP_IDS:
+        from flask import jsonify
+        try:
+            existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+        except Exception:
+            existing = set()
+        if "/paper/verified-snapshot-provenance-status" not in existing:
+            flask_app.add_url_rule(
+                "/paper/verified-snapshot-provenance-status",
+                "verified_snapshot_provenance_status",
+                lambda: jsonify(status_payload(core)),
+            )
+        _REGISTERED_APP_IDS.add(id(flask_app))
+    return {"status": "ok", "overall": "pass", "version": VERSION, "route_registered": True}


### PR DESCRIPTION
## Purpose
Continue Issue #82 fresh-day/accounting provenance work after PR #98 without mutating paper state.

Current Railway evidence shows the active/on-disk state is corrupted, the fresh-day guard is correctly pending, the canonical ledger chain is healthy under `legacy-pre-stable-core`, clean-epoch active metadata is absent, `state_guard` did not restore a backup, and `/paper/state-io-status` currently reports `atomic_save_state` rather than a backup fallback read.

## Changes
- Add `/paper/verified-snapshot-provenance-status` as a bounded observational endpoint.
- Inspect only the exact clean/verified recovery marker files, bounded forensic archive manifest metadata, and the already-loaded in-memory portfolio.
- Never import/call the one-shot recovery modules from the provenance probe.
- Never read the large state/backup JSON files from this endpoint.
- Register the probe before the one-shot verified recovery module in the existing data-integrity bridge.
- Add focused read-only/provenance regressions.
- Extend Change Safety Audit selection so provenance changes run the focused regression in addition to the mandatory core invariant suite.

## Authority boundary
No orders, no state writes/restores, no halt clear, no ledger rewrite/relabel, no strategy/sizing/risk-threshold/live/ML authority change.

## Required merge evidence
Do not merge unless the exact PR head passes Change Safety Audit including the focused provenance test, repository safety validation, architecture debt/ownership/config checks, and exact Gunicorn bootstrap startup smoke.