### PR TITLE
Add read-only verified journal and ledger provenance status

### DIFF
--- a/PROJECT_HANDOFF_CURRENT.md
+++ b/PROJECT_HANDOFF_CURRENT.md
@@ -1,295 +1,255 @@
 # Project Handoff — Authoritative Current Runtime
 
-Last updated: 2026-08-21 12:15 CDT  
+Last updated: 2026-08-21 12:58 CDT  
 Repository: `sterlingfancher-cmyk/Trading-bot`  
-Current `main`: `45b83dfca905aef4b2e51f30a0fb2ec7480f53f1` (`Add read-only verified snapshot provenance probe (#101)`)  
-Active PR: #102 `agent/verified-snapshot-backup-provenance-20260821`  
+Current `main`: `78bddaf5ea6e3a6fc8b6e102f47c77a8b4955dad` (`Add read-only backup provenance status`, PR #102)  
+Active PR: #103 `agent/verified-snapshot-journal-ledger-provenance-20260821`  
 Canonical Railway paper service: `https://trading-bot-clean.up.railway.app`
 
 ## Communication / Continuity Rule
 
-Keep Trading-bot progress communication in the **currently active ChatGPT project conversation**. This is not permanently tied to one thread. When the project intentionally moves to a new conversation, refresh this handoff first and treat the new conversation as the active project chat.
+Keep Trading-bot progress communication in the **currently active ChatGPT project conversation**. It is not permanently tied to one thread. When the project intentionally moves to a new conversation, refresh this handoff first and treat the new conversation as the active project chat.
 
-Project-specific monitoring tasks that could post into stale chats remain disabled unless a future active project conversation intentionally re-establishes them. Repository handoff maintenance is mandatory so a new conversation can recover exact state without relying on prior-chat memory.
-
-When the active conversation is becoming too large for reliable continuation, warn the user **before** starting another test/update sequence, finish or stop at a clean boundary, refresh this handoff with all material evidence and the exact next action, then move conversations. Do not force a chat switch in the middle of an avoidable test sequence.
+Project-specific monitoring tasks that could post into stale chats remain disabled unless a future active project conversation intentionally re-establishes them. When the current conversation is becoming too large for reliable continuation, warn the user **before** starting another testing/update sequence, stop at a clean boundary, refresh this file with all material evidence and the exact next action, then move chats. Do not force a switch mid-test when avoidable.
 
 ## Executive Status
 
-Operational stabilization is still blocked by Issue #82. Runtime remains paper-only. Rules remain sole execution authority. Live authority is disabled. ML/AI remains shadow-only for execution.
+Issue #82 remains the operational stabilization gate. Runtime is paper-only; rules remain sole execution authority; live authority is disabled; ML/AI execution remains shadow-only.
 
-The fresh-day protection is correctly failing closed, but the authoritative paper account snapshot is corrupted and cannot seed a new risk day. Current live/on-disk state remains approximately:
-- `cash=-26064.308325`
-- `equity=-26064.31`
-- no open positions
-- `realized_total=-94929.16`
+The prospective fresh-day guard is correctly failing closed, but the authoritative paper account snapshot is corrupted and cannot seed a new risk day:
+- cash `-26064.308324919723`
+- equity `-26064.31`
+- zero open positions
+- realized total `-94929.16`
+- stale risk day start `-26064.31`
+- stale risk peak `0.01`
+- halt `daily loss limit hit (3.0%)`
+- fresh-day reset pending
 
-Risk remains stale from 2026-08-20:
-- `day_start_equity=-26064.31`
-- `day_peak_equity=0.01`
-- `halted=true`
-- `halt_reason='daily loss limit hit (3.0%)'`
-- `fresh_day_reset_pending=true`
-
-Do not clear the halt, rewrite the risk peak, force a fresh-day baseline, rewrite/relabel canonical ledger rows, restore an older backup, or overwrite the account from an incomplete reconstruction merely to make an audit pass.
+Do **not** clear the halt, rewrite the risk peak, force a baseline, restore an older state backup, rewrite/relabel canonical ledger rows, or overwrite the account from the incomplete `$10,724.779592` reconstruction just to make an audit pass.
 
 ## Current Runtime Evidence — 2026-08-21
 
-### Fresh-day guard
+### Fresh-day / self-check
 
-`/paper/fresh-day-check`:
-- `baseline_status=pending`
-- risk date remains `2026-08-20`
-- `day_start_equity=-26064.31`
-- `day_peak_equity=0.01`
-- `fresh_day_reset_pending=true`
-- `halted=true`
-
-`/paper/fresh-risk-day-baseline-guard-status`:
-- installed / overall pass
-- `current_equity_sane=false`
-- start/peak both not sane
-- `fresh_day_reset_pending=true`
-- prospective only; no halt clear/current-day rewrite/peak rewrite/history edit/order/strategy/sizing/threshold/live/ML authority change
-
-Interpretation: PR #83/#87 protection is functioning and refusing to manufacture a 2026-08-21 baseline from invalid equity.
-
-### Compact self-check
+`/paper/fresh-day-check` remains pending on the 2026-08-20 risk state. `/paper/fresh-risk-day-baseline-guard-status` is installed/pass but reports current equity, day start, and day peak as not sane; the guard is correctly refusing the reset.
 
 `/paper/self-check` at 09:51 CDT:
-- overall `warn`, status `ok`
 - account cash/equity `-26064.31`, no positions, realized total `-94929.16`
-- auto runner healthy; no active runner error
-- all 9 bounded component checks pass
+- runner healthy; no active runner error
+- all nine bounded component checks pass
 - scanner/entry ownership and runtime shadow parity pass
-- entries remain blocked by the stale risk halt
+- entries blocked by stale risk halt
 
 ### Full daily audit
 
 `/paper/daily-audit?full=1` at 09:52 CDT:
-- overall `fail` because risk is halted and accounting is unreconciled
+- overall fail because risk is halted and accounting is unreconciled
 - runner and market-data/provider accounting pass
-- persistent volume healthy; in-memory/on-disk richness matched
-- accounting reconstruction estimates `cash/equity=10724.779592`, `realized_total=724.779592`, zero positions
-- reconstruction coverage is incomplete: 193 ignored/unmatched legacy exit rows beginning 2026-08-07
-- separate ledger-economic integrity also fails
+- persistent volume healthy; in-memory/on-disk richness match
+- legacy state-trade reconstruction estimates cash/equity `10724.779592`, realized total `724.779592`, zero positions
+- reconstruction coverage is incomplete with 193 ignored/unmatched legacy exits beginning 2026-08-07
+- separate ledger economic integrity also fails
 
-Therefore `$10,724.779592` is forensic evidence only and **must not be promoted automatically into authoritative state**.
+`10724.779592` is forensic evidence only and is not an authoritative recovery value.
 
 ### Canonical execution ledger
 
 `/paper/canonical-execution-ledger-status`:
-- status/overall pass
 - append-only/hash-chain enabled
-- hook applied; authoritative for new executions
-- `chain_valid=true`, no parse/hash errors
+- authoritative hook applied for new executions
+- `chain_valid=true`
+- no parse/hash errors
 - `row_count=55`
-- `current_epoch_id=legacy-pre-stable-core`
-- `current_epoch_rows=55`
+- all 55 currently report epoch `legacy-pre-stable-core`
 - last execution id `e746b3e674654f9199402c8904df1f43`
 
-The ledger is healthy and immutable. Do not edit/relabel these rows. The active runtime no longer exposes `stable-paper-v2-20260812-verified01`.
+The ledger remains immutable. Never edit/relabel these rows to manufacture epoch continuity.
 
-### Clean accounting epoch status
+### Clean epoch / persistence / recovery
 
-`/paper/clean-accounting-epoch-status`:
-- `status=blocked`, `overall=warn`
-- `marker_status=null`
-- `forensic_archive_dir=null`
-- `historical_recovery_decision=null`
-- `historical_evidence_archived=false`
-- `clean_start=false`
-- `zero_trade_baseline=false`
-- `validation_hold=false`
+`/paper/clean-accounting-epoch-status` is blocked/warn with no active completion marker, no forensic archive dir, no historical recovery disposition, `clean_start=false`, and `zero_trade_baseline=false`. The displayed v1 epoch id is a target constant when inactive, not active-epoch proof.
 
-The endpoint's displayed `epoch_id=stable-paper-v1-20260810-clean01` is a target constant when inactive, not proof of an active clean epoch.
-
-### State recovery guard
-
-`/paper/state-recovery-status` at approximately 10:54 CDT:
+`/paper/state-recovery-status`:
 - `restored=false`
-- `pre_restore_backup_file=null`
-- current state valid, score 39, 303 trades, 0 positions, 500 history rows
-- largest backup valid, score 39, 280 trades, 19 positions, 500 history rows
-- decision `should_restore=false`
-- reason `backup_has_fewer_trades_than_current`
-- current runner timestamp is newer than largest backup
-- monotonic trade and runner-timestamp guards enabled
+- current state 303 trades / 0 positions
+- largest backup 280 trades / 19 positions
+- decision `should_restore=false`, reason `backup_has_fewer_trades_than_current`
 
-Interpretation: `state_guard` did **not** resurrect the old snapshot during this startup. Restoring `state_backup_largest.json` would roll history backward and is prohibited.
+Therefore startup recovery did not resurrect the current state on this boot and restoring `state_backup_largest.json` is prohibited.
 
-### State I/O hardening
+`/paper/state-io-status`:
+- latest event `atomic_save_state`
+- current state valid structurally with 303 trades / 0 positions
+- no current evidence of a fallback backup read
 
-`/paper/state-io-status` at 10:59 CDT:
-- installed / status ok
-- `last_status_event=atomic_save_state`
-- current state valid with 303 trades, 0 positions, 500 history rows
-- `state.json` about 25.8 MB
-- latest/prewrite backups about 25.4 MB; largest backup about 38.3 MB
-- atomic writes, retry reads, backup fallback reads, thread/file locking, and non-overlapping cycle protections enabled
-- run state inactive at snapshot, no run error, zero overlap blocks
+The corrupted snapshot now persists normally; the known pre-PR #98 X-Ray independent state I/O remains the leading proven mechanism capable of replacing a newer live state with stale persisted state.
 
-Interpretation: current State I/O does not show a backup fallback read; the latest recorded event is normal atomic persistence. This does not prove no fallback read occurred historically, but combined with `state_guard.restored=false` it proves the corrupted `state.json` existed before the current startup recovery decision.
+### PR #101 — marker/archive provenance
 
-### PR #101 verified-snapshot marker/archive provenance result
+PR #101 merged as `45b83dfca905aef4b2e51f30a0fb2ec7480f53f1` after exact-head Change Safety Audit, focused provenance tests, repo safety, architecture/config/debt checks, and Gunicorn startup smoke passed.
 
-PR #101 merged to main as `45b83dfca905aef4b2e51f30a0fb2ec7480f53f1`. Exact-head Change Safety Audit, focused provenance regression, repository validation, architecture debt/ownership/config checks, and exact Gunicorn startup smoke passed before merge.
-
-`/paper/verified-snapshot-provenance-status` at 12:06 CDT returned:
-- `active_runtime.accounting_epoch_id=null`
-- `active_runtime.paper_accounting_epoch_id=null`
-- active cash/equity remain `-26064.31`, 303 trades, 0 positions
-- `clean_epoch_marker_found=false`
-- expected clean marker path `/data/clean_epoch_journal-recovery-incomplete-2026-08-10.json` does not exist
-- `verified_snapshot_marker_found=false`
-- expected verified marker path `/data/verified_snapshot_verified-bad-tick-and-ledger-divergence-2026-08-12.json` does not exist
-- `verified_snapshot_archive_found=false`
-- `/data/forensic_archives` itself does not exist
+`/paper/verified-snapshot-provenance-status` at 12:06 CDT:
+- active accounting epoch ids null
+- clean recovery marker missing
+- verified Aug. 12 recovery marker missing
+- `/data/forensic_archives` missing
+- no matching verified manifest
 - `durable_verified_evidence_found=false`
 - diagnosis `recovery_markers_and_verified_archive_not_found`
-- endpoint confirms reporting-only/no-write/no-restore/no-ledger-rewrite authority
 
-Interpretation: the dedicated Aug. 10/Aug. 12 recovery marker and forensic archive evidence is no longer present on the current Railway volume. This removes the simplest mechanically proven recovery source. Do not infer authoritative account values from memory or the incomplete reconstruction.
+### PR #102 — retained backup/snapshot provenance
 
-## PR #102 — Read-only retained-backup provenance discriminator
+PR #102 merged as `78bddaf5ea6e3a6fc8b6e102f47c77a8b4955dad`. Its exact PR head passed Change Safety Audit, all focused provenance/core regressions, repository safety, architecture ownership/config/debt checks, and exact Gunicorn bootstrap smoke before merge. Both Railway deployment contexts later reported success.
 
-PR #102 is the next bounded discriminator. It adds `/paper/verified-snapshot-backup-provenance-status` and is **diagnostic only**.
+`/paper/verified-snapshot-backup-provenance-status` at 12:46 CDT is decisive:
+- diagnosis `verified_snapshot_not_found_in_retained_backup_or_targeted_snapshot_set`
+- `verified_snapshot_backup_evidence_found=false`
+- no verified signature path
+- no clean signature path
+- no verified token-only path
+- `state.json.bak`, `state_backup_latest.json`, `state_backup_prewrite.json`, and `state_backup_largest.json` all contain only `legacy-pre-stable-core` epoch ids and no `paper_accounting_epoch` object / verified decision / verified baseline / bad-execution token
+- largest backup is the Aug. 10 38.3 MB / 280-trade snapshot and still has no clean or verified epoch object
+- snapshot manifest retains eight periodic checkpoints, all 303-trade / zero-position snapshots from Aug. 20–21
+- no recovery-era or zero-trade snapshot remains to inspect
+- 113,860,712 bytes were streamed read-only; no whole-state load, write, restore, prune, or ledger mutation occurred
 
-It will:
-- stream the four known retained state backups: `state.json.bak`, `state_backup_latest.json`, `state_backup_prewrite.json`, `state_backup_largest.json`;
-- never load an entire large backup JSON into memory;
-- read the small `state_snapshots/manifest.json` without pruning/deleting anything;
-- scan at most three retained snapshots that look recovery-era by tiny trade count or Aug. 12 timestamp;
-- bound per-file and cumulative bytes read;
-- extract only the exact `paper_accounting_epoch` JSON object with brace/string-aware bounded parsing;
-- require the full verified signature before treating a backup as authoritative provenance: epoch `stable-paper-v2-20260812-verified01`, decision `verified-bad-tick-and-ledger-divergence-2026-08-12`, baseline type `verified_snapshot_with_open_position`, recovery disposition `verified_snapshot_rollforward`, archived-history flag true, and prior epoch `stable-paper-v1-20260810-clean01`;
-- keep startup `apply()` constant-time; large backup scans occur only when the explicit route is requested;
-- perform no orders, state writes, backup restores, snapshot deletion/pruning, halt clears, ledger rewrites/relabels, or strategy/sizing/threshold/live/ML changes.
+Conclusion: **no current Railway state backup or retained state snapshot preserves the Aug. 12 verified epoch.** Do not restore any current backup.
 
-Do not merge #102 unless its **final exact head** passes the mandatory Change Safety Audit, both provenance regressions, core Stable Paper invariants, repository safety, architecture ownership/config/debt checks, and exact Gunicorn startup smoke.
+## Durable GitHub Evidence of the Prior Verified Recovery
+
+Although current Railway recovery artifacts are gone, merged GitHub history independently proves the verified v2 recovery was not merely planned:
+
+- PR #45 merged as `9b659c88f77d5004e82ee0dda8e6d26c074621e8` on Aug. 12. Its exact-signature recovery reversed the proven LRCX `36.26` bad-tick mutation, restored the remaining `3.42486` LRCX shares at `312.90` basis, and started `stable-paper-v2-20260812-verified01` under validation hold. The recovery constants deterministically yield cash `10768.497730982748` and starting equity `11885.824057382748` at verified LRCX mark `326.24`.
+- PR #46 merged as `16c4c2371e46d23d15057f172a37756ff5245342` after a Railway bootstrap hang **following PR #45**; it fixed the recovery journal-lock deadlock without changing recovery arithmetic or authority.
+- PR #48 merged as `b5ea9d9192f7ac7cf65d8e342d11727ac3249b2b` and explicitly describes the v1→v2 verified snapshot migration as successful. It accepted only the exact successor relationship: active v2, prior v1, `verified_snapshot_rollforward`, archived historical evidence.
+- PR #52 merged as `d82f6eb327c90dede362fc0160167ac8c18c327f`; its rationale says the canonical execution ledger was already authoritative for `stable-paper-v2-20260812-verified01` and fixed compact reporting to use the persisted active successor epoch.
+
+These are durable historical facts, but they still do not by themselves prove that every one of the **current** 55 immutable canonical rows belongs downstream of that cutover. That temporal link is the purpose of PR #103.
+
+## PR #103 — Journal/Ledger Temporal Provenance
+
+PR #103 is a read-only Issue #82 discriminator. It adds `/paper/verified-snapshot-journal-ledger-provenance-status`.
+
+The verified recovery wrote top-level `accounting_epoch_id=stable-paper-v2-20260812-verified01` and `verified_snapshot_epoch_started_local` into both trade-journal files. Normal journal mirroring starts from the existing journal object and preserves unknown top-level keys, so those markers may have survived even though state markers/backups did not.
+
+The #103 route:
+- scans only root-level selected trade-journal scalar keys using bounded streaming reads so nested historical tokens cannot falsely prove provenance;
+- line-streams the current canonical JSONL and independently verifies the same previous-hash/event-hash chain semantics;
+- reports epoch histogram, first/last execution ids, first/last ledger timestamps, and whether every parseable current ledger row is at/after the verified journal cutover time;
+- never syncs/seeds the journal, writes files, restores state, edits/relabels ledger rows, clears a halt, places orders, or changes strategy/sizing/risk/live/ML authority;
+- performs no journal or ledger scans during startup; reads occur only on explicit route access.
+
+Do not merge #103 unless its final exact head passes Change Safety Audit, all three provenance regressions, mandatory Stable Paper Core invariants, repository safety, architecture ownership/config/debt checks, and exact Gunicorn bootstrap smoke.
 
 ## Issue #82 — Stabilization Exit Gate
 
-Issue #82 remains open and authoritative.
-
 Prospective protections already merged:
-- #56 source terminal-price plausibility guard
+- #56 source terminal-price plausibility
 - #79 fresh cached quote provenance/plausibility
-- #80 catastrophic persisted `last_price` fallback guard
+- #80 catastrophic persisted `last_price` valuation fallback guard
 - #81 pre-mutation duplicate full-exit guard
 - #83 fresh-day baseline sanity guard
-- #87 fresh-day guard installed before full WSGI composition
-- #98 diagnostic X-Ray independent authoritative state I/O removed
+- #87 pre-WSGI fresh-day installation order
+- #98 removal of diagnostic X-Ray authoritative state I/O
 
-Remaining acceptance:
-1. authoritative economic state recovered from mechanically proven provenance, not inference;
-2. sane fresh-day risk initialization from protected positive valuation;
-3. one normal forward paper market session after clean reset;
-4. evidence-based historical-accounting disposition without rewriting immutable execution history;
+Still required:
+1. recover authoritative economics from mechanically defensible provenance, not inference;
+2. sane positive fresh-day risk initialization;
+3. one normal forward paper market session after recovery;
+4. evidence-based historical-accounting disposition without rewriting immutable executions;
 5. clean active audit with sane valuation, healthy runner/market data, valid canonical chain, no new active economic/coverage issue, and risk reflecting real economics.
 
-Current fresh-day status remains `pending`, which is the correct fail-closed state while authoritative equity is invalid.
+Current fresh-day state remains correctly pending while authoritative equity is invalid.
 
 ## This Week's Reliability / Architecture / Governance Changes
 
-### 2026-08-18
-- #79 merged — validate fresh cached quotes before `latest_price` return; poisoned-cache regression added.
-- #80 merged — fail closed on catastrophic persisted `last_price` valuation fallback.
-- #81 merged — block duplicate full exits at canonical pre-mutation boundary; historical TEM evidence remains immutable.
+### Aug. 18
+- #79 cached-quote validation
+- #80 persisted-mark valuation fail-closed guard
+- #81 canonical pre-mutation duplicate full-exit guard
 
-### 2026-08-19
-- #83 merged — prospective fresh-risk-day baseline sanity guard.
-- Issue #84 opened — Stable Paper Core v3 consolidation.
-- #85 merged — Stage A immutable canonical shadow state models/ownership contract.
+### Aug. 19
+- #83 fresh-risk-day baseline sanity guard
+- Issue #84 opened — Stable Paper Core v3
+- #85 Stage A immutable shadow state models
 
-### 2026-08-20
-- #86 merged — compact observational `/paper/fresh-day-check`.
-- #87 merged — install fresh-day guard before full WSGI composition; exact Gunicorn smoke passed.
-- #88 merged — master system audit + architecture-debt regression gate. Audit baseline: 250 Python files / 90,409 lines; 34 runtime mutation overlaps; 5 env conflicts; 5 route overlaps; 80 duplicate-function groups; 540 broad exception-pass sites; 8 watchdog loops; 32 critical findings; fragmented ownership included `save_state` 17, `scan_signals` 14, `try_entries_and_rotations` 13, `entry_quality_check` 10, `enter_position` 9.
-- #89 merged — Stage B deterministic shadow valuation.
-- #90 merged — Stage C deterministic shadow risk lifecycle.
-- #91 merged — Stage D shadow canonical StateStore.
-- #92 merged — Stage E shadow ledger-derived bidirectional accounting.
+### Aug. 20
+- #86 compact `/paper/fresh-day-check`
+- #87 pre-WSGI guard ordering fix
+- #88 master system audit + architecture-debt freeze. Audit baseline: 250 Python files / 90,409 lines; 34 mutation overlaps; 5 env conflicts; 5 route overlaps; 80 duplicate-function groups; 540 broad exception-pass sites; 8 watchdog loops; 32 critical findings; fragmented owners included `save_state` 17, `scan_signals` 14, `try_entries_and_rotations` 13, `entry_quality_check` 10, `enter_position` 9.
+- #89 Stage B deterministic shadow valuation
+- #90 Stage C deterministic shadow risk
+- #91 Stage D shadow StateStore
+- #92 Stage E shadow ledger/accounting projection
 
-### 2026-08-21
-- #93 merged — Stage F shadow canary-readiness planner; no authoritative cutover.
-- Issue #94 created — mandatory per-change regression/impact auditing.
-- #95 merged — exact-head Change Safety Audit with mandatory core invariants, impact-aware tests, architecture/config/ownership/debt checks, and exact startup smoke.
-- Issue #96 created — self-diagnosing incident triage/recommendation engine.
-- #97 merged — shadow-only `system_sentinel` foundation; no production mutation/self-healing authority.
-- #98 merged as `c6ef7958a247ae88ba9a5c3670ed756ac0d06426` — `entry_pipeline_xray` no longer loads/saves authoritative state or reassigns `core.portfolio`; exact regression proves stale-file/live-memory split cannot replace live state. Required CI passed and Railway deployed.
-- #99 merged as `0874368ad5bf303337b8c94ed1c9ae967c2231b5` — authoritative handoff refresh through Aug. 21.
-- #100 merged as `69ec3d39a565a8c9068d0a088f441723e6883c3e` — current-chat continuity + clean-epoch provenance handoff update.
-- #101 merged as `45b83dfca905aef4b2e51f30a0fb2ec7480f53f1` — bounded marker/archive verified-snapshot provenance probe; production evidence found no surviving marker/archive root.
-- #102 open — bounded retained-backup/snapshot provenance probe; no mutation authority.
+### Aug. 21
+- #93 Stage F shadow canary-readiness only
+- Issue #94 mandatory per-change regression/impact auditing
+- #95 exact-head Change Safety Audit gate
+- Issue #96 self-diagnosing triage/recommendation engine
+- #97 shadow-only `system_sentinel`
+- #98 X-Ray stale-file/live-memory overwrite repair, merge `c6ef7958a247ae88ba9a5c3670ed756ac0d06426`
+- #99 handoff refresh, merge `0874368ad5bf303337b8c94ed1c9ae967c2231b5`
+- #100 current-chat continuity/clean-epoch handoff, merge `69ec3d39a565a8c9068d0a088f441723e6883c3e`
+- #101 marker/archive provenance probe, merge `45b83dfca905aef4b2e51f30a0fb2ec7480f53f1`
+- #102 retained-backup provenance probe, merge `78bddaf5ea6e3a6fc8b6e102f47c77a8b4955dad`; runtime result found no surviving verified backup/snapshot
+- #103 open — journal/ledger temporal provenance probe
 
 ## Stable Paper Core v3 / Issue #84
 
-Issue #84 remains open. Shadow/parity stages:
-- A #85 — immutable state models
-- B #89 — deterministic valuation
-- C #90 — deterministic risk
-- D #91 — shadow StateStore
-- E #92 — ledger/accounting projection
-- F #93 — canary readiness only
-- G — blocked until authoritative cutover/parity/prospective evidence
+Shadow/parity stages:
+- A #85 immutable state
+- B #89 valuation
+- C #90 risk
+- D #91 StateStore
+- E #92 accounting projection
+- F #93 canary readiness only
+- G blocked until #82 authoritative recovery/parity/prospective evidence
 
-Do not use shadow core to bypass Issue #82.
+Do not use shadow core to bypass #82.
 
 ## Mandatory Change Safety / Issue #94
 
-PR #95 implemented the in-repository exact-head audit. Every relevant PR must pass Change Safety Audit plus overlapping regressions and the mandatory core suite. Missing/stale/failing evidence blocks merge.
+PR #95 established the in-repository exact-head audit. Every relevant PR must pass overlapping regressions plus the mandatory core suite; stale/missing/failing evidence blocks merge. #101 added verified-marker provenance selection, #102 added retained-backup provenance, and #103 extends the focused set to journal/ledger provenance.
 
-PR #101 added focused verified-snapshot provenance regression selection. PR #102 extends that focused set to the retained-backup provenance regression while preserving all mandatory core tests.
-
-Final post-rebuild completion still includes repository-rule/branch-protection enforcement where permissions support it and acceptance/closure of Issue #94.
+Repository branch protection is not currently enabled on `main`, so final post-rebuild governance still includes repository-rule enforcement where permissions support it. The in-repo audit policy remains mandatory regardless.
 
 ## Self-Diagnosing Sentinel / Issue #96
 
-PR #97 provides the shadow diagnostic foundation across valuation, accounting, ledger, risk, startup, configuration, ownership, runner, and market-data boundaries. It may recommend bounded fixes and select affected tests, but must not rewrite state, clear halts, alter execution history, change strategy/sizing/hard-risk/live/ML authority, or auto-merge authoritative repairs.
-
-## Prior Verified Accounting Recovery — Forensic Facts Only
-
-Existing recovery code documents the previously verified Aug. 12 recovery design:
-- old epoch `stable-paper-v1-20260810-clean01`
-- target `stable-paper-v2-20260812-verified01`
-- decision `verified-bad-tick-and-ledger-divergence-2026-08-12`
-- exact LRCX bad execution id `5ca38922916e4612ae3cda8d9801107d`
-- expected marker `verified_snapshot_verified-bad-tick-and-ledger-divergence-2026-08-12.json`
-- expected forensic archive root `/data/forensic_archives`
-- recovery code wrote the recovered state to `state.json`, state I/O latest/largest/prewrite backups, and `state.json.bak`, then reset the bounded snapshot archive with the recovered zero-trade state.
-
-The current dedicated marker/archive files are absent. PR #102 therefore checks only whether any retained backup or recovery-like snapshot still contains the **exact full epoch object**. Do not call `verified_snapshot_epoch_recovery.status_payload()` as a diagnostic route: in the legacy module it delegates to `apply()`, the one-shot recovery entry point.
+#97 is advisory/shadow only across valuation, accounting, ledger, risk, startup, config/ownership, runner, and market-data boundaries. It may classify incidents and recommend bounded tests/fixes but must not rewrite state, clear halts, edit execution history, change strategy/sizing/hard-risk/live/ML authority, or auto-merge authoritative repairs.
 
 ## Historical TEM Duplicate Exit
 
 Immutable TEM evidence:
-1. long entry `29.640567 @ 54.885`, execution `d647d8a0580b44edbab0224e6c339bfd`;
-2. first full exit `29.640567 @ 53.105`, execution `7b13d9194a23407f926667b2f48d4057`;
-3. duplicate full exit `@ 52.905`, execution `3530dbf965db4894ba93b7098cec3696`.
+1. entry `29.640567 @ 54.885`, execution `d647d8a0580b44edbab0224e6c339bfd`
+2. first full exit `29.640567 @ 53.105`, execution `7b13d9194a23407f926667b2f48d4057`
+3. duplicate full exit `@ 52.905`, execution `3530dbf965db4894ba93b7098cec3696`
 
-PR #81 prospectively prevents recurrence. Never delete/rewrite/fabricate/relabel the historical row.
+#81 prospectively prevents recurrence. Never delete/rewrite/fabricate/relabel the historical row.
+
+## Known CI / Ops Debt
+
+The post-#102 `daily-operational-audit` status is red because three older test expectations are stale, not because #102 provenance behavior failed: one expects recursion to win next-action precedence over section 10b, one expects a curated test fixture to be `pass` rather than `warn`, and one looks for the obsolete literal bootstrap version token `v6-registration-heartbeat`. Keep this cleanup separate from the active accounting-provenance sequence unless it becomes a required gate.
+
+`.github/workflows/refactor-audit.yml` still contains the old `https://web-production-e1796.up.railway.app` research target. Do not use that old-domain runtime artifact as clean-service acceptance evidence.
 
 ## Canonical Runtime / Validation Links
 
 Use only the clean service:
 - bootstrap: `https://trading-bot-clean.up.railway.app/bootstrap-status`
-- compact fresh-day: `https://trading-bot-clean.up.railway.app/paper/fresh-day-check`
+- fresh-day: `https://trading-bot-clean.up.railway.app/paper/fresh-day-check`
 - fresh-day guard: `https://trading-bot-clean.up.railway.app/paper/fresh-risk-day-baseline-guard-status`
 - self-check: `https://trading-bot-clean.up.railway.app/paper/self-check`
-- full diagnostics: `https://trading-bot-clean.up.railway.app/paper/full-self-check`
-- full daily audit: `https://trading-bot-clean.up.railway.app/paper/daily-audit?full=1`
+- full audit: `https://trading-bot-clean.up.railway.app/paper/daily-audit?full=1`
 - canonical ledger: `https://trading-bot-clean.up.railway.app/paper/canonical-execution-ledger-status`
-- clean epoch: `https://trading-bot-clean.up.railway.app/paper/clean-accounting-epoch-status`
 - state recovery: `https://trading-bot-clean.up.railway.app/paper/state-recovery-status`
 - state I/O: `https://trading-bot-clean.up.railway.app/paper/state-io-status`
-- verified marker/archive provenance: `https://trading-bot-clean.up.railway.app/paper/verified-snapshot-provenance-status`
-- verified backup provenance after #102 deploy: `https://trading-bot-clean.up.railway.app/paper/verified-snapshot-backup-provenance-status`
-- quote/exit integrity: `https://trading-bot-clean.up.railway.app/paper/exit-price-integrity-status`
+- marker/archive provenance: `https://trading-bot-clean.up.railway.app/paper/verified-snapshot-provenance-status`
+- backup provenance: `https://trading-bot-clean.up.railway.app/paper/verified-snapshot-backup-provenance-status`
+- journal/ledger provenance after #103 deploy: `https://trading-bot-clean.up.railway.app/paper/verified-snapshot-journal-ledger-provenance-status`
 
-Do not manually call `/paper/run` unless a future validation plan explicitly requires it.
-
-Known ops debt: `.github/workflows/refactor-audit.yml` still contains the older `https://web-production-e1796.up.railway.app` runtime-research target. Do not treat that old-domain snapshot as clean-service acceptance evidence.
+Never manually call `/paper/run` unless a future validation plan explicitly requires it.
 
 ## Risk / Authority Boundaries — Preserve
 
@@ -303,22 +263,22 @@ Known ops debt: `.github/workflows/refactor-audit.yml` still contains the older 
 - rules sole execution authority
 - ML shadow-only for execution
 - no historical ledger fabrication/deletion/rewrite/relabel
-- no manual state repair merely to pass an audit
+- no manual account/risk repair merely to pass an audit
 
 ## Exact Next Action
 
-1. Re-fetch PR #102 exact final head after this handoff commit.
-2. Inspect the exact diff for accidental write/restore/prune/recovery authority and confirm startup does not scan large backups.
-3. Merge only if Change Safety Audit, both provenance regressions, core invariants, repository safety, architecture ownership/config/debt, and exact Gunicorn bootstrap smoke pass on that exact head.
-4. Wait for Railway to deploy and settle to `delegate_ready:true`.
-5. Run only `https://trading-bot-clean.up.railway.app/paper/verified-snapshot-backup-provenance-status`.
-6. If a backup/snapshot contains the full verified epoch signature, use that mechanically proven source to design a bounded successor recovery that preserves all 55 canonical ledger rows/hash chain and archives the current contaminated state first.
-7. If no full verified signature survives, do not guess. The next discriminator must remain read-only and target remaining durable evidence sources (for example journal/snapshot metadata) before any authoritative recovery design.
-8. After proven authoritative recovery, require sane fresh-day reset, one normal forward paper session, and a clean active audit before Issue #82 closure or Stage F/G authority.
+1. Re-fetch PR #103 final head after this handoff update.
+2. Inspect the exact diff for accidental journal sync/write, state mutation, ledger append/relabel, recovery calls, or startup file scans.
+3. Merge only if the **final exact head** passes Change Safety Audit, all provenance/core regressions, repo safety, architecture ownership/config/debt checks, and exact Gunicorn bootstrap smoke.
+4. Wait for Railway deployment success and `delegate_ready:true`.
+5. Run only `https://trading-bot-clean.up.railway.app/paper/verified-snapshot-journal-ledger-provenance-status`.
+6. If root-level verified journal identity/start survives and the valid 55-row ledger is entirely downstream in time, combine that durable runtime evidence with merged PR #45/#46/#48/#52 historical evidence to build a **read-only successor reconstruction** from the exact verified baseline plus immutable post-cutover canonical rows. Compare before any authoritative recovery PR.
+7. If journal provenance is also gone, do not guess. Pivot to historical GitHub workflow/handoff artifacts and other durable evidence sources rather than expanding blind state repair.
+8. Only after mechanically defended economic recovery: require sane fresh-day reset, one normal forward paper session, and a clean active audit before closing #82 or enabling Stage F/G authority.
 
 ## Conversation Continuity Protocol
 
-Stay in the current active project chat through a coherent testing/update sequence. The assistant cannot rely on a UI context meter, so it must use conversation size/complexity judgment and proactively warn the user before continuation becomes unsafe. When a move is needed, stop at a clean boundary, refresh this handoff, then use:
+Stay in the current active project chat through a coherent testing/update sequence. When a move is needed, stop at a clean boundary, refresh this handoff, and start the new chat with:
 
 ```text
 Use the direct @GitHub connector and continue the Trading-bot project from sterlingfancher-cmyk/Trading-bot. Read PROJECT_HANDOFF_CURRENT.md first and treat it as the authoritative continuation state. Treat this conversation as the current active project chat and keep project-status communication here. Verify current main/PR/CI and the canonical Railway clean-service read-only evidence before changing code. Continue from the Exact Next Action. Preserve paper-only authority, hard risk thresholds, canonical ledger history, rules-only execution authority, ML shadow-only execution, and the Issue #82/#84/#94/#96 gates. Do not manually repair account state or clear halts from inference.

--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -10,11 +10,11 @@ import argparse
 import json
 import subprocess
 import sys
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-VERSION = "change-safety-audit-2026-08-21-v3-provenance"
+VERSION = "change-safety-audit-2026-08-21-v4-provenance"
 
 CORE_TESTS = (
     "test_architecture_stage_b.py",
@@ -33,6 +33,7 @@ CONFIG_TESTS = ("test_architecture_stage_b.py",)
 PROVENANCE_TESTS = (
     "test_verified_snapshot_provenance_status.py",
     "test_verified_snapshot_backup_provenance_status.py",
+    "test_verified_snapshot_journal_ledger_provenance_status.py",
 )
 
 
@@ -79,7 +80,10 @@ def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ..
             categories.add("python")
         if name.startswith("test_") or "/test_" in path:
             categories.add("tests")
-        if any(token in path for token in ("bootstrap", "wsgi", "sitecustomize", "usercustomize", "app.py")):
+        if any(
+            token in path
+            for token in ("bootstrap", "wsgi", "sitecustomize", "usercustomize", "app.py")
+        ):
             categories.add("runtime_composition")
             boundaries.add("startup_runtime")
         if any(token in path for token in ("state", "persistence", "journal")):
@@ -97,7 +101,10 @@ def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ..
         if "risk" in path:
             categories.add("risk")
             boundaries.add("risk")
-        if any(token in path for token in ("signal", "scanner", "decision", "entry", "exit", "sizing")):
+        if any(
+            token in path
+            for token in ("signal", "scanner", "decision", "entry", "exit", "sizing")
+        ):
             categories.add("strategy_decision")
             boundaries.add("decision")
         if any(token in path for token in ("config", "contract", "railway", "procfile")):
@@ -122,8 +129,8 @@ def planned_regressions(paths: Iterable[str]) -> tuple[str, ...]:
         tests.extend(CONFIG_TESTS)
     if any(_is_verified_snapshot_provenance_path(path) for path in path_tuple):
         tests.extend(PROVENANCE_TESTS)
-    existing = []
-    seen = set()
+    existing: list[str] = []
+    seen: set[str] = set()
     for test in tests:
         if test not in seen and Path(test).exists():
             existing.append(test)

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-21-v29-verified-backup-provenance"
+VERSION = "data-integrity-startup-bridge-2026-08-21-v30-journal-ledger-provenance"
 MODULES = (
     "final_daily_audit_compactor",
     "daily_audit_entry_count_bridge",
@@ -32,12 +32,15 @@ MODULES = (
     "clean_accounting_epoch",
     "paper_bidirectional_accounting_guard",
     "paper_execution_timestamp_semantics",
-    # Small marker/archive forensic probe.  It deliberately runs before the
+    # Small marker/archive forensic probe. It deliberately runs before the
     # one-shot recovery module and does not import/call recovery implementations.
     "verified_snapshot_provenance_status",
-    # Backup/snapshot provenance probe.  Its apply() is constant-time and never
+    # Backup/snapshot provenance probe. Its apply() is constant-time and never
     # scans backups during startup; scanning occurs only on its explicit route.
     "verified_snapshot_backup_provenance_status",
+    # Trade-journal/canonical-ledger provenance probe. Its apply() is also
+    # constant-time; journal/ledger reads occur only on its explicit route.
+    "verified_snapshot_journal_ledger_provenance_status",
     # Patch the exact one-shot recovery's journal rotation before the recovery
     # runs. The migration already owns the journal lock, so it must not call the
     # journal mirror recursively from inside that critical section.
@@ -50,7 +53,7 @@ MODULES = (
     # the restored open LRCX lot and all future executions remain canonical.
     "verified_snapshot_accounting_baseline",
     # Issue #82 fresh-day gate: never initialize a new risk day from a
-    # non-finite/non-positive persisted valuation.  This guard is prospective and
+    # non-finite/non-positive persisted valuation. This guard is prospective and
     # never rewrites an already-initialized current day.
     "fresh_risk_day_baseline_guard",
     "absolute_daily_halt_lifecycle_guard",

--- a/test_change_safety_audit.py
+++ b/test_change_safety_audit.py
@@ -72,6 +72,7 @@ class ChangeSafetyAuditTests(unittest.TestCase):
         for path in (
             "verified_snapshot_provenance_status.py",
             "verified_snapshot_backup_provenance_status.py",
+            "verified_snapshot_journal_ledger_provenance_status.py",
         ):
             categories, boundaries = classify_paths((path,))
             tests = planned_regressions((path,))
@@ -81,6 +82,9 @@ class ChangeSafetyAuditTests(unittest.TestCase):
             self.assertIn("accounting", boundaries)
             self.assertIn("test_verified_snapshot_provenance_status.py", tests)
             self.assertIn("test_verified_snapshot_backup_provenance_status.py", tests)
+            self.assertIn(
+                "test_verified_snapshot_journal_ledger_provenance_status.py", tests
+            )
             for core_test in (
                 "test_architecture_stage_b.py",
                 "test_architecture_stage_c.py",

--- a/test_verified_snapshot_journal_ledger_provenance_status.py
+++ b/test_verified_snapshot_journal_ledger_provenance_status.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import verified_snapshot_journal_ledger_provenance_status as probe
+
+
+class DummyCore:
+    def local_ts_text(self):
+        return "2026-08-21 12:50:00 CDT"
+
+
+class VerifiedSnapshotJournalLedgerProvenanceTests(unittest.TestCase):
+    def _patch_root(self, root: str):
+        return mock.patch.multiple(
+            probe,
+            STATE_DIR=root,
+            JOURNAL_FILES=(
+                os.path.join(root, "trade_journal.json"),
+                os.path.join(root, "trade_journal_backup.json"),
+            ),
+            LEDGER_FILE=os.path.join(root, "canonical_execution_ledger.jsonl"),
+        )
+
+    @staticmethod
+    def _canonical_json(payload):
+        return json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            default=str,
+        )
+
+    def _write_ledger(self, path: Path, recorded_times, epoch="legacy-pre-stable-core"):
+        previous = ""
+        rows = []
+        for index, recorded in enumerate(recorded_times, start=1):
+            body = {
+                "execution_id": f"exec-{index}",
+                "ledger_version": "canonical-execution-ledger-2026-08-10-v1",
+                "recorded_local": recorded,
+                "accounting_epoch_id": epoch,
+                "action": "entry" if index % 2 else "exit",
+                "symbol": "TEST",
+                "side": "long",
+                "price": 100.0 + index,
+                "shares": 1.0,
+            }
+            event_hash = hashlib.sha256(
+                (previous + "|" + self._canonical_json(body)).encode("utf-8")
+            ).hexdigest()
+            row = dict(body)
+            row["previous_event_hash"] = previous
+            row["event_hash"] = event_hash
+            rows.append(row)
+            previous = event_hash
+        path.write_text(
+            "".join(self._canonical_json(row) + "\n" for row in rows),
+            encoding="utf-8",
+        )
+
+    def _write_verified_journal(self, path: Path):
+        payload = {
+            "accounting_epoch_id": probe.VERIFIED_EPOCH_ID,
+            "created_local": "2026-08-10 13:00:00",
+            "snapshots": [
+                {
+                    "accounting_epoch_id": "nested-misleading-value",
+                    "verified_snapshot_epoch_started_local": "1999-01-01 00:00:00",
+                }
+            ],
+            "trades": [],
+            "updated_local": "2026-08-21 12:00:00",
+            "verified_snapshot_epoch_started_local": "2026-08-12 16:00:00 CDT",
+            "version": "trade-journal-2026-08-10-v1",
+        }
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+    def test_verified_journal_plus_post_cutover_valid_ledger_is_proven(self):
+        with tempfile.TemporaryDirectory() as root, self._patch_root(root):
+            self._write_verified_journal(Path(root) / "trade_journal.json")
+            self._write_ledger(
+                Path(root) / "canonical_execution_ledger.jsonl",
+                ["2026-08-12 16:05:00 CDT", "2026-08-13 09:30:00 CDT"],
+            )
+            payload = probe.status_payload(DummyCore())
+
+            self.assertEqual(payload["overall"], "pass")
+            self.assertEqual(
+                payload["diagnosis"],
+                "verified_journal_cutover_with_post_cutover_ledger_provenance_found",
+            )
+            self.assertTrue(payload["verified_journal_epoch_found"])
+            self.assertTrue(payload["canonical_ledger"]["chain_valid"])
+            self.assertEqual(payload["canonical_ledger"]["row_count"], 2)
+            self.assertEqual(
+                payload["canonical_ledger"]["epoch_counts"],
+                {"legacy-pre-stable-core": 2},
+            )
+            self.assertTrue(
+                payload["chronology"]["all_ledger_rows_at_or_after_verified_start"]
+            )
+            self.assertFalse(payload["authority"]["writes_files"])
+            self.assertFalse(
+                payload["authority"]["rewrites_or_relabels_canonical_ledger"]
+            )
+
+    def test_nested_verified_tokens_do_not_count_as_top_level_epoch(self):
+        with tempfile.TemporaryDirectory() as root, self._patch_root(root):
+            journal = {
+                "accounting_epoch_id": "legacy-pre-stable-core",
+                "snapshots": [
+                    {
+                        "accounting_epoch_id": probe.VERIFIED_EPOCH_ID,
+                        "verified_snapshot_epoch_started_local": "2026-08-12 16:00:00 CDT",
+                    }
+                ],
+                "trades": [],
+            }
+            (Path(root) / "trade_journal.json").write_text(
+                json.dumps(journal), encoding="utf-8"
+            )
+            self._write_ledger(
+                Path(root) / "canonical_execution_ledger.jsonl",
+                ["2026-08-13 09:30:00 CDT"],
+            )
+            payload = probe.status_payload(DummyCore())
+
+            self.assertFalse(payload["verified_journal_epoch_found"])
+            self.assertEqual(
+                payload["diagnosis"], "verified_journal_provenance_not_found"
+            )
+            top = payload["journal_files"][0]["top_level"]
+            self.assertEqual(top.get("accounting_epoch_id"), "legacy-pre-stable-core")
+            self.assertNotIn("verified_snapshot_epoch_started_local", top)
+
+    def test_pre_cutover_ledger_row_prevents_chronology_claim(self):
+        with tempfile.TemporaryDirectory() as root, self._patch_root(root):
+            self._write_verified_journal(Path(root) / "trade_journal.json")
+            self._write_ledger(
+                Path(root) / "canonical_execution_ledger.jsonl",
+                ["2026-08-12 15:59:59 CDT", "2026-08-12 16:05:00 CDT"],
+            )
+            payload = probe.status_payload(DummyCore())
+
+            self.assertEqual(payload["overall"], "warn")
+            self.assertEqual(
+                payload["diagnosis"],
+                "verified_journal_epoch_found_but_ledger_chronology_not_proven",
+            )
+            self.assertFalse(
+                payload["chronology"]["all_ledger_rows_at_or_after_verified_start"]
+            )
+
+    def test_hash_tamper_fails_closed(self):
+        with tempfile.TemporaryDirectory() as root, self._patch_root(root):
+            self._write_verified_journal(Path(root) / "trade_journal.json")
+            ledger = Path(root) / "canonical_execution_ledger.jsonl"
+            self._write_ledger(ledger, ["2026-08-12 16:05:00 CDT"])
+            row = json.loads(ledger.read_text(encoding="utf-8"))
+            row["price"] = 999.0
+            ledger.write_text(self._canonical_json(row) + "\n", encoding="utf-8")
+
+            payload = probe.status_payload(DummyCore())
+            self.assertEqual(payload["overall"], "fail")
+            self.assertFalse(payload["canonical_ledger"]["chain_valid"])
+            self.assertEqual(
+                payload["diagnosis"],
+                "verified_journal_epoch_found_but_canonical_ledger_not_valid",
+            )
+
+    def test_status_is_read_only_and_startup_apply_does_not_scan(self):
+        with tempfile.TemporaryDirectory() as root, self._patch_root(root):
+            journal = Path(root) / "trade_journal.json"
+            ledger = Path(root) / "canonical_execution_ledger.jsonl"
+            self._write_verified_journal(journal)
+            self._write_ledger(ledger, ["2026-08-12 16:05:00 CDT"])
+            before = {
+                str(path.relative_to(root)): (path.stat().st_size, path.stat().st_mtime_ns)
+                for path in Path(root).rglob("*")
+                if path.is_file()
+            }
+            probe.status_payload(DummyCore())
+            after = {
+                str(path.relative_to(root)): (path.stat().st_size, path.stat().st_mtime_ns)
+                for path in Path(root).rglob("*")
+                if path.is_file()
+            }
+            self.assertEqual(before, after)
+
+            with mock.patch.object(
+                probe,
+                "_stream_top_level_strings",
+                side_effect=AssertionError("startup scanned journal"),
+            ), mock.patch.object(
+                probe,
+                "_ledger_summary",
+                side_effect=AssertionError("startup scanned ledger"),
+            ):
+                applied = probe.apply(DummyCore())
+            self.assertEqual(applied["status"], "ok")
+            self.assertFalse(applied["startup_scans_files"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verified_snapshot_journal_ledger_provenance_status.py
+++ b/verified_snapshot_journal_ledger_provenance_status.py
@@ -1,0 +1,507 @@
+"""Read-only journal/ledger provenance probe for the Aug. 12 verified epoch.
+
+Issue #82 evidence shows the active paper state, dedicated recovery markers,
+forensic archives, retained state backups, and retained state snapshots no longer
+carry the verified-snapshot epoch.  This probe asks the next narrower question:
+did the independently persisted trade journal retain the verified epoch marker,
+and if so, is the current append-only canonical ledger chronologically downstream
+of that cutover?
+
+The probe is observational only.  Startup ``apply()`` is constant-time.  File
+reads occur only when the explicit status endpoint is requested.  It never calls
+journal sync/seed, recovery routines, state writers, or ledger append functions.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import os
+from typing import Any, Dict, Iterable, List, Tuple
+
+VERSION = "verified-snapshot-journal-ledger-provenance-2026-08-21-v1"
+VERIFIED_EPOCH_ID = "stable-paper-v2-20260812-verified01"
+CLEAN_EPOCH_ID = "stable-paper-v1-20260810-clean01"
+
+STATE_DIR = (
+    os.environ.get("STATE_DIR")
+    or os.environ.get("PERSISTENT_STATE_DIR")
+    or os.environ.get("RAILWAY_VOLUME_MOUNT_PATH")
+    or "."
+)
+JOURNAL_FILES = (
+    os.path.join(STATE_DIR, "trade_journal.json"),
+    os.path.join(STATE_DIR, "trade_journal_backup.json"),
+)
+LEDGER_FILE = os.path.join(STATE_DIR, "canonical_execution_ledger.jsonl")
+
+JOURNAL_KEYS = {
+    "accounting_epoch_id",
+    "verified_snapshot_epoch_started_local",
+    "clean_epoch_started_local",
+    "created_local",
+    "updated_local",
+    "version",
+}
+MAX_JOURNAL_BYTES_PER_FILE = 128 * 1024 * 1024
+MAX_LEDGER_BYTES = 32 * 1024 * 1024
+MAX_LEDGER_LINE_BYTES = 2 * 1024 * 1024
+CHUNK_BYTES = 1024 * 1024
+
+_REGISTERED_APP_IDS: set[int] = set()
+
+
+def _now(core: Any = None) -> str:
+    try:
+        return str(core.local_ts_text())
+    except Exception:
+        return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _mtime_local(path: str) -> str | None:
+    try:
+        return dt.datetime.fromtimestamp(os.path.getmtime(path)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+    except Exception:
+        return None
+
+
+def _decode_json_string(raw: bytearray) -> str | None:
+    try:
+        # Reuse the JSON decoder so escaped quotes/backslashes are interpreted
+        # exactly as JSON rather than with a hand-written unescape table.
+        return json.loads(b'"' + bytes(raw) + b'"'.decode("utf-8"))
+    except Exception:
+        try:
+            return bytes(raw).decode("utf-8", errors="replace")
+        except Exception:
+            return None
+
+
+def _stream_top_level_strings(path: str) -> Dict[str, Any]:
+    """Extract selected string/null scalar keys from the root JSON object only."""
+    exists = os.path.isfile(path)
+    size = int(os.path.getsize(path)) if exists else 0
+    out: Dict[str, Any] = {
+        "path": path,
+        "exists": exists,
+        "size_bytes": size,
+        "modified_local": _mtime_local(path) if exists else None,
+        "bytes_scanned": 0,
+        "scan_truncated": False,
+        "read_error": None,
+        "top_level": {},
+    }
+    if not exists or size <= 0:
+        return out
+
+    budget = min(size, MAX_JOURNAL_BYTES_PER_FILE)
+    nesting = 0
+    in_string = False
+    escaped = False
+    string_role: str | None = None
+    string_buf = bytearray()
+    current_key: str | None = None
+    expecting_key = False
+    expecting_value = False
+    primitive_buf = bytearray()
+    primitive_active = False
+    scanned = 0
+
+    def finish_primitive() -> None:
+        nonlocal primitive_active, primitive_buf, current_key, expecting_value
+        if not primitive_active:
+            return
+        token = bytes(primitive_buf).strip().decode("utf-8", errors="replace")
+        if current_key in JOURNAL_KEYS:
+            if token == "null":
+                out["top_level"][current_key] = None
+            elif token in {"true", "false"}:
+                out["top_level"][current_key] = token == "true"
+            else:
+                out["top_level"][current_key] = token
+        primitive_active = False
+        primitive_buf = bytearray()
+        current_key = None
+        expecting_value = False
+
+    try:
+        with open(path, "rb") as handle:
+            while scanned < budget:
+                chunk = handle.read(min(CHUNK_BYTES, budget - scanned))
+                if not chunk:
+                    break
+                scanned += len(chunk)
+                for value in chunk:
+                    if in_string:
+                        if escaped:
+                            string_buf.append(value)
+                            escaped = False
+                            continue
+                        if value == 0x5C:  # backslash
+                            string_buf.append(value)
+                            escaped = True
+                            continue
+                        if value == 0x22:  # quote
+                            text = _decode_json_string(string_buf)
+                            in_string = False
+                            string_buf = bytearray()
+                            if string_role == "key":
+                                current_key = text
+                                expecting_key = False
+                            elif string_role == "value":
+                                if current_key in JOURNAL_KEYS:
+                                    out["top_level"][current_key] = text
+                                current_key = None
+                                expecting_value = False
+                            string_role = None
+                            continue
+                        string_buf.append(value)
+                        continue
+
+                    if primitive_active:
+                        if nesting == 1 and value in (0x2C, 0x7D):  # comma or }
+                            finish_primitive()
+                            if value == 0x2C:
+                                expecting_key = True
+                            else:
+                                nesting -= 1
+                            continue
+                        primitive_buf.append(value)
+                        continue
+
+                    if value == 0x22:  # quote
+                        if nesting == 1 and expecting_key:
+                            in_string = True
+                            string_role = "key"
+                            string_buf = bytearray()
+                        elif nesting == 1 and expecting_value:
+                            in_string = True
+                            string_role = "value"
+                            string_buf = bytearray()
+                        else:
+                            # A nested string is irrelevant; still consume it so
+                            # braces/commas inside the string do not affect depth.
+                            in_string = True
+                            string_role = "ignore"
+                            string_buf = bytearray()
+                        continue
+
+                    if value in (0x7B, 0x5B):  # { or [
+                        nesting += 1
+                        if nesting == 1:
+                            expecting_key = True
+                        continue
+                    if value in (0x7D, 0x5D):  # } or ]
+                        if nesting == 1 and expecting_value:
+                            finish_primitive()
+                        nesting = max(0, nesting - 1)
+                        if nesting == 0:
+                            break
+                        continue
+                    if nesting != 1:
+                        continue
+                    if value == 0x3A and current_key is not None:  # colon
+                        expecting_value = True
+                        continue
+                    if value == 0x2C:  # comma
+                        current_key = None
+                        expecting_value = False
+                        expecting_key = True
+                        continue
+                    if expecting_value and value not in (0x20, 0x09, 0x0A, 0x0D):
+                        # Root scalar that is not a JSON string.
+                        primitive_active = True
+                        primitive_buf = bytearray([value])
+
+                if nesting == 0 and scanned > 0:
+                    break
+        if primitive_active:
+            finish_primitive()
+    except Exception as exc:
+        out["read_error"] = f"{type(exc).__name__}: {exc}"
+
+    out["bytes_scanned"] = scanned
+    out["scan_truncated"] = scanned < size and nesting != 0
+    epoch = out["top_level"].get("accounting_epoch_id")
+    out["verified_epoch_top_level"] = epoch == VERIFIED_EPOCH_ID
+    out["clean_epoch_top_level"] = epoch == CLEAN_EPOCH_ID
+    out["verified_start_local"] = out["top_level"].get(
+        "verified_snapshot_epoch_started_local"
+    )
+    return out
+
+
+def _canonical_json(payload: Dict[str, Any]) -> str:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    )
+
+
+def _parse_local_timestamp(value: Any) -> dt.datetime | None:
+    text = str(value or "").strip()
+    if len(text) < 19:
+        return None
+    try:
+        return dt.datetime.strptime(text[:19], "%Y-%m-%d %H:%M:%S")
+    except Exception:
+        return None
+
+
+def _ledger_summary(path: str) -> Dict[str, Any]:
+    exists = os.path.isfile(path)
+    size = int(os.path.getsize(path)) if exists else 0
+    result: Dict[str, Any] = {
+        "path": path,
+        "exists": exists,
+        "size_bytes": size,
+        "modified_local": _mtime_local(path) if exists else None,
+        "bytes_scanned": 0,
+        "scan_truncated": False,
+        "row_count": 0,
+        "parse_error_count": 0,
+        "chain_error_count": 0,
+        "chain_valid": True,
+        "errors": [],
+        "epoch_counts": {},
+        "first_execution_id": None,
+        "last_execution_id": None,
+        "first_recorded_local": None,
+        "last_recorded_local": None,
+        "recorded_local_parseable_count": 0,
+        "recorded_local_unparseable_count": 0,
+        "recorded_local_values": [],
+    }
+    if not exists or size <= 0:
+        return result
+
+    prev_hash = ""
+    total = 0
+    rows = 0
+    errors: List[str] = []
+    epoch_counts: Dict[str, int] = {}
+    timestamps: List[str] = []
+    try:
+        with open(path, "rb") as handle:
+            for line_no, raw in enumerate(handle, start=1):
+                if total >= MAX_LEDGER_BYTES:
+                    result["scan_truncated"] = True
+                    break
+                total += len(raw)
+                if total > MAX_LEDGER_BYTES:
+                    result["scan_truncated"] = True
+                    break
+                if len(raw) > MAX_LEDGER_LINE_BYTES:
+                    errors.append(f"line_{line_no}:line_too_large")
+                    continue
+                text = raw.strip()
+                if not text:
+                    continue
+                try:
+                    row = json.loads(text.decode("utf-8"))
+                except Exception as exc:
+                    errors.append(f"line_{line_no}:{type(exc).__name__}")
+                    continue
+                if not isinstance(row, dict):
+                    errors.append(f"line_{line_no}:non_dict")
+                    continue
+
+                rows += 1
+                expected_prev = str(row.get("previous_event_hash") or "")
+                if expected_prev != prev_hash:
+                    errors.append(f"line_{line_no}:previous_hash_mismatch")
+                body = dict(row)
+                stored_hash = str(body.pop("event_hash", "") or "")
+                body.pop("previous_event_hash", None)
+                expected_hash = hashlib.sha256(
+                    (prev_hash + "|" + _canonical_json(body)).encode("utf-8")
+                ).hexdigest()
+                if not stored_hash or stored_hash != expected_hash:
+                    errors.append(f"line_{line_no}:event_hash_mismatch")
+                prev_hash = stored_hash
+
+                epoch = str(row.get("accounting_epoch_id") or "missing")
+                epoch_counts[epoch] = epoch_counts.get(epoch, 0) + 1
+                execution_id = row.get("execution_id")
+                recorded = row.get("recorded_local")
+                if result["first_execution_id"] is None:
+                    result["first_execution_id"] = execution_id
+                    result["first_recorded_local"] = recorded
+                result["last_execution_id"] = execution_id
+                result["last_recorded_local"] = recorded
+                if recorded is not None and len(timestamps) < 256:
+                    timestamps.append(str(recorded))
+    except Exception as exc:
+        errors.append(f"read:{type(exc).__name__}:{exc}")
+
+    parse_errors = [e for e in errors if "hash_mismatch" not in e]
+    chain_errors = [e for e in errors if "hash_mismatch" in e]
+    parseable = sum(1 for value in timestamps if _parse_local_timestamp(value) is not None)
+    result.update(
+        {
+            "bytes_scanned": min(total, MAX_LEDGER_BYTES),
+            "row_count": rows,
+            "parse_error_count": len(parse_errors),
+            "chain_error_count": len(chain_errors),
+            "chain_valid": not errors and not result["scan_truncated"],
+            "errors": errors[:8],
+            "epoch_counts": dict(sorted(epoch_counts.items())),
+            "recorded_local_parseable_count": parseable,
+            "recorded_local_unparseable_count": len(timestamps) - parseable,
+            "recorded_local_values": timestamps,
+        }
+    )
+    return result
+
+
+def _chronology(ledger: Dict[str, Any], verified_start: Any) -> Dict[str, Any]:
+    start_dt = _parse_local_timestamp(verified_start)
+    values = ledger.get("recorded_local_values")
+    values = values if isinstance(values, list) else []
+    parsed = [_parse_local_timestamp(v) for v in values]
+    parseable = [value for value in parsed if value is not None]
+    all_parseable = bool(values) and len(parseable) == len(values)
+    all_after = bool(start_dt is not None and all_parseable) and all(
+        value >= start_dt for value in parseable
+    )
+    return {
+        "verified_start_local": verified_start,
+        "verified_start_parseable": start_dt is not None,
+        "ledger_timestamp_count": len(values),
+        "ledger_all_timestamps_parseable": all_parseable,
+        "all_ledger_rows_at_or_after_verified_start": all_after,
+        "earliest_ledger_recorded_local": (
+            min(parseable).strftime("%Y-%m-%d %H:%M:%S") if parseable else None
+        ),
+        "latest_ledger_recorded_local": (
+            max(parseable).strftime("%Y-%m-%d %H:%M:%S") if parseable else None
+        ),
+    }
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    journals = [_stream_top_level_strings(path) for path in JOURNAL_FILES]
+    verified_journals = [row for row in journals if row.get("verified_epoch_top_level")]
+    verified_starts = [
+        row.get("verified_start_local")
+        for row in verified_journals
+        if row.get("verified_start_local")
+    ]
+    ledger = _ledger_summary(LEDGER_FILE)
+
+    verified_start = min(
+        verified_starts,
+        key=lambda value: _parse_local_timestamp(value) or dt.datetime.max,
+    ) if verified_starts else None
+    chronology = _chronology(ledger, verified_start)
+
+    if verified_journals and verified_start and ledger.get("chain_valid") and chronology.get(
+        "all_ledger_rows_at_or_after_verified_start"
+    ):
+        diagnosis = "verified_journal_cutover_with_post_cutover_ledger_provenance_found"
+        overall = "pass"
+    elif verified_journals and not verified_start:
+        diagnosis = "verified_journal_epoch_found_without_verified_start_time"
+        overall = "warn"
+    elif verified_journals and not ledger.get("chain_valid"):
+        diagnosis = "verified_journal_epoch_found_but_canonical_ledger_not_valid"
+        overall = "fail"
+    elif verified_journals:
+        diagnosis = "verified_journal_epoch_found_but_ledger_chronology_not_proven"
+        overall = "warn"
+    elif any(row.get("verified_start_local") for row in journals):
+        diagnosis = "verified_journal_start_marker_found_without_verified_epoch_identity"
+        overall = "warn"
+    else:
+        diagnosis = "verified_journal_provenance_not_found"
+        overall = "warn"
+
+    # Keep the response compact: chronology has already consumed the timestamp
+    # list; operators need boundaries/counts, not every ledger timestamp.
+    ledger.pop("recorded_local_values", None)
+
+    return {
+        "status": "ok",
+        "overall": overall,
+        "type": "verified_snapshot_journal_ledger_provenance_status",
+        "version": VERSION,
+        "generated_local": _now(core),
+        "diagnosis": diagnosis,
+        "verified_journal_epoch_found": bool(verified_journals),
+        "verified_journal_paths": [row.get("path") for row in verified_journals],
+        "verified_snapshot_epoch_started_local": verified_start,
+        "journal_files": journals,
+        "canonical_ledger": ledger,
+        "chronology": chronology,
+        "performance_contract": {
+            "startup_scans_files": False,
+            "journal_streaming_reads_only": True,
+            "ledger_line_streaming_only": True,
+            "max_journal_bytes_per_file": MAX_JOURNAL_BYTES_PER_FILE,
+            "max_ledger_bytes": MAX_LEDGER_BYTES,
+        },
+        "authority": {
+            "reporting_only": True,
+            "places_orders": False,
+            "writes_files": False,
+            "syncs_or_seeds_journal": False,
+            "restores_backups": False,
+            "repairs_historical_state": False,
+            "rewrites_or_relabels_canonical_ledger": False,
+            "clears_hard_halt": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    # Called during deterministic startup: deliberately perform no file scans.
+    return {
+        "status": "ok",
+        "overall": "pass",
+        "version": VERSION,
+        "installed": True,
+        "startup_scans_files": False,
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    if flask_app is None:
+        return {
+            "status": "pending",
+            "overall": "warn",
+            "version": VERSION,
+            "reason": "flask_app_missing",
+        }
+    if id(flask_app) not in _REGISTERED_APP_IDS:
+        from flask import jsonify
+
+        try:
+            existing = {
+                getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()
+            }
+        except Exception:
+            existing = set()
+        route = "/paper/verified-snapshot-journal-ledger-provenance-status"
+        if route not in existing:
+            flask_app.add_url_rule(
+                route,
+                "verified_snapshot_journal_ledger_provenance_status",
+                lambda: jsonify(status_payload(core)),
+            )
+        _REGISTERED_APP_IDS.add(id(flask_app))
+    return {
+        "status": "ok",
+        "overall": "pass",
+        "version": VERSION,
+        "route_registered": True,
+        "startup_scans_files": False,
+    }


### PR DESCRIPTION
Issue #82 follow-up after the deployed marker/archive and retained-backup probes found no surviving verified-snapshot epoch evidence in current Railway state files. This PR adds one narrower reporting-only discriminator: inspect only root-level trade-journal epoch/start metadata and the existing append-only canonical ledger chronology/hash chain.

The new `/paper/verified-snapshot-journal-ledger-provenance-status` route performs file reads only when explicitly requested. Startup `apply()` is constant-time and scans no journal or ledger files. The route never syncs/seeds the journal, writes/restores state, edits/relabels ledger rows, clears halts, places orders, or changes strategy, thresholds, sizing, live authority, or ML authority.

It also adds a focused regression covering root-vs-nested journal metadata, valid post-cutover chronology, pre-cutover chronology rejection, ledger hash tamper fail-closed behavior, read-only behavior, and no startup scans. The exact-head Change Safety Audit is extended so all verified-snapshot provenance changes run this regression plus the existing provenance tests and mandatory Stable Paper Core invariants.

Do not merge unless the final exact head passes Change Safety Audit, provenance/core regressions, repository safety, architecture ownership/config/debt validation, and exact Gunicorn bootstrap smoke.