### PR TITLE
Add read-only day-peak provenance status

### DIFF
--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-VERSION = "change-safety-audit-2026-08-21-v4-provenance"
+VERSION = "change-safety-audit-2026-08-21-v5-day-peak-provenance"
 
 CORE_TESTS = (
     "test_architecture_stage_b.py",
@@ -35,6 +35,7 @@ PROVENANCE_TESTS = (
     "test_verified_snapshot_backup_provenance_status.py",
     "test_verified_snapshot_journal_ledger_provenance_status.py",
 )
+DAY_PEAK_PROVENANCE_TESTS = ("test_day_peak_provenance_status.py",)
 
 
 @dataclass(frozen=True)
@@ -64,6 +65,10 @@ def changed_files(base: str, head: str) -> tuple[str, ...]:
 def _is_verified_snapshot_provenance_path(path: str) -> bool:
     lowered = path.lower()
     return "verified_snapshot" in lowered and "provenance" in lowered
+
+
+def _is_day_peak_provenance_path(path: str) -> bool:
+    return "day_peak_provenance" in path.lower()
 
 
 def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ...]]:
@@ -98,6 +103,9 @@ def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ..
         if _is_verified_snapshot_provenance_path(path):
             categories.add("state_persistence")
             boundaries.update(("state", "accounting"))
+        if _is_day_peak_provenance_path(path):
+            categories.add("risk")
+            boundaries.update(("risk", "state"))
         if "risk" in path:
             categories.add("risk")
             boundaries.add("risk")
@@ -129,6 +137,8 @@ def planned_regressions(paths: Iterable[str]) -> tuple[str, ...]:
         tests.extend(CONFIG_TESTS)
     if any(_is_verified_snapshot_provenance_path(path) for path in path_tuple):
         tests.extend(PROVENANCE_TESTS)
+    if any(_is_day_peak_provenance_path(path) for path in path_tuple):
+        tests.extend(DAY_PEAK_PROVENANCE_TESTS)
     existing: list[str] = []
     seen: set[str] = set()
     for test in tests:

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-21-v30-journal-ledger-provenance"
+VERSION = "data-integrity-startup-bridge-2026-08-21-v31-day-peak-provenance"
 MODULES = (
     "final_daily_audit_compactor",
     "daily_audit_entry_count_bridge",
@@ -41,6 +41,9 @@ MODULES = (
     # Trade-journal/canonical-ledger provenance probe. Its apply() is also
     # constant-time; journal/ledger reads occur only on its explicit route.
     "verified_snapshot_journal_ledger_provenance_status",
+    # Current-day risk-peak provenance probe. Its apply() is constant-time and
+    # reads in-process history/reports only when its explicit route is requested.
+    "day_peak_provenance_status",
     # Patch the exact one-shot recovery's journal rotation before the recovery
     # runs. The migration already owns the journal lock, so it must not call the
     # journal mirror recursively from inside that critical section.

--- a/day_peak_provenance_status.py
+++ b/day_peak_provenance_status.py
@@ -1,0 +1,394 @@
+"""Read-only provenance probe for a suspicious current-day risk equity peak.
+
+Issue #82 evidence on the historically canonical paper service shows a sane
+fresh-day baseline and economically coherent current account, while the persisted
+``day_peak_equity`` is far above current/day-start equity and is driving a hard
+intraday-drawdown halt.  This module does not repair that state.  It only compares
+three already-persisted observation streams:
+
+* the current risk-control snapshot;
+* the rolling equity ``history`` written by ``calculate_equity`` on every call;
+* current-day compiled intraday reports, whose headline equity is copied at the
+  end of a cycle.
+
+That comparison can distinguish a sustained reported peak from a transient
+valuation spike that occurred between compiled reports.  Startup ``apply()`` is
+constant-time and performs no state scan.  The explicit route reads only the
+in-process portfolio and never calls valuation/provider, state-save, recovery,
+risk-update, order, journal, or ledger mutation functions.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import math
+from typing import Any, Dict, List
+
+VERSION = "day-peak-provenance-status-2026-08-21-v1"
+ROUTE = "/paper/day-peak-provenance-status"
+MAX_REPORT_ROWS = 16
+MAX_TRADE_ROWS = 20
+HISTORY_WINDOW_RADIUS = 6
+_REGISTERED_APP_IDS: set[int] = set()
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _f(value: Any) -> float | None:
+    try:
+        if value is None or isinstance(value, bool):
+            return None
+        number = float(value)
+        return number if math.isfinite(number) else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _same_money(a: Any, b: Any, tolerance: float = 0.02) -> bool:
+    left = _f(a)
+    right = _f(b)
+    return bool(left is not None and right is not None and abs(left - right) <= tolerance)
+
+
+def _now(core: Any = None) -> str:
+    try:
+        return str(core.local_ts_text())
+    except Exception:
+        return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _trade_local(core: Any, raw: Any) -> str | None:
+    value = _f(raw)
+    if value is None:
+        return None
+    try:
+        return str(core.local_ts_text(value))
+    except Exception:
+        try:
+            return dt.datetime.fromtimestamp(value).strftime("%Y-%m-%d %H:%M:%S")
+        except Exception:
+            return None
+
+
+def _history_summary(portfolio: Dict[str, Any], peak: float | None) -> Dict[str, Any]:
+    numeric: List[tuple[int, float]] = []
+    for index, raw in enumerate(_l(portfolio.get("history"))):
+        value = _f(raw)
+        if value is not None:
+            numeric.append((index, value))
+
+    if not numeric:
+        return {
+            "count": 0,
+            "numeric_count": 0,
+            "minimum_equity": None,
+            "maximum_equity": None,
+            "maximum_index": None,
+            "current_peak_observed": False,
+            "peak_window": [],
+        }
+
+    maximum_index, maximum_equity = max(numeric, key=lambda row: row[1])
+    minimum_equity = min(value for _, value in numeric)
+    all_history = _l(portfolio.get("history"))
+    start = max(0, maximum_index - HISTORY_WINDOW_RADIUS)
+    stop = min(len(all_history), maximum_index + HISTORY_WINDOW_RADIUS + 1)
+    window = []
+    for index in range(start, stop):
+        value = _f(all_history[index])
+        window.append({"index": index, "equity": value})
+
+    return {
+        "count": len(all_history),
+        "numeric_count": len(numeric),
+        "minimum_equity": round(minimum_equity, 6),
+        "maximum_equity": round(maximum_equity, 6),
+        "maximum_index": maximum_index,
+        "values_after_maximum": max(0, len(all_history) - maximum_index - 1),
+        "current_peak_observed": _same_money(maximum_equity, peak),
+        "peak_window": window,
+    }
+
+
+def _report_observation(report: Dict[str, Any]) -> Dict[str, Any]:
+    headline = _d(report.get("headline"))
+    risk = _d(report.get("risk_controls"))
+    positions = headline.get("open_positions")
+    if not isinstance(positions, list):
+        positions = []
+    return {
+        "date": report.get("date"),
+        "generated_local": report.get("generated_local"),
+        "headline_equity": _f(headline.get("equity")),
+        "headline_cash": _f(headline.get("cash")),
+        "headline_day_pnl_pct": _f(headline.get("day_pnl_pct")),
+        "headline_intraday_drawdown_pct": _f(headline.get("intraday_drawdown_pct")),
+        "risk_day_start_equity": _f(risk.get("day_start_equity")),
+        "risk_day_peak_equity": _f(risk.get("day_peak_equity")),
+        "risk_intraday_drawdown_pct": _f(risk.get("intraday_drawdown_pct")),
+        "risk_halted": bool(risk.get("halted")),
+        "risk_halt_reason": risk.get("halt_reason"),
+        "open_positions": [str(symbol) for symbol in positions[:12]],
+    }
+
+
+def _report_summary(portfolio: Dict[str, Any], risk_date: str, peak: float | None) -> Dict[str, Any]:
+    reports = _d(portfolio.get("reports"))
+    raw_rows = [
+        row for row in _l(reports.get("intraday_history"))
+        if isinstance(row, dict) and str(row.get("date") or "") == risk_date
+    ]
+    observations = [_report_observation(row) for row in raw_rows]
+
+    headline_rows = [
+        (index, row["headline_equity"])
+        for index, row in enumerate(observations)
+        if row.get("headline_equity") is not None
+    ]
+    max_headline_index = None
+    max_headline_equity = None
+    if headline_rows:
+        max_headline_index, max_headline_equity = max(headline_rows, key=lambda row: row[1])
+
+    first_peak_risk_index = None
+    for index, row in enumerate(observations):
+        if _same_money(row.get("risk_day_peak_equity"), peak):
+            first_peak_risk_index = index
+            break
+
+    first_peak_risk = (
+        observations[first_peak_risk_index] if first_peak_risk_index is not None else None
+    )
+    previous = (
+        observations[first_peak_risk_index - 1]
+        if first_peak_risk_index is not None and first_peak_risk_index > 0
+        else None
+    )
+
+    previous_symbols = set((previous or {}).get("open_positions") or [])
+    first_symbols = set((first_peak_risk or {}).get("open_positions") or [])
+    candidate_symbols = sorted(previous_symbols | first_symbols)
+
+    return {
+        "reports_container_date": reports.get("date"),
+        "current_day_report_count": len(observations),
+        "maximum_headline_equity": max_headline_equity,
+        "maximum_headline_generated_local": (
+            observations[max_headline_index].get("generated_local")
+            if max_headline_index is not None else None
+        ),
+        "current_peak_observed_in_headline": _same_money(max_headline_equity, peak),
+        "first_report_carrying_current_risk_peak": first_peak_risk,
+        "report_before_current_risk_peak_first_seen": previous,
+        "candidate_symbols_at_peak_boundary": candidate_symbols,
+        "symbols_added_at_boundary": sorted(first_symbols - previous_symbols),
+        "symbols_removed_at_boundary": sorted(previous_symbols - first_symbols),
+        "latest_observations": observations[-MAX_REPORT_ROWS:],
+        "reference_caveat": (
+            "headline equity is a copied historical scalar; embedded risk_controls may "
+            "share the live risk dict until a save/reload, so headline chronology is "
+            "stronger evidence than repeated embedded peak values"
+        ),
+    }
+
+
+def _today_trades(portfolio: Dict[str, Any], core: Any, risk_date: str) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for raw in _l(portfolio.get("trades")):
+        if not isinstance(raw, dict):
+            continue
+        local = _trade_local(core, raw.get("time"))
+        if not local or not local.startswith(risk_date):
+            continue
+        rows.append(
+            {
+                "local_time": local,
+                "symbol": raw.get("symbol"),
+                "action": raw.get("action"),
+                "side": raw.get("side"),
+                "price": _f(raw.get("price")),
+                "shares": _f(raw.get("shares")),
+                "execution_id": raw.get("execution_id"),
+                "exit_reason": raw.get("exit_reason"),
+            }
+        )
+    return rows[-MAX_TRADE_ROWS:]
+
+
+def _current_positions(portfolio: Dict[str, Any]) -> List[Dict[str, Any]]:
+    positions = _d(portfolio.get("positions"))
+    rows: List[Dict[str, Any]] = []
+    for symbol, raw in sorted(positions.items()):
+        row = _d(raw)
+        rows.append(
+            {
+                "symbol": str(symbol),
+                "side": row.get("side"),
+                "shares": _f(row.get("shares")),
+                "entry": _f(row.get("entry")),
+                "last_price": _f(row.get("last_price")),
+                "peak": _f(row.get("peak")),
+                "trough": _f(row.get("trough")),
+                "entry_time_local": None,
+            }
+        )
+        entry_time = row.get("entry_time")
+        rows[-1]["entry_time_local"] = _trade_local(None, entry_time)
+    return rows
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    portfolio = _d(getattr(core, "portfolio", None)) if core is not None else {}
+    risk = _d(portfolio.get("risk_controls"))
+    risk_date = str(risk.get("date") or "")
+    start = _f(risk.get("day_start_equity"))
+    peak = _f(risk.get("day_peak_equity"))
+    current = _f(portfolio.get("equity"))
+    cash = _f(portfolio.get("cash"))
+
+    history = _history_summary(portfolio, peak)
+    reports = _report_summary(portfolio, risk_date, peak)
+
+    peak_gain_fraction = None
+    current_drawdown_fraction = None
+    current_vs_start_fraction = None
+    if start is not None and start > 0 and peak is not None:
+        peak_gain_fraction = (peak - start) / start
+    if peak is not None and peak > 0 and current is not None:
+        current_drawdown_fraction = max(0.0, (peak - current) / peak)
+    if start is not None and start > 0 and current is not None:
+        current_vs_start_fraction = (current - start) / start
+
+    history_has_peak = bool(history.get("current_peak_observed"))
+    report_has_peak = bool(reports.get("current_peak_observed_in_headline"))
+    first_peak_report = reports.get("first_report_carrying_current_risk_peak")
+    first_peak_report_equity = _f(_d(first_peak_report).get("headline_equity"))
+
+    if peak is None or start is None or current is None:
+        diagnosis = "insufficient_current_risk_or_account_fields"
+        overall = "warn"
+    elif history_has_peak and report_has_peak:
+        diagnosis = "current_day_peak_observed_in_equity_history_and_report_headline"
+        overall = "pass"
+    elif history_has_peak and not report_has_peak:
+        diagnosis = "transient_equity_peak_observed_between_compiled_report_headlines"
+        overall = "pass"
+    elif first_peak_report and not _same_money(first_peak_report_equity, peak):
+        diagnosis = "risk_peak_present_in_report_metadata_without_matching_headline_equity"
+        overall = "warn"
+    else:
+        diagnosis = "current_risk_peak_not_proven_by_retained_equity_observations"
+        overall = "warn"
+
+    return {
+        "status": "ok",
+        "overall": overall,
+        "type": "day_peak_provenance_status",
+        "version": VERSION,
+        "generated_local": _now(core),
+        "diagnosis": diagnosis,
+        "current_account": {
+            "cash": cash,
+            "equity": current,
+            "positions_count": len(_d(portfolio.get("positions"))),
+        },
+        "risk": {
+            "date": risk_date or None,
+            "day_start_equity": start,
+            "day_peak_equity": peak,
+            "halted": bool(risk.get("halted")),
+            "halt_reason": risk.get("halt_reason"),
+            "intraday_drawdown_pct": _f(risk.get("intraday_drawdown_pct")),
+            "peak_gain_from_day_start_pct": (
+                round(peak_gain_fraction * 100.0, 6)
+                if peak_gain_fraction is not None else None
+            ),
+            "current_drawdown_from_peak_pct": (
+                round(current_drawdown_fraction * 100.0, 6)
+                if current_drawdown_fraction is not None else None
+            ),
+            "current_change_from_day_start_pct": (
+                round(current_vs_start_fraction * 100.0, 6)
+                if current_vs_start_fraction is not None else None
+            ),
+        },
+        "equity_history": history,
+        "intraday_reports": reports,
+        "current_positions": _current_positions(portfolio),
+        "current_day_trades": _today_trades(portfolio, core, risk_date),
+        "evidence_interpretation": {
+            "history_peak_matches_risk_peak": history_has_peak,
+            "report_headline_peak_matches_risk_peak": report_has_peak,
+            "transient_between_reports": bool(history_has_peak and not report_has_peak),
+            "does_not_prove_quote_source_or_symbol": True,
+            "next_safe_step_if_transient": (
+                "use the peak-boundary time/symbol set with independent historical market data; "
+                "do not clear the halt or rewrite the peak from this probe alone"
+            ),
+        },
+        "authority": {
+            "reporting_only": True,
+            "places_orders": False,
+            "calls_market_data_providers": False,
+            "writes_files": False,
+            "saves_state": False,
+            "updates_risk_controls": False,
+            "rewrites_current_day_peak": False,
+            "clears_hard_halt": False,
+            "repairs_historical_state": False,
+            "rewrites_or_relabels_canonical_ledger": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    # Deterministic startup registration only. Do not inspect portfolio/history here.
+    return {
+        "status": "ok",
+        "overall": "pass",
+        "version": VERSION,
+        "installed": True,
+        "startup_reads_runtime_state": False,
+        "startup_calls_market_data_providers": False,
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    if flask_app is None:
+        return {
+            "status": "pending",
+            "overall": "warn",
+            "version": VERSION,
+            "reason": "flask_app_missing",
+        }
+    app_id = id(flask_app)
+    if app_id not in _REGISTERED_APP_IDS:
+        from flask import jsonify
+
+        try:
+            existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+        except Exception:
+            existing = set()
+        if ROUTE not in existing:
+            flask_app.add_url_rule(
+                ROUTE,
+                "day_peak_provenance_status",
+                lambda: jsonify(status_payload(core)),
+            )
+        _REGISTERED_APP_IDS.add(app_id)
+    return {
+        "status": "ok",
+        "overall": "pass",
+        "version": VERSION,
+        "route_registered": True,
+        "startup_reads_runtime_state": False,
+    }

--- a/test_change_safety_audit.py
+++ b/test_change_safety_audit.py
@@ -94,6 +94,24 @@ class ChangeSafetyAuditTests(unittest.TestCase):
             ):
                 self.assertIn(core_test, tests)
 
+    def test_day_peak_provenance_change_selects_focused_risk_regression(self) -> None:
+        path = "day_peak_provenance_status.py"
+        categories, boundaries = classify_paths((path,))
+        tests = planned_regressions((path,))
+
+        self.assertIn("risk", categories)
+        self.assertIn("risk", boundaries)
+        self.assertIn("state", boundaries)
+        self.assertIn("test_day_peak_provenance_status.py", tests)
+        for core_test in (
+            "test_architecture_stage_b.py",
+            "test_architecture_stage_c.py",
+            "test_architecture_stage_d_state_store.py",
+            "test_architecture_stage_e_accounting.py",
+            "test_architecture_stage_f_canary.py",
+        ):
+            self.assertIn(core_test, tests)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_day_peak_provenance_status.py
+++ b/test_day_peak_provenance_status.py
@@ -21,10 +21,10 @@ class _Core:
         return mapping.get(float(ts), "2026-08-21 13:15:00 CDT")
 
 
-def _report(time_text, equity, peak, positions):
+def _report(time_text, equity, peak, positions, date="2026-08-21"):
     return {
         "type": "intraday",
-        "date": "2026-08-21",
+        "date": date,
         "generated_local": time_text,
         "headline": {
             "equity": equity,
@@ -34,7 +34,7 @@ def _report(time_text, equity, peak, positions):
             "open_positions": positions,
         },
         "risk_controls": {
-            "date": "2026-08-21",
+            "date": date,
             "day_start_equity": 100.0,
             "day_peak_equity": peak,
             "intraday_drawdown_pct": max(0.0, (peak - equity) / peak * 100.0),
@@ -73,7 +73,13 @@ def _portfolio(transient=True):
             "intraday_history": [
                 _report("2026-08-21 13:05:00 CDT", 102.0, 102.0, ["OLD"]),
                 _report("2026-08-21 13:10:00 CDT", second_equity, 150.0, ["ABC"]),
-                _report("2026-08-20 13:10:00 CDT", 999.0, 999.0, ["STALE"]),
+                _report(
+                    "2026-08-20 13:10:00 CDT",
+                    999.0,
+                    999.0,
+                    ["STALE"],
+                    date="2026-08-20",
+                ),
             ],
         },
         "trades": [

--- a/test_day_peak_provenance_status.py
+++ b/test_day_peak_provenance_status.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import copy
+import unittest
+from unittest import mock
+
+import day_peak_provenance_status as probe
+
+
+class _Core:
+    def __init__(self, portfolio):
+        self.portfolio = portfolio
+
+    def local_ts_text(self, ts=None):
+        if ts is None:
+            return "2026-08-21 13:40:00 CDT"
+        mapping = {
+            1000.0: "2026-08-21 13:05:00 CDT",
+            1010.0: "2026-08-21 13:10:00 CDT",
+        }
+        return mapping.get(float(ts), "2026-08-21 13:15:00 CDT")
+
+
+def _report(time_text, equity, peak, positions):
+    return {
+        "type": "intraday",
+        "date": "2026-08-21",
+        "generated_local": time_text,
+        "headline": {
+            "equity": equity,
+            "cash": 100.0,
+            "day_pnl_pct": 2.0,
+            "intraday_drawdown_pct": 0.0,
+            "open_positions": positions,
+        },
+        "risk_controls": {
+            "date": "2026-08-21",
+            "day_start_equity": 100.0,
+            "day_peak_equity": peak,
+            "intraday_drawdown_pct": max(0.0, (peak - equity) / peak * 100.0),
+            "halted": peak >= 150.0,
+            "halt_reason": "performance risk hard intraday drawdown halt (2.50%)" if peak >= 150.0 else "",
+        },
+    }
+
+
+def _portfolio(transient=True):
+    second_equity = 103.0 if transient else 150.0
+    return {
+        "cash": 100.0,
+        "equity": 103.0,
+        "history": [100.0, 102.0, 150.0, 103.0],
+        "positions": {
+            "ABC": {
+                "side": "long",
+                "shares": 1.0,
+                "entry": 100.0,
+                "last_price": 103.0,
+                "peak": 150.0,
+                "entry_time": 1000.0,
+            }
+        },
+        "risk_controls": {
+            "date": "2026-08-21",
+            "day_start_equity": 100.0,
+            "day_peak_equity": 150.0,
+            "intraday_drawdown_pct": 31.333,
+            "halted": True,
+            "halt_reason": "performance risk hard intraday drawdown halt (2.50%)",
+        },
+        "reports": {
+            "date": "2026-08-21",
+            "intraday_history": [
+                _report("2026-08-21 13:05:00 CDT", 102.0, 102.0, ["OLD"]),
+                _report("2026-08-21 13:10:00 CDT", second_equity, 150.0, ["ABC"]),
+                _report("2026-08-20 13:10:00 CDT", 999.0, 999.0, ["STALE"]),
+            ],
+        },
+        "trades": [
+            {
+                "time": 1000.0,
+                "symbol": "ABC",
+                "action": "entry",
+                "side": "long",
+                "price": 100.0,
+                "shares": 1.0,
+                "execution_id": "entry-1",
+            },
+            {
+                "time": 1010.0,
+                "symbol": "OLD",
+                "action": "exit",
+                "side": "long",
+                "price": 99.0,
+                "shares": 1.0,
+                "execution_id": "exit-1",
+            },
+        ],
+    }
+
+
+class DayPeakProvenanceStatusTests(unittest.TestCase):
+    def test_transient_peak_between_report_headlines_is_detected(self):
+        core = _Core(_portfolio(transient=True))
+        payload = probe.status_payload(core)
+
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["overall"], "pass")
+        self.assertEqual(
+            payload["diagnosis"],
+            "transient_equity_peak_observed_between_compiled_report_headlines",
+        )
+        self.assertTrue(payload["equity_history"]["current_peak_observed"])
+        self.assertEqual(payload["equity_history"]["maximum_equity"], 150.0)
+        self.assertFalse(payload["intraday_reports"]["current_peak_observed_in_headline"])
+        self.assertEqual(payload["intraday_reports"]["maximum_headline_equity"], 103.0)
+        self.assertEqual(
+            payload["intraday_reports"]["first_report_carrying_current_risk_peak"]["generated_local"],
+            "2026-08-21 13:10:00 CDT",
+        )
+        self.assertEqual(
+            payload["intraday_reports"]["report_before_current_risk_peak_first_seen"]["generated_local"],
+            "2026-08-21 13:05:00 CDT",
+        )
+        self.assertEqual(
+            payload["intraday_reports"]["candidate_symbols_at_peak_boundary"],
+            ["ABC", "OLD"],
+        )
+        self.assertTrue(payload["evidence_interpretation"]["transient_between_reports"])
+
+    def test_sustained_peak_in_report_headline_is_distinguished(self):
+        core = _Core(_portfolio(transient=False))
+        payload = probe.status_payload(core)
+
+        self.assertEqual(
+            payload["diagnosis"],
+            "current_day_peak_observed_in_equity_history_and_report_headline",
+        )
+        self.assertTrue(payload["intraday_reports"]["current_peak_observed_in_headline"])
+        self.assertEqual(payload["intraday_reports"]["maximum_headline_equity"], 150.0)
+
+    def test_probe_is_read_only_and_filters_trades_to_current_risk_date(self):
+        portfolio = _portfolio(transient=True)
+        before = copy.deepcopy(portfolio)
+        core = _Core(portfolio)
+
+        with mock.patch("builtins.open", side_effect=AssertionError("file I/O forbidden")):
+            payload = probe.status_payload(core)
+
+        self.assertEqual(portfolio, before)
+        self.assertEqual(len(payload["current_day_trades"]), 2)
+        self.assertTrue(payload["authority"]["reporting_only"])
+        self.assertFalse(payload["authority"]["writes_files"])
+        self.assertFalse(payload["authority"]["calls_market_data_providers"])
+        self.assertFalse(payload["authority"]["updates_risk_controls"])
+        self.assertFalse(payload["authority"]["rewrites_current_day_peak"])
+        self.assertFalse(payload["authority"]["clears_hard_halt"])
+
+    def test_startup_apply_does_not_scan_runtime_state(self):
+        core = _Core(_portfolio(transient=True))
+        with mock.patch.object(probe, "status_payload", side_effect=AssertionError("must not run")):
+            payload = probe.apply(core)
+        self.assertEqual(payload["overall"], "pass")
+        self.assertFalse(payload["startup_reads_runtime_state"])
+        self.assertFalse(payload["startup_calls_market_data_providers"])
+
+    def test_route_registration_is_bounded(self):
+        try:
+            from flask import Flask
+        except Exception:  # pragma: no cover - dependency is installed in CI
+            self.skipTest("Flask not installed")
+
+        app = Flask(__name__)
+        core = _Core(_portfolio(transient=True))
+        result = probe.register_routes(app, core)
+        self.assertEqual(result["overall"], "pass")
+        self.assertIn(probe.ROUTE, {rule.rule for rule in app.url_map.iter_rules()})
+        client = app.test_client()
+        response = client.get(probe.ROUTE)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()["type"], "day_peak_provenance_status")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue #82 follow-up on the historically canonical paper service. The fresh-day baseline now passes with sane positive day-start equity, while the account is economically coherent/currently up on the day but remains hard-halted because persisted day_peak_equity is ~45% above day start. The compact daily audit shows runner and market data pass; the remaining accounting warning is the already-known immutable TEM duplicate full-exit row prospectively blocked by PR #81.

This PR adds `/paper/day-peak-provenance-status`, a reporting-only discriminator that compares the current risk snapshot with the rolling equity history and current-day compiled intraday report headlines. Because `calculate_equity` records every equity observation before updating risk, the route can distinguish a sustained report-level peak from a transient valuation spike between compiled reports and return the peak boundary/candidate symbols for independent historical market-data verification.

Safety: startup `apply()` is constant-time and reads no runtime state. The explicit route reads only the in-process portfolio. It makes no provider calls, writes no files/state, does not update risk, does not rewrite day peak, does not clear the halt, does not repair accounting, does not modify ledger/journal rows, places no orders, and changes no strategy/threshold/sizing/live/ML authority.

The mandatory Change Safety Audit is extended so day-peak provenance changes select the focused regression plus the Stable Paper Core invariant suite. Do not merge unless the final exact head passes focused tests, repository safety, architecture ownership/config/debt checks, and exact Gunicorn bootstrap smoke.