### PR TITLE
Add read-only backup provenance status

### DIFF
--- a/PROJECT_HANDOFF_CURRENT.md
+++ b/PROJECT_HANDOFF_CURRENT.md
@@ -1,24 +1,24 @@
 # Project Handoff — Authoritative Current Runtime
 
-Last updated: 2026-08-21 11:06 CDT  
+Last updated: 2026-08-21 12:15 CDT  
 Repository: `sterlingfancher-cmyk/Trading-bot`  
-Current `main`: `69ec3d39a565a8c9068d0a088f441723e6883c3e` (`Update handoff for current-chat continuity and clean-epoch provenance (#100)`)  
-Active provenance PR: #101, branch `agent/verified-snapshot-provenance-20260821`  
+Current `main`: `45b83dfca905aef4b2e51f30a0fb2ec7480f53f1` (`Add read-only verified snapshot provenance probe (#101)`)  
+Active PR: #102 `agent/verified-snapshot-backup-provenance-20260821`  
 Canonical Railway paper service: `https://trading-bot-clean.up.railway.app`
 
 ## Communication / Continuity Rule
 
-Keep Trading-bot progress communication in the **currently active ChatGPT project conversation**. This is not permanently tied to one thread. When the project intentionally moves to a new ChatGPT conversation, update this handoff first and treat the new conversation as the active project chat.
+Keep Trading-bot progress communication in the **currently active ChatGPT project conversation**. This is not permanently tied to one thread. When the project intentionally moves to a new conversation, refresh this handoff first and treat the new conversation as the active project chat.
 
 Project-specific monitoring tasks that could post into stale chats remain disabled unless a future active project conversation intentionally re-establishes them. Repository handoff maintenance is mandatory so a new conversation can recover exact state without relying on prior-chat memory.
 
-When the active conversation is becoming too large for reliable continuation, warn the user **before** a testing/update sequence is started, finish or stop at a clean boundary, refresh this handoff with all material evidence and the exact next action, then move conversations. Do not force a chat switch in the middle of an avoidable test sequence.
+When the active conversation is becoming too large for reliable continuation, warn the user **before** starting another test/update sequence, finish or stop at a clean boundary, refresh this handoff with all material evidence and the exact next action, then move conversations. Do not force a chat switch in the middle of an avoidable test sequence.
 
 ## Executive Status
 
 Operational stabilization is still blocked by Issue #82. Runtime remains paper-only. Rules remain sole execution authority. Live authority is disabled. ML/AI remains shadow-only for execution.
 
-The fresh-day protection is now correctly fail-closed, but the authoritative paper account snapshot is corrupted and cannot seed a new risk day. Current live/on-disk state is approximately:
+The fresh-day protection is correctly failing closed, but the authoritative paper account snapshot is corrupted and cannot seed a new risk day. Current live/on-disk state remains approximately:
 - `cash=-26064.308325`
 - `equity=-26064.31`
 - no open positions
@@ -31,7 +31,7 @@ Risk remains stale from 2026-08-20:
 - `halt_reason='daily loss limit hit (3.0%)'`
 - `fresh_day_reset_pending=true`
 
-Do not clear the halt, rewrite the risk peak, force a baseline, rewrite/relabel canonical ledger rows, or overwrite the account from an incomplete reconstruction merely to make an audit pass.
+Do not clear the halt, rewrite the risk peak, force a fresh-day baseline, rewrite/relabel canonical ledger rows, restore an older backup, or overwrite the account from an incomplete reconstruction merely to make an audit pass.
 
 ## Current Runtime Evidence — 2026-08-21
 
@@ -39,7 +39,7 @@ Do not clear the halt, rewrite the risk peak, force a baseline, rewrite/relabel 
 
 `/paper/fresh-day-check`:
 - `baseline_status=pending`
-- risk date still `2026-08-20`
+- risk date remains `2026-08-20`
 - `day_start_equity=-26064.31`
 - `day_peak_equity=0.01`
 - `fresh_day_reset_pending=true`
@@ -52,7 +52,7 @@ Do not clear the halt, rewrite the risk peak, force a baseline, rewrite/relabel 
 - `fresh_day_reset_pending=true`
 - prospective only; no halt clear/current-day rewrite/peak rewrite/history edit/order/strategy/sizing/threshold/live/ML authority change
 
-Interpretation: PR #83/#87 protection is functioning and refusing to manufacture a 2026-08-21 risk baseline from invalid equity.
+Interpretation: PR #83/#87 protection is functioning and refusing to manufacture a 2026-08-21 baseline from invalid equity.
 
 ### Compact self-check
 
@@ -71,7 +71,7 @@ Interpretation: PR #83/#87 protection is functioning and refusing to manufacture
 - runner and market-data/provider accounting pass
 - persistent volume healthy; in-memory/on-disk richness matched
 - accounting reconstruction estimates `cash/equity=10724.779592`, `realized_total=724.779592`, zero positions
-- reconstruction coverage is incomplete: 193 ignored/unmatched legacy exit rows, beginning 2026-08-07
+- reconstruction coverage is incomplete: 193 ignored/unmatched legacy exit rows beginning 2026-08-07
 - separate ledger-economic integrity also fails
 
 Therefore `$10,724.779592` is forensic evidence only and **must not be promoted automatically into authoritative state**.
@@ -102,9 +102,9 @@ The ledger is healthy and immutable. Do not edit/relabel these rows. The active 
 - `zero_trade_baseline=false`
 - `validation_hold=false`
 
-The endpoint's displayed `epoch_id=stable-paper-v1-20260810-clean01` is a target constant when inactive, not proof of an active clean epoch. Active clean metadata/marker is absent from this status path.
+The endpoint's displayed `epoch_id=stable-paper-v1-20260810-clean01` is a target constant when inactive, not proof of an active clean epoch.
 
-### State recovery guard — decisive current-startup evidence
+### State recovery guard
 
 `/paper/state-recovery-status` at approximately 10:54 CDT:
 - `restored=false`
@@ -113,12 +113,12 @@ The endpoint's displayed `epoch_id=stable-paper-v1-20260810-clean01` is a target
 - largest backup valid, score 39, 280 trades, 19 positions, 500 history rows
 - decision `should_restore=false`
 - reason `backup_has_fewer_trades_than_current`
-- current runner timestamp rank is materially newer than the largest backup
-- monotonic trade and runner timestamp guards enabled
+- current runner timestamp is newer than largest backup
+- monotonic trade and runner-timestamp guards enabled
 
-Interpretation: `state_guard` did **not** resurrect the old snapshot during this startup. Restoring `state_backup_largest.json` would roll execution history backward and is prohibited.
+Interpretation: `state_guard` did **not** resurrect the old snapshot during this startup. Restoring `state_backup_largest.json` would roll history backward and is prohibited.
 
-### State I/O hardening — latest evidence
+### State I/O hardening
 
 `/paper/state-io-status` at 10:59 CDT:
 - installed / status ok
@@ -126,26 +126,47 @@ Interpretation: `state_guard` did **not** resurrect the old snapshot during this
 - current state valid with 303 trades, 0 positions, 500 history rows
 - `state.json` about 25.8 MB
 - latest/prewrite backups about 25.4 MB; largest backup about 38.3 MB
-- atomic writes, retry reads, backup fallback reads, thread/file locking, and non-overlapping cycle protections are enabled
+- atomic writes, retry reads, backup fallback reads, thread/file locking, and non-overlapping cycle protections enabled
 - run state inactive at snapshot, no run error, zero overlap blocks
 
-Interpretation: there is no evidence in the **current** State I/O status of a fallback backup read; the latest recorded event is a normal atomic save. This status does not preserve a complete historical event log, so it cannot by itself prove that no fallback read ever occurred before PR #98. Combined with `state_guard.restored=false`, the corrupted `/data/state.json` existed before the current startup recovery decision. The pre-PR #98 X-Ray independent state I/O remains the leading known resurrection mechanism, but final provenance still needs durable marker/archive evidence.
+Interpretation: current State I/O does not show a backup fallback read; the latest recorded event is normal atomic persistence. This does not prove no fallback read occurred historically, but combined with `state_guard.restored=false` it proves the corrupted `state.json` existed before the current startup recovery decision.
 
-## PR #101 — Read-only verified-snapshot provenance probe
+### PR #101 verified-snapshot marker/archive provenance result
 
-PR #101 was opened from main specifically to answer the remaining provenance question without touching paper state.
+PR #101 merged to main as `45b83dfca905aef4b2e51f30a0fb2ec7480f53f1`. Exact-head Change Safety Audit, focused provenance regression, repository validation, architecture debt/ownership/config checks, and exact Gunicorn startup smoke passed before merge.
 
-Head at PR creation: `62edf2d4f74259b1a728e7d06a8387638a2c1755` before the handoff refresh commit.
+`/paper/verified-snapshot-provenance-status` at 12:06 CDT returned:
+- `active_runtime.accounting_epoch_id=null`
+- `active_runtime.paper_accounting_epoch_id=null`
+- active cash/equity remain `-26064.31`, 303 trades, 0 positions
+- `clean_epoch_marker_found=false`
+- expected clean marker path `/data/clean_epoch_journal-recovery-incomplete-2026-08-10.json` does not exist
+- `verified_snapshot_marker_found=false`
+- expected verified marker path `/data/verified_snapshot_verified-bad-tick-and-ledger-divergence-2026-08-12.json` does not exist
+- `verified_snapshot_archive_found=false`
+- `/data/forensic_archives` itself does not exist
+- `durable_verified_evidence_found=false`
+- diagnosis `recovery_markers_and_verified_archive_not_found`
+- endpoint confirms reporting-only/no-write/no-restore/no-ledger-rewrite authority
 
-It adds `/paper/verified-snapshot-provenance-status` with these boundaries:
-- reads only exact small clean/verified recovery marker files, bounded forensic archive manifests, and the already-loaded in-memory portfolio;
-- does **not** read the 25–38 MB state/backup files;
-- does not import or call either one-shot recovery implementation;
-- no file writes, backup restore, state repair, halt clear, ledger rewrite/relabel, order placement, strategy/sizing/risk-threshold/live/ML change;
-- bounded archive directory scan and bounded returned matches;
-- focused regression added to Change Safety Audit while preserving the mandatory core invariant suite.
+Interpretation: the dedicated Aug. 10/Aug. 12 recovery marker and forensic archive evidence is no longer present on the current Railway volume. This removes the simplest mechanically proven recovery source. Do not infer authoritative account values from memory or the incomplete reconstruction.
 
-Do not merge #101 unless exact-head Change Safety Audit, repository validation, architecture debt/ownership/config checks, focused provenance tests, and exact Gunicorn startup smoke are green.
+## PR #102 — Read-only retained-backup provenance discriminator
+
+PR #102 is the next bounded discriminator. It adds `/paper/verified-snapshot-backup-provenance-status` and is **diagnostic only**.
+
+It will:
+- stream the four known retained state backups: `state.json.bak`, `state_backup_latest.json`, `state_backup_prewrite.json`, `state_backup_largest.json`;
+- never load an entire large backup JSON into memory;
+- read the small `state_snapshots/manifest.json` without pruning/deleting anything;
+- scan at most three retained snapshots that look recovery-era by tiny trade count or Aug. 12 timestamp;
+- bound per-file and cumulative bytes read;
+- extract only the exact `paper_accounting_epoch` JSON object with brace/string-aware bounded parsing;
+- require the full verified signature before treating a backup as authoritative provenance: epoch `stable-paper-v2-20260812-verified01`, decision `verified-bad-tick-and-ledger-divergence-2026-08-12`, baseline type `verified_snapshot_with_open_position`, recovery disposition `verified_snapshot_rollforward`, archived-history flag true, and prior epoch `stable-paper-v1-20260810-clean01`;
+- keep startup `apply()` constant-time; large backup scans occur only when the explicit route is requested;
+- perform no orders, state writes, backup restores, snapshot deletion/pruning, halt clears, ledger rewrites/relabels, or strategy/sizing/threshold/live/ML changes.
+
+Do not merge #102 unless its **final exact head** passes the mandatory Change Safety Audit, both provenance regressions, core Stable Paper invariants, repository safety, architecture ownership/config/debt checks, and exact Gunicorn startup smoke.
 
 ## Issue #82 — Stabilization Exit Gate
 
@@ -167,12 +188,12 @@ Remaining acceptance:
 4. evidence-based historical-accounting disposition without rewriting immutable execution history;
 5. clean active audit with sane valuation, healthy runner/market data, valid canonical chain, no new active economic/coverage issue, and risk reflecting real economics.
 
-Current fresh-day status is `pending`, which is the correct fail-closed state while authoritative equity is invalid.
+Current fresh-day status remains `pending`, which is the correct fail-closed state while authoritative equity is invalid.
 
 ## This Week's Reliability / Architecture / Governance Changes
 
 ### 2026-08-18
-- #79 merged — validate fresh cached quotes before `latest_price` return.
+- #79 merged — validate fresh cached quotes before `latest_price` return; poisoned-cache regression added.
 - #80 merged — fail closed on catastrophic persisted `last_price` valuation fallback.
 - #81 merged — block duplicate full exits at canonical pre-mutation boundary; historical TEM evidence remains immutable.
 
@@ -183,7 +204,7 @@ Current fresh-day status is `pending`, which is the correct fail-closed state wh
 
 ### 2026-08-20
 - #86 merged — compact observational `/paper/fresh-day-check`.
-- #87 merged — install fresh-day guard before full WSGI composition; Gunicorn smoke passed.
+- #87 merged — install fresh-day guard before full WSGI composition; exact Gunicorn smoke passed.
 - #88 merged — master system audit + architecture-debt regression gate. Audit baseline: 250 Python files / 90,409 lines; 34 runtime mutation overlaps; 5 env conflicts; 5 route overlaps; 80 duplicate-function groups; 540 broad exception-pass sites; 8 watchdog loops; 32 critical findings; fragmented ownership included `save_state` 17, `scan_signals` 14, `try_entries_and_rotations` 13, `entry_quality_check` 10, `enter_position` 9.
 - #89 merged — Stage B deterministic shadow valuation.
 - #90 merged — Stage C deterministic shadow risk lifecycle.
@@ -193,13 +214,14 @@ Current fresh-day status is `pending`, which is the correct fail-closed state wh
 ### 2026-08-21
 - #93 merged — Stage F shadow canary-readiness planner; no authoritative cutover.
 - Issue #94 created — mandatory per-change regression/impact auditing.
-- #95 merged — exact-head Change Safety Audit with core invariants, impact-aware tests, architecture/config/ownership/debt checks, and exact startup smoke.
+- #95 merged — exact-head Change Safety Audit with mandatory core invariants, impact-aware tests, architecture/config/ownership/debt checks, and exact startup smoke.
 - Issue #96 created — self-diagnosing incident triage/recommendation engine.
 - #97 merged — shadow-only `system_sentinel` foundation; no production mutation/self-healing authority.
-- #98 merged as `c6ef7958a247ae88ba9a5c3670ed756ac0d06426` — `entry_pipeline_xray` no longer loads/saves authoritative state or reassigns `core.portfolio`; regression proves stale-file/live-memory split cannot replace live state. Required CI passed and Railway deployed.
-- #99 merged as `0874368ad5bf303337b8c94ed1c9ae967c2231b5` — authoritative handoff refresh.
+- #98 merged as `c6ef7958a247ae88ba9a5c3670ed756ac0d06426` — `entry_pipeline_xray` no longer loads/saves authoritative state or reassigns `core.portfolio`; exact regression proves stale-file/live-memory split cannot replace live state. Required CI passed and Railway deployed.
+- #99 merged as `0874368ad5bf303337b8c94ed1c9ae967c2231b5` — authoritative handoff refresh through Aug. 21.
 - #100 merged as `69ec3d39a565a8c9068d0a088f441723e6883c3e` — current-chat continuity + clean-epoch provenance handoff update.
-- #101 open — bounded read-only durable recovery provenance probe and focused Change Safety regression selection.
+- #101 merged as `45b83dfca905aef4b2e51f30a0fb2ec7480f53f1` — bounded marker/archive verified-snapshot provenance probe; production evidence found no surviving marker/archive root.
+- #102 open — bounded retained-backup/snapshot provenance probe; no mutation authority.
 
 ## Stable Paper Core v3 / Issue #84
 
@@ -216,7 +238,9 @@ Do not use shadow core to bypass Issue #82.
 
 ## Mandatory Change Safety / Issue #94
 
-PR #95 implemented the in-repository exact-head audit. Every relevant PR must pass Change Safety Audit plus overlapping regressions and the mandatory core suite. Missing/stale/failing evidence blocks merge. PR #101 additionally routes verified-snapshot provenance changes to their focused regression, demonstrating the intended impact-aware model instead of indiscriminately expanding all tests.
+PR #95 implemented the in-repository exact-head audit. Every relevant PR must pass Change Safety Audit plus overlapping regressions and the mandatory core suite. Missing/stale/failing evidence blocks merge.
+
+PR #101 added focused verified-snapshot provenance regression selection. PR #102 extends that focused set to the retained-backup provenance regression while preserving all mandatory core tests.
 
 Final post-rebuild completion still includes repository-rule/branch-protection enforcement where permissions support it and acceptance/closure of Issue #94.
 
@@ -224,17 +248,18 @@ Final post-rebuild completion still includes repository-rule/branch-protection e
 
 PR #97 provides the shadow diagnostic foundation across valuation, accounting, ledger, risk, startup, configuration, ownership, runner, and market-data boundaries. It may recommend bounded fixes and select affected tests, but must not rewrite state, clear halts, alter execution history, change strategy/sizing/hard-risk/live/ML authority, or auto-merge authoritative repairs.
 
-## Prior Verified Accounting Recovery — Forensic Evidence Only
+## Prior Verified Accounting Recovery — Forensic Facts Only
 
 Existing recovery code documents the previously verified Aug. 12 recovery design:
 - old epoch `stable-paper-v1-20260810-clean01`
 - target `stable-paper-v2-20260812-verified01`
 - decision `verified-bad-tick-and-ledger-divergence-2026-08-12`
 - exact LRCX bad execution id `5ca38922916e4612ae3cda8d9801107d`
-- expected recovery marker path under the persistent state directory: `verified_snapshot_verified-bad-tick-and-ledger-divergence-2026-08-12.json`
-- forensic archives under `/data/forensic_archives` with `verified_snapshot_recovery_manifest.json`
+- expected marker `verified_snapshot_verified-bad-tick-and-ledger-divergence-2026-08-12.json`
+- expected forensic archive root `/data/forensic_archives`
+- recovery code wrote the recovered state to `state.json`, state I/O latest/largest/prewrite backups, and `state.json.bak`, then reset the bounded snapshot archive with the recovered zero-trade state.
 
-Do **not** call `verified_snapshot_epoch_recovery.status_payload()` as a diagnostic route: in the legacy module it delegates to `apply()`, which is the one-shot recovery entry point. PR #101's provenance probe intentionally avoids importing/calling that module.
+The current dedicated marker/archive files are absent. PR #102 therefore checks only whether any retained backup or recovery-like snapshot still contains the **exact full epoch object**. Do not call `verified_snapshot_epoch_recovery.status_payload()` as a diagnostic route: in the legacy module it delegates to `apply()`, the one-shot recovery entry point.
 
 ## Historical TEM Duplicate Exit
 
@@ -258,7 +283,8 @@ Use only the clean service:
 - clean epoch: `https://trading-bot-clean.up.railway.app/paper/clean-accounting-epoch-status`
 - state recovery: `https://trading-bot-clean.up.railway.app/paper/state-recovery-status`
 - state I/O: `https://trading-bot-clean.up.railway.app/paper/state-io-status`
-- verified snapshot provenance after #101 deploy: `https://trading-bot-clean.up.railway.app/paper/verified-snapshot-provenance-status`
+- verified marker/archive provenance: `https://trading-bot-clean.up.railway.app/paper/verified-snapshot-provenance-status`
+- verified backup provenance after #102 deploy: `https://trading-bot-clean.up.railway.app/paper/verified-snapshot-backup-provenance-status`
 - quote/exit integrity: `https://trading-bot-clean.up.railway.app/paper/exit-price-integrity-status`
 
 Do not manually call `/paper/run` unless a future validation plan explicitly requires it.
@@ -281,18 +307,18 @@ Known ops debt: `.github/workflows/refactor-audit.yml` still contains the older 
 
 ## Exact Next Action
 
-1. Re-fetch PR #101 exact head and CI after this handoff commit.
-2. Inspect the exact PR diff for accidental write/recovery authority.
-3. Merge only if Change Safety Audit, focused provenance regression, repository safety, architecture debt/ownership/config, and exact Gunicorn startup smoke all pass at the exact head.
-4. Wait for Railway to deploy the merge and settle to `delegate_ready:true`.
-5. Run only `https://trading-bot-clean.up.railway.app/paper/verified-snapshot-provenance-status`.
-6. If the exact verified marker or matching forensic manifest survives, use that mechanically proven durable evidence to design the bounded successor recovery without rewriting the 55-row canonical ledger.
-7. If neither survives, do not guess. Build the next bounded read-only discriminator for recovery metadata in specific backups/archive inventory without promoting the incomplete `$10,724.779592` reconstruction.
-8. After proven authoritative recovery, require sane fresh-day reset, forward paper session, and clean active audit before Issue #82 closure or Stage F/G authority.
+1. Re-fetch PR #102 exact final head after this handoff commit.
+2. Inspect the exact diff for accidental write/restore/prune/recovery authority and confirm startup does not scan large backups.
+3. Merge only if Change Safety Audit, both provenance regressions, core invariants, repository safety, architecture ownership/config/debt, and exact Gunicorn bootstrap smoke pass on that exact head.
+4. Wait for Railway to deploy and settle to `delegate_ready:true`.
+5. Run only `https://trading-bot-clean.up.railway.app/paper/verified-snapshot-backup-provenance-status`.
+6. If a backup/snapshot contains the full verified epoch signature, use that mechanically proven source to design a bounded successor recovery that preserves all 55 canonical ledger rows/hash chain and archives the current contaminated state first.
+7. If no full verified signature survives, do not guess. The next discriminator must remain read-only and target remaining durable evidence sources (for example journal/snapshot metadata) before any authoritative recovery design.
+8. After proven authoritative recovery, require sane fresh-day reset, one normal forward paper session, and a clean active audit before Issue #82 closure or Stage F/G authority.
 
 ## Conversation Continuity Protocol
 
-Stay in the current active project chat through a coherent testing/update sequence. The assistant cannot rely on a UI meter, so it must use conversation size/complexity judgment and proactively warn the user before continuation becomes unsafe. When a move is needed, stop at a clean boundary, refresh this handoff, then use:
+Stay in the current active project chat through a coherent testing/update sequence. The assistant cannot rely on a UI context meter, so it must use conversation size/complexity judgment and proactively warn the user before continuation becomes unsafe. When a move is needed, stop at a clean boundary, refresh this handoff, then use:
 
 ```text
 Use the direct @GitHub connector and continue the Trading-bot project from sterlingfancher-cmyk/Trading-bot. Read PROJECT_HANDOFF_CURRENT.md first and treat it as the authoritative continuation state. Treat this conversation as the current active project chat and keep project-status communication here. Verify current main/PR/CI and the canonical Railway clean-service read-only evidence before changing code. Continue from the Exact Next Action. Preserve paper-only authority, hard risk thresholds, canonical ledger history, rules-only execution authority, ML shadow-only execution, and the Issue #82/#84/#94/#96 gates. Do not manually repair account state or clear halts from inference.

--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Iterable
 
-VERSION = "change-safety-audit-2026-08-21-v2-provenance"
+VERSION = "change-safety-audit-2026-08-21-v3-provenance"
 
 CORE_TESTS = (
     "test_architecture_stage_b.py",
@@ -30,7 +30,10 @@ RUNTIME_TESTS = (
 STATE_TESTS = ("test_state_store_stage_c.py",)
 DECISION_TESTS = ("test_shadow_decision_stage_d.py",)
 CONFIG_TESTS = ("test_architecture_stage_b.py",)
-PROVENANCE_TESTS = ("test_verified_snapshot_provenance_status.py",)
+PROVENANCE_TESTS = (
+    "test_verified_snapshot_provenance_status.py",
+    "test_verified_snapshot_backup_provenance_status.py",
+)
 
 
 @dataclass(frozen=True)
@@ -55,6 +58,11 @@ def _git(*args: str) -> str:
 def changed_files(base: str, head: str) -> tuple[str, ...]:
     text = _git("diff", "--name-only", f"{base}...{head}")
     return tuple(sorted({line.strip() for line in text.splitlines() if line.strip()}))
+
+
+def _is_verified_snapshot_provenance_path(path: str) -> bool:
+    lowered = path.lower()
+    return "verified_snapshot" in lowered and "provenance" in lowered
 
 
 def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ...]]:
@@ -83,7 +91,7 @@ def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ..
         if any(token in path for token in ("accounting", "ledger", "execution")):
             categories.add("accounting_execution")
             boundaries.update(("accounting", "execution"))
-        if "verified_snapshot_provenance" in path:
+        if _is_verified_snapshot_provenance_path(path):
             categories.add("state_persistence")
             boundaries.update(("state", "accounting"))
         if "risk" in path:
@@ -112,7 +120,7 @@ def planned_regressions(paths: Iterable[str]) -> tuple[str, ...]:
         tests.extend(DECISION_TESTS)
     if "configuration" in categories:
         tests.extend(CONFIG_TESTS)
-    if any("verified_snapshot_provenance" in path.lower() for path in path_tuple):
+    if any(_is_verified_snapshot_provenance_path(path) for path in path_tuple):
         tests.extend(PROVENANCE_TESTS)
     existing = []
     seen = set()

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-21-v28-verified-snapshot-provenance"
+VERSION = "data-integrity-startup-bridge-2026-08-21-v29-verified-backup-provenance"
 MODULES = (
     "final_daily_audit_compactor",
     "daily_audit_entry_count_bridge",
@@ -32,9 +32,12 @@ MODULES = (
     "clean_accounting_epoch",
     "paper_bidirectional_accounting_guard",
     "paper_execution_timestamp_semantics",
-    # Read-only forensic probe.  It deliberately runs before the exact one-shot
-    # recovery module and does not import/call either recovery implementation.
+    # Small marker/archive forensic probe.  It deliberately runs before the
+    # one-shot recovery module and does not import/call recovery implementations.
     "verified_snapshot_provenance_status",
+    # Backup/snapshot provenance probe.  Its apply() is constant-time and never
+    # scans backups during startup; scanning occurs only on its explicit route.
+    "verified_snapshot_backup_provenance_status",
     # Patch the exact one-shot recovery's journal rotation before the recovery
     # runs. The migration already owns the journal lock, so it must not call the
     # journal mirror recursively from inside that critical section.

--- a/test_change_safety_audit.py
+++ b/test_change_safety_audit.py
@@ -68,23 +68,27 @@ class ChangeSafetyAuditTests(unittest.TestCase):
         for boundary in ("startup_runtime", "state", "valuation", "accounting", "risk"):
             self.assertIn(boundary, boundaries)
 
-    def test_verified_snapshot_provenance_change_selects_focused_regression(self) -> None:
-        paths = ("verified_snapshot_provenance_status.py",)
-        categories, boundaries = classify_paths(paths)
-        tests = planned_regressions(paths)
-
-        self.assertIn("state_persistence", categories)
-        self.assertIn("state", boundaries)
-        self.assertIn("accounting", boundaries)
-        self.assertIn("test_verified_snapshot_provenance_status.py", tests)
-        for core_test in (
-            "test_architecture_stage_b.py",
-            "test_architecture_stage_c.py",
-            "test_architecture_stage_d_state_store.py",
-            "test_architecture_stage_e_accounting.py",
-            "test_architecture_stage_f_canary.py",
+    def test_verified_snapshot_provenance_change_selects_focused_regressions(self) -> None:
+        for path in (
+            "verified_snapshot_provenance_status.py",
+            "verified_snapshot_backup_provenance_status.py",
         ):
-            self.assertIn(core_test, tests)
+            categories, boundaries = classify_paths((path,))
+            tests = planned_regressions((path,))
+
+            self.assertIn("state_persistence", categories)
+            self.assertIn("state", boundaries)
+            self.assertIn("accounting", boundaries)
+            self.assertIn("test_verified_snapshot_provenance_status.py", tests)
+            self.assertIn("test_verified_snapshot_backup_provenance_status.py", tests)
+            for core_test in (
+                "test_architecture_stage_b.py",
+                "test_architecture_stage_c.py",
+                "test_architecture_stage_d_state_store.py",
+                "test_architecture_stage_e_accounting.py",
+                "test_architecture_stage_f_canary.py",
+            ):
+                self.assertIn(core_test, tests)
 
 
 if __name__ == "__main__":

--- a/test_verified_snapshot_backup_provenance_status.py
+++ b/test_verified_snapshot_backup_provenance_status.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import verified_snapshot_backup_provenance_status as probe
+
+
+class DummyCore:
+    def local_ts_text(self):
+        return "2026-08-21 12:10:00 CDT"
+
+
+class VerifiedSnapshotBackupProvenanceStatusTests(unittest.TestCase):
+    def _patch_root(self, root: str):
+        snapshot_dir = os.path.join(root, "state_snapshots")
+        return mock.patch.multiple(
+            probe,
+            STATE_DIR=root,
+            STATE_FILE=os.path.join(root, "state.json"),
+            BACKUP_FILES=(
+                os.path.join(root, "state.json.bak"),
+                os.path.join(root, "state_backup_latest.json"),
+                os.path.join(root, "state_backup_prewrite.json"),
+                os.path.join(root, "state_backup_largest.json"),
+            ),
+            SNAPSHOT_DIR=snapshot_dir,
+            SNAPSHOT_MANIFEST=os.path.join(snapshot_dir, "manifest.json"),
+        )
+
+    def _verified_state_text(self) -> str:
+        return json.dumps(
+            {
+                "cash": 10768.497731,
+                "equity": 11915.688807,
+                "positions": {"LRCX": {"qty": 3.42486}},
+                "trades": [],
+                "accounting_epoch_id": probe.VERIFIED_EPOCH_ID,
+                "paper_accounting_epoch": {
+                    "id": probe.VERIFIED_EPOCH_ID,
+                    "decision_id": probe.VERIFIED_DECISION_ID,
+                    "baseline_type": probe.VERIFIED_BASELINE_TYPE,
+                    "historical_recovery_decision": probe.VERIFIED_RECOVERY_DECISION,
+                    "historical_evidence_archived": True,
+                    "prior_epoch_id": probe.CLEAN_EPOCH_ID,
+                    "forensic_archive_dir": "/data/forensic_archives/example",
+                    "verified_snapshot_baseline": {
+                        "bad_tick_reversed": {"execution_id": probe.BAD_EXECUTION_ID}
+                    },
+                },
+            },
+            separators=(",", ":"),
+        )
+
+    def test_verified_backup_block_is_proven_without_full_json_load(self):
+        with tempfile.TemporaryDirectory() as root, self._patch_root(root):
+            path = Path(root) / "state.json.bak"
+            path.write_text(self._verified_state_text(), encoding="utf-8")
+            payload = probe.status_payload(DummyCore())
+
+            self.assertEqual(payload["overall"], "pass")
+            self.assertEqual(
+                payload["diagnosis"], "verified_snapshot_backup_provenance_found"
+            )
+            self.assertTrue(payload["verified_snapshot_backup_evidence_found"])
+            self.assertEqual(payload["verified_signature_paths"], [str(path)])
+            row = payload["backup_files"][0]
+            self.assertTrue(row["verified_signature"])
+            self.assertEqual(row["epoch_block"]["id"], probe.VERIFIED_EPOCH_ID)
+            self.assertEqual(
+                row["epoch_block"]["decision_id"], probe.VERIFIED_DECISION_ID
+            )
+            self.assertFalse(
+                payload["performance_contract"]["loads_whole_state_files_into_memory"]
+            )
+
+    def test_token_without_exact_epoch_block_is_not_overstated(self):
+        with tempfile.TemporaryDirectory() as root, self._patch_root(root):
+            path = Path(root) / "state_backup_latest.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "cash": -26064.31,
+                        "reports": {"note": probe.VERIFIED_EPOCH_ID},
+                        "paper_accounting_epoch": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            payload = probe.status_payload(DummyCore())
+
+            self.assertEqual(payload["overall"], "warn")
+            self.assertEqual(
+                payload["diagnosis"],
+                "verified_epoch_token_found_without_verified_epoch_block_signature",
+            )
+            self.assertFalse(payload["verified_snapshot_backup_evidence_found"])
+            self.assertIn(str(path), payload["verified_token_only_paths"])
+
+    def test_clean_backup_only_is_reported_as_incomplete_provenance(self):
+        with tempfile.TemporaryDirectory() as root, self._patch_root(root):
+            path = Path(root) / "state_backup_largest.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "accounting_epoch_id": probe.CLEAN_EPOCH_ID,
+                        "paper_accounting_epoch": {
+                            "id": probe.CLEAN_EPOCH_ID,
+                            "decision_id": probe.CLEAN_DECISION_ID,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            payload = probe.status_payload(DummyCore())
+
+            self.assertEqual(payload["overall"], "warn")
+            self.assertEqual(
+                payload["diagnosis"],
+                "clean_epoch_backup_provenance_found_verified_snapshot_missing",
+            )
+            self.assertIn(str(path), payload["clean_signature_paths"])
+
+    def test_targeted_zero_trade_snapshot_can_prove_verified_epoch(self):
+        with tempfile.TemporaryDirectory() as root, self._patch_root(root):
+            snapshot_dir = Path(root) / "state_snapshots"
+            snapshot_dir.mkdir(parents=True)
+            snapshot = snapshot_dir / "state_t000000_r0_20260812_100000.json"
+            snapshot.write_text(self._verified_state_text(), encoding="utf-8")
+            manifest = {
+                "status": "ok",
+                "snapshots": [
+                    {
+                        "path": str(snapshot),
+                        "filename": snapshot.name,
+                        "created_local": "2026-08-12 10:00:00",
+                        "created_ts": 1786546800,
+                        "trades_count": 0,
+                        "positions_count": 1,
+                        "runner_timestamp_rank": 0,
+                        "size_bytes": snapshot.stat().st_size,
+                        "reason": "execution_advanced",
+                    }
+                ],
+            }
+            (snapshot_dir / "manifest.json").write_text(
+                json.dumps(manifest), encoding="utf-8"
+            )
+
+            payload = probe.status_payload(DummyCore())
+            self.assertEqual(payload["overall"], "pass")
+            self.assertTrue(payload["verified_snapshot_backup_evidence_found"])
+            self.assertIn(str(snapshot), payload["verified_signature_paths"])
+            self.assertEqual(len(payload["targeted_snapshot_files"]), 1)
+
+    def test_status_is_read_only_and_apply_does_not_scan(self):
+        with tempfile.TemporaryDirectory() as root, self._patch_root(root):
+            path = Path(root) / "state.json.bak"
+            path.write_text(self._verified_state_text(), encoding="utf-8")
+            before = {
+                str(p.relative_to(root)): (p.stat().st_size, p.stat().st_mtime_ns)
+                for p in Path(root).rglob("*")
+                if p.is_file()
+            }
+            payload = probe.status_payload(DummyCore())
+            after = {
+                str(p.relative_to(root)): (p.stat().st_size, p.stat().st_mtime_ns)
+                for p in Path(root).rglob("*")
+                if p.is_file()
+            }
+            self.assertEqual(before, after)
+            self.assertFalse(payload["authority"]["writes_files"])
+            self.assertFalse(payload["authority"]["restores_backups"])
+            self.assertFalse(payload["authority"]["deletes_or_prunes_snapshots"])
+
+            with mock.patch.object(
+                probe, "_scan_state_file", side_effect=AssertionError("startup scanned")
+            ):
+                applied = probe.apply(DummyCore())
+            self.assertEqual(applied["status"], "ok")
+            self.assertFalse(applied["startup_scans_backups"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verified_snapshot_backup_provenance_status.py
+++ b/verified_snapshot_backup_provenance_status.py
@@ -22,7 +22,7 @@ import os
 import re
 from typing import Any, Dict, List
 
-VERSION = "verified-snapshot-backup-provenance-status-2026-08-21-v1"
+VERSION = "verified-snapshot-backup-provenance-status-2026-08-21-v2-object-bounded"
 
 CLEAN_DECISION_ID = "journal-recovery-incomplete-2026-08-10"
 CLEAN_EPOCH_ID = "stable-paper-v1-20260810-clean01"
@@ -128,15 +128,52 @@ def _load_small_json(path: str) -> tuple[Dict[str, Any], str | None]:
         return {}, f"{type(exc).__name__}: {exc}"
 
 
+def _bounded_json_object(raw: bytes) -> tuple[bytes, str | None]:
+    """Return the first complete JSON object in raw without parsing whole state."""
+    start = raw.find(b"{")
+    if start < 0:
+        return b"", "epoch_object_start_not_found"
+    depth = 0
+    in_string = False
+    escaped = False
+    for index in range(start, len(raw)):
+        value = raw[index]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif value == 0x5C:
+                escaped = True
+            elif value == 0x22:
+                in_string = False
+            continue
+        if value == 0x22:
+            in_string = True
+        elif value == 0x7B:
+            depth += 1
+        elif value == 0x7D:
+            depth -= 1
+            if depth == 0:
+                return raw[start : index + 1], None
+    return b"", "epoch_object_exceeds_bounded_read"
+
+
 def _extract_epoch_block(path: str, offset: int) -> Dict[str, Any]:
     try:
         with open(path, "rb") as handle:
             handle.seek(max(0, offset))
-            block = handle.read(EPOCH_BLOCK_BYTES)
+            raw = handle.read(EPOCH_BLOCK_BYTES)
     except Exception as exc:
         return {"read_error": f"{type(exc).__name__}: {exc}"}
 
-    values: Dict[str, Any] = {}
+    block, object_error = _bounded_json_object(raw)
+    if object_error:
+        return {
+            "read_error": object_error,
+            "verified_signature": False,
+            "clean_signature": False,
+        }
+
+    values: Dict[str, Any] = {"read_error": None}
     for name, pattern in _FIELD_PATTERNS.items():
         match = pattern.search(block)
         values[name] = _decode(match.group(1)) if match and match.group(1) else None
@@ -145,6 +182,7 @@ def _extract_epoch_block(path: str, offset: int) -> Dict[str, Any]:
         _bool_token(archived_match.group(1)) if archived_match else None
     )
     values["bad_execution_id_found_in_epoch_block"] = BAD_EXECUTION_ID.encode() in block
+    values["epoch_object_bytes"] = len(block)
 
     values["verified_signature"] = bool(
         values.get("id") == VERIFIED_EPOCH_ID
@@ -283,14 +321,11 @@ def _snapshot_candidates(manifest: Dict[str, Any]) -> List[str]:
             continue
         path = str(row.get("path") or "")
         created = str(row.get("created_local") or "")
+        raw_trades = row.get("trades_count")
         try:
-            trades = int(row.get("trades_count") or 0)
+            trades = int(raw_trades) if raw_trades is not None else 999999
         except Exception:
             trades = 999999
-        # Both the Aug. 10 clean cutover and Aug. 12 verified cutover created a
-        # zero-trade baseline.  Also accept tiny pre-cutover counts or a manifest
-        # timestamp explicitly from Aug. 12, but never scan arbitrary retained
-        # snapshots merely because they exist.
         likely_recovery_snapshot = bool(
             trades <= 11 or created.startswith("2026-08-12")
         )
@@ -382,9 +417,6 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
 
 
 def apply(core: Any = None) -> Dict[str, Any]:
-    # Important: data_integrity_startup_bridge calls apply() during startup.  Do
-    # not scan 25-40 MB backups at startup; scanning occurs only on explicit HTTP
-    # status request.
     return {
         "status": "ok",
         "overall": "pass",

--- a/verified_snapshot_backup_provenance_status.py
+++ b/verified_snapshot_backup_provenance_status.py
@@ -1,0 +1,428 @@
+"""Read-only backup/snapshot provenance probe for the Aug. 12 verified epoch.
+
+This module answers one narrow forensic question after Issue #82 evidence showed
+that the active state lost its accounting-epoch identity and the dedicated
+recovery marker/archive files are gone: do any currently retained state backups
+or low-trade-count snapshots still contain the exact verified-snapshot epoch
+metadata?
+
+The probe is deliberately observational:
+- it never imports/calls either one-shot recovery module;
+- it never writes, restores, deletes, renames, or relabels any file/state/ledger;
+- startup apply() is constant-time and does not scan backups;
+- the HTTP status route scans only a fixed set of known backup files plus a small
+  bounded subset of snapshot files selected from the snapshot manifest;
+- files are streamed in chunks and never fully parsed into memory.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import re
+from typing import Any, Dict, List
+
+VERSION = "verified-snapshot-backup-provenance-status-2026-08-21-v1"
+
+CLEAN_DECISION_ID = "journal-recovery-incomplete-2026-08-10"
+CLEAN_EPOCH_ID = "stable-paper-v1-20260810-clean01"
+VERIFIED_DECISION_ID = "verified-bad-tick-and-ledger-divergence-2026-08-12"
+VERIFIED_EPOCH_ID = "stable-paper-v2-20260812-verified01"
+VERIFIED_BASELINE_TYPE = "verified_snapshot_with_open_position"
+VERIFIED_RECOVERY_DECISION = "verified_snapshot_rollforward"
+BAD_EXECUTION_ID = "5ca38922916e4612ae3cda8d9801107d"
+
+STATE_DIR = (
+    os.environ.get("STATE_DIR")
+    or os.environ.get("PERSISTENT_STATE_DIR")
+    or os.environ.get("RAILWAY_VOLUME_MOUNT_PATH")
+    or "."
+)
+STATE_FILE = os.path.join(STATE_DIR, "state.json")
+BACKUP_FILES = (
+    os.path.join(STATE_DIR, "state.json.bak"),
+    os.path.join(STATE_DIR, "state_backup_latest.json"),
+    os.path.join(STATE_DIR, "state_backup_prewrite.json"),
+    os.path.join(STATE_DIR, "state_backup_largest.json"),
+)
+SNAPSHOT_DIR = os.path.join(STATE_DIR, "state_snapshots")
+SNAPSHOT_MANIFEST = os.path.join(SNAPSHOT_DIR, "manifest.json")
+
+CHUNK_BYTES = 1024 * 1024
+OVERLAP_BYTES = 256 * 1024
+MAX_FILE_BYTES = 64 * 1024 * 1024
+MAX_TOTAL_BYTES = 256 * 1024 * 1024
+EPOCH_BLOCK_BYTES = 256 * 1024
+MAX_SNAPSHOT_ROWS = 16
+MAX_SNAPSHOT_FILES_SCANNED = 3
+MAX_METADATA_BYTES = 2 * 1024 * 1024
+
+_REGISTERED_APP_IDS: set[int] = set()
+
+_FIELD_PATTERNS = {
+    "id": re.compile(rb'"id"\s*:\s*"([^"]+)"'),
+    "decision_id": re.compile(rb'"decision_id"\s*:\s*"([^"]+)"'),
+    "baseline_type": re.compile(rb'"baseline_type"\s*:\s*"([^"]+)"'),
+    "historical_recovery_decision": re.compile(
+        rb'"historical_recovery_decision"\s*:\s*"([^"]+)"'
+    ),
+    "prior_epoch_id": re.compile(rb'"prior_epoch_id"\s*:\s*"([^"]+)"'),
+    "forensic_archive_dir": re.compile(
+        rb'"forensic_archive_dir"\s*:\s*(?:"([^"]*)"|null)'
+    ),
+}
+_ACCOUNTING_EPOCH_ID_PATTERN = re.compile(
+    rb'"accounting_epoch_id"\s*:\s*(?:"([^"]+)"|null)'
+)
+_ARCHIVED_PATTERN = re.compile(
+    rb'"historical_evidence_archived"\s*:\s*(true|false|null)'
+)
+
+
+def _now(core: Any = None) -> str:
+    try:
+        return str(core.local_ts_text())
+    except Exception:
+        return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _decode(value: bytes | None) -> str | None:
+    if not value:
+        return None
+    try:
+        return value.decode("utf-8", errors="replace")
+    except Exception:
+        return None
+
+
+def _bool_token(value: bytes | None) -> bool | None:
+    if value == b"true":
+        return True
+    if value == b"false":
+        return False
+    return None
+
+
+def _mtime_local(path: str) -> str | None:
+    try:
+        return dt.datetime.fromtimestamp(os.path.getmtime(path)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+    except Exception:
+        return None
+
+
+def _load_small_json(path: str) -> tuple[Dict[str, Any], str | None]:
+    try:
+        if not os.path.isfile(path):
+            return {}, None
+        size = int(os.path.getsize(path))
+        if size > MAX_METADATA_BYTES:
+            return {}, "metadata_file_too_large"
+        with open(path, "r", encoding="utf-8") as handle:
+            value = json.load(handle)
+        if not isinstance(value, dict):
+            return {}, "metadata_not_object"
+        return value, None
+    except Exception as exc:
+        return {}, f"{type(exc).__name__}: {exc}"
+
+
+def _extract_epoch_block(path: str, offset: int) -> Dict[str, Any]:
+    try:
+        with open(path, "rb") as handle:
+            handle.seek(max(0, offset))
+            block = handle.read(EPOCH_BLOCK_BYTES)
+    except Exception as exc:
+        return {"read_error": f"{type(exc).__name__}: {exc}"}
+
+    values: Dict[str, Any] = {}
+    for name, pattern in _FIELD_PATTERNS.items():
+        match = pattern.search(block)
+        values[name] = _decode(match.group(1)) if match and match.group(1) else None
+    archived_match = _ARCHIVED_PATTERN.search(block)
+    values["historical_evidence_archived"] = (
+        _bool_token(archived_match.group(1)) if archived_match else None
+    )
+    values["bad_execution_id_found_in_epoch_block"] = BAD_EXECUTION_ID.encode() in block
+
+    values["verified_signature"] = bool(
+        values.get("id") == VERIFIED_EPOCH_ID
+        and values.get("decision_id") == VERIFIED_DECISION_ID
+        and values.get("baseline_type") == VERIFIED_BASELINE_TYPE
+        and values.get("historical_recovery_decision") == VERIFIED_RECOVERY_DECISION
+        and values.get("historical_evidence_archived") is True
+        and values.get("prior_epoch_id") == CLEAN_EPOCH_ID
+    )
+    values["clean_signature"] = bool(
+        values.get("id") == CLEAN_EPOCH_ID
+        and values.get("decision_id") == CLEAN_DECISION_ID
+    )
+    return values
+
+
+def _scan_state_file(path: str, remaining_budget: int) -> Dict[str, Any]:
+    exists = os.path.isfile(path)
+    size = int(os.path.getsize(path)) if exists else 0
+    result: Dict[str, Any] = {
+        "path": path,
+        "exists": exists,
+        "size_bytes": size,
+        "modified_local": _mtime_local(path) if exists else None,
+        "bytes_scanned": 0,
+        "scan_truncated": False,
+        "paper_accounting_epoch_key_found": False,
+        "accounting_epoch_ids_found": [],
+        "verified_epoch_token_found": False,
+        "verified_decision_token_found": False,
+        "verified_baseline_token_found": False,
+        "bad_execution_id_token_found": False,
+        "verified_signature": False,
+        "clean_signature": False,
+        "epoch_block": None,
+        "read_error": None,
+    }
+    if not exists or size <= 0 or remaining_budget <= 0:
+        return result
+
+    file_budget = min(size, MAX_FILE_BYTES, remaining_budget)
+    overlap = b""
+    absolute = 0
+    epoch_offset: int | None = None
+    accounting_ids: List[str] = []
+    verified_token = VERIFIED_EPOCH_ID.encode()
+    decision_token = VERIFIED_DECISION_ID.encode()
+    baseline_token = VERIFIED_BASELINE_TYPE.encode()
+    bad_execution_token = BAD_EXECUTION_ID.encode()
+    epoch_key = b'"paper_accounting_epoch"'
+
+    try:
+        with open(path, "rb") as handle:
+            while absolute < file_budget:
+                to_read = min(CHUNK_BYTES, file_budget - absolute)
+                chunk = handle.read(to_read)
+                if not chunk:
+                    break
+                data = overlap + chunk
+                data_start = absolute - len(overlap)
+
+                if epoch_offset is None:
+                    idx = data.find(epoch_key)
+                    if idx >= 0:
+                        epoch_offset = max(0, data_start + idx)
+                        result["paper_accounting_epoch_key_found"] = True
+
+                if verified_token in data:
+                    result["verified_epoch_token_found"] = True
+                if decision_token in data:
+                    result["verified_decision_token_found"] = True
+                if baseline_token in data:
+                    result["verified_baseline_token_found"] = True
+                if bad_execution_token in data:
+                    result["bad_execution_id_token_found"] = True
+
+                for match in _ACCOUNTING_EPOCH_ID_PATTERN.finditer(data):
+                    value = _decode(match.group(1)) if match.group(1) else None
+                    if value and value not in accounting_ids:
+                        accounting_ids.append(value)
+                        if len(accounting_ids) >= 8:
+                            break
+
+                absolute += len(chunk)
+                overlap = data[-OVERLAP_BYTES:]
+
+        result["bytes_scanned"] = absolute
+        result["scan_truncated"] = absolute < size
+        result["accounting_epoch_ids_found"] = accounting_ids
+        if epoch_offset is not None:
+            block = _extract_epoch_block(path, epoch_offset)
+            result["epoch_block"] = block
+            result["verified_signature"] = bool(block.get("verified_signature"))
+            result["clean_signature"] = bool(block.get("clean_signature"))
+    except Exception as exc:
+        result["read_error"] = f"{type(exc).__name__}: {exc}"
+
+    return result
+
+
+def _snapshot_manifest_summary() -> Dict[str, Any]:
+    payload, error = _load_small_json(SNAPSHOT_MANIFEST)
+    rows = payload.get("snapshots") if isinstance(payload.get("snapshots"), list) else []
+    cleaned: List[Dict[str, Any]] = []
+    for row in rows[:MAX_SNAPSHOT_ROWS]:
+        if not isinstance(row, dict):
+            continue
+        cleaned.append(
+            {
+                "path": row.get("path"),
+                "filename": row.get("filename"),
+                "created_local": row.get("created_local"),
+                "created_ts": row.get("created_ts"),
+                "trades_count": row.get("trades_count"),
+                "positions_count": row.get("positions_count"),
+                "runner_timestamp_rank": row.get("runner_timestamp_rank"),
+                "size_bytes": row.get("size_bytes"),
+                "reason": row.get("reason"),
+            }
+        )
+    return {
+        "manifest_path": SNAPSHOT_MANIFEST,
+        "manifest_exists": os.path.isfile(SNAPSHOT_MANIFEST),
+        "read_error": error,
+        "retained_rows_reported": len(rows),
+        "rows_returned": cleaned,
+    }
+
+
+def _snapshot_candidates(manifest: Dict[str, Any]) -> List[str]:
+    rows = manifest.get("rows_returned")
+    rows = rows if isinstance(rows, list) else []
+    candidates: List[str] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        path = str(row.get("path") or "")
+        created = str(row.get("created_local") or "")
+        try:
+            trades = int(row.get("trades_count") or 0)
+        except Exception:
+            trades = 999999
+        # Both the Aug. 10 clean cutover and Aug. 12 verified cutover created a
+        # zero-trade baseline.  Also accept tiny pre-cutover counts or a manifest
+        # timestamp explicitly from Aug. 12, but never scan arbitrary retained
+        # snapshots merely because they exist.
+        likely_recovery_snapshot = bool(
+            trades <= 11 or created.startswith("2026-08-12")
+        )
+        if likely_recovery_snapshot and path and path not in candidates:
+            candidates.append(path)
+        if len(candidates) >= MAX_SNAPSHOT_FILES_SCANNED:
+            break
+    return candidates
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    total_scanned = 0
+    backup_rows: List[Dict[str, Any]] = []
+    for path in BACKUP_FILES:
+        row = _scan_state_file(path, MAX_TOTAL_BYTES - total_scanned)
+        total_scanned += int(row.get("bytes_scanned") or 0)
+        backup_rows.append(row)
+
+    manifest = _snapshot_manifest_summary()
+    snapshot_rows: List[Dict[str, Any]] = []
+    for path in _snapshot_candidates(manifest):
+        if total_scanned >= MAX_TOTAL_BYTES:
+            break
+        row = _scan_state_file(path, MAX_TOTAL_BYTES - total_scanned)
+        total_scanned += int(row.get("bytes_scanned") or 0)
+        snapshot_rows.append(row)
+
+    all_rows = backup_rows + snapshot_rows
+    verified_rows = [row for row in all_rows if bool(row.get("verified_signature"))]
+    clean_rows = [row for row in all_rows if bool(row.get("clean_signature"))]
+    token_only_rows = [
+        row
+        for row in all_rows
+        if not bool(row.get("verified_signature"))
+        and bool(row.get("verified_epoch_token_found"))
+    ]
+
+    if verified_rows:
+        diagnosis = "verified_snapshot_backup_provenance_found"
+        overall = "pass"
+    elif token_only_rows:
+        diagnosis = "verified_epoch_token_found_without_verified_epoch_block_signature"
+        overall = "warn"
+    elif clean_rows:
+        diagnosis = "clean_epoch_backup_provenance_found_verified_snapshot_missing"
+        overall = "warn"
+    else:
+        diagnosis = "verified_snapshot_not_found_in_retained_backup_or_targeted_snapshot_set"
+        overall = "warn"
+
+    return {
+        "status": "ok",
+        "overall": overall,
+        "type": "verified_snapshot_backup_provenance_status",
+        "version": VERSION,
+        "generated_local": _now(core),
+        "diagnosis": diagnosis,
+        "verified_snapshot_backup_evidence_found": bool(verified_rows),
+        "verified_signature_paths": [row.get("path") for row in verified_rows],
+        "clean_signature_paths": [row.get("path") for row in clean_rows],
+        "verified_token_only_paths": [row.get("path") for row in token_only_rows],
+        "backup_files": backup_rows,
+        "snapshot_manifest": manifest,
+        "targeted_snapshot_files": snapshot_rows,
+        "performance_contract": {
+            "streaming_reads_only": True,
+            "loads_whole_state_files_into_memory": False,
+            "max_file_bytes": MAX_FILE_BYTES,
+            "max_total_bytes": MAX_TOTAL_BYTES,
+            "bytes_scanned": total_scanned,
+            "max_snapshot_files_scanned": MAX_SNAPSHOT_FILES_SCANNED,
+            "startup_scans_backups": False,
+        },
+        "authority": {
+            "reporting_only": True,
+            "places_orders": False,
+            "writes_files": False,
+            "restores_backups": False,
+            "deletes_or_prunes_snapshots": False,
+            "repairs_historical_state": False,
+            "rewrites_or_relabels_canonical_ledger": False,
+            "clears_hard_halt": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    # Important: data_integrity_startup_bridge calls apply() during startup.  Do
+    # not scan 25-40 MB backups at startup; scanning occurs only on explicit HTTP
+    # status request.
+    return {
+        "status": "ok",
+        "overall": "pass",
+        "version": VERSION,
+        "installed": True,
+        "startup_scans_backups": False,
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    if flask_app is None:
+        return {
+            "status": "pending",
+            "overall": "warn",
+            "version": VERSION,
+            "reason": "flask_app_missing",
+        }
+    if id(flask_app) not in _REGISTERED_APP_IDS:
+        from flask import jsonify
+
+        try:
+            existing = {
+                getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()
+            }
+        except Exception:
+            existing = set()
+        route = "/paper/verified-snapshot-backup-provenance-status"
+        if route not in existing:
+            flask_app.add_url_rule(
+                route,
+                "verified_snapshot_backup_provenance_status",
+                lambda: jsonify(status_payload(core)),
+            )
+        _REGISTERED_APP_IDS.add(id(flask_app))
+    return {
+        "status": "ok",
+        "overall": "pass",
+        "version": VERSION,
+        "route_registered": True,
+        "startup_scans_backups": False,
+    }


### PR DESCRIPTION
Read-only diagnostics only. Adds a bounded status route that inspects retained backup metadata for the previously recorded accounting epoch. It performs no orders, account changes, file writes, restores, deletes, halt changes, ledger edits, strategy changes, sizing changes, threshold changes, or live/ML authority changes. Startup remains constant-time; backup reads occur only when the explicit diagnostic status route is requested. Exact-head Change Safety Audit and focused provenance regressions are required before merge.