### PR TITLE
Auto-capture consolidated recovery gate

### DIFF
--- a/PROJECT_HANDOFF_CURRENT.md
+++ b/PROJECT_HANDOFF_CURRENT.md
@@ -1,36 +1,38 @@
 # Project Handoff — Authoritative Current Runtime
 
-Last updated: 2026-08-21 16:45 CDT  
+Last updated: 2026-08-21 16:50 CDT  
 Repository: `sterlingfancher-cmyk/Trading-bot`  
-Current `main`: `b7f685e460ec31fa1f93987ff29704c01bed650a` (PR #109)  
-Active PR: consolidated verified-v2 recovery gate on `agent/consolidated-v2-recovery-gate-20260821`  
+Current `main`: `bd799b71df65e457fc25a3a2d9f2609020f0da61` (PR #110)  
+Active PR: #111 `agent/auto-capture-recovery-gate-20260821`  
 Authoritative paper runtime for Issue #82 validation: `https://web-production-e1796.up.railway.app`  
 Contaminated split-lineage service: `https://trading-bot-clean.up.railway.app`
 
 ## Communication / Continuity Rule
 
-Keep Trading-bot progress communication in the currently active ChatGPT project conversation. When intentionally moving chats, refresh this file first, stop at a clean boundary, and treat the new conversation as active. Project-specific monitoring tasks remain disabled unless explicitly re-established. Warn before the current conversation becomes too large for reliable continuation.
+Keep Trading-bot progress communication in the currently active ChatGPT project conversation. When intentionally moving chats, refresh this file first, stop at a clean boundary, and treat the new conversation as active. Project-specific monitoring tasks remain disabled unless explicitly re-established. Warn before the active conversation becomes too large for reliable continuation.
+
+The user explicitly asked to stop the repeated one-endpoint/manual-paste forensic loop. From PR #110 forward, use one consolidated recovery gate plus automated GitHub runtime capture. Do not ask the user to run another per-event TEM/SLS/TOST forensic endpoint unless automated evidence is technically unavailable and a new safety boundary cannot otherwise be resolved.
 
 ## Safety / Authority Boundaries
 
 - Paper-only until explicit approval.
 - Rules remain sole execution authority; ML/AI remains shadow-only.
-- Never manually clear a halt, rewrite `day_peak_equity`, force a fresh-day baseline, restore an older state backup, or overwrite state from an incomplete reconstruction.
+- Never manually clear a halt, rewrite `day_peak_equity`, force a fresh-day baseline, restore an older state backup, or overwrite account state from an incomplete reconstruction.
 - Never delete, edit, fabricate, or relabel canonical execution-ledger rows.
 - Never change strategy, normal signal thresholds, sizing, hard-risk thresholds, live authority, or ML authority merely to make an audit pass.
 - Do not casually call `/paper/run`; use read-only diagnostics unless an explicit validation plan requires a cycle.
 - Every relevant change must pass the exact-head Change Safety Audit plus focused regressions, repository validation, architecture/ownership/config/debt checks, and exact Gunicorn bootstrap smoke before merge.
-- While Issue #82 remains open, authoritative runtime changes must map to a demonstrated safety defect or #94 governance/validation requirement.
+- While Issue #82 remains open, authoritative runtime changes must map directly to a demonstrated safety defect; governance/validation-only changes may map to Issue #94.
 
 ## Executive Status
 
 Issue #82 remains the stabilization exit gate.
 
-The central Aug. 21 discovery is that the two Railway services are **different persistent-state lineages running the same code**. `trading-bot-clean` is contaminated legacy state and is not the Aug. 12 verified successor. The historically canonical `web-production-e1796` service still carries the mechanically proven `stable-paper-v2-20260812-verified01` lineage.
+The decisive Aug. 21 finding is that the two Railway services are **different persistent-state lineages running the same code**. `trading-bot-clean` is contaminated legacy state and is not the Aug. 12 verified successor. The historically canonical `web-production-e1796` service still carries the mechanically proven `stable-paper-v2-20260812-verified01` lineage.
 
 Do not design recovery from `trading-bot-clean`. Use `web-production-e1796` for all #82 economic/risk validation until a deliberate service/volume consolidation is separately designed and proven.
 
-The authoritative v2 canonical ledger is hash-chain valid, currently 39 rows, all in `stable-paper-v2-20260812-verified01`. Five immutable executions now have independent evidence that their economic effects are invalid and must be excluded only from a counterfactual successor projection while their rows remain untouched:
+The authoritative v2 canonical ledger is hash-chain valid, currently 39 rows, all in `stable-paper-v2-20260812-verified01`. Five immutable executions now have independent evidence that their economic effects are invalid. They must remain untouched in the historical ledger but be excluded from the counterfactual successor economics:
 
 1. TEM duplicate full exit `3530dbf965db4894ba93b7098cec3696`, exact immutable price `52.904999`, qty `29.640567`.
 2. SLS catastrophic favorable partial exit `b6584fe0e28744d8bfa2da26f413af70`, exact immutable price `186.2901`, qty `2.144057692`.
@@ -38,7 +40,7 @@ The authoritative v2 canonical ledger is hash-chain valid, currently 39 rows, al
 4. TOST catastrophic favorable partial exit `cb10928f441148aaa3faf041a84bc4c8`, `1.24333584 @ 190.244995`.
 5. TOST catastrophic favorable partial exit `1451d91c06b34b199364b56f72ad376f`, `1.24333584 @ 74.269997`.
 
-The account remains hard-halted because persisted `day_peak_equity=19150.437724108448` is unsupported by retained equity observations. Do not clear the halt or rewrite the peak. The preferred recovery path is to correct successor economic state under validation hold while leaving the current-day halt/peak untouched, then allow the next legitimate fresh-risk-day initialization to occur prospectively from sane corrected economics.
+The account remains hard-halted because persisted `day_peak_equity=19150.437724108448` is not supported by retained equity observations. Do not clear the halt or rewrite the peak. Preferred recovery direction is a bounded exact-signature successor economic migration under validation hold while leaving the current-day halt/peak untouched; then permit the next legitimate fresh-risk-day initialization to occur prospectively from sane corrected economics.
 
 ## Split Railway State Lineage — Decisive Aug. 21 Evidence
 
@@ -62,9 +64,25 @@ Direct runtime evidence proved:
 - canonical hash chain valid with no parse/hash errors
 - authoritative execution hook active
 - sane current-day baseline initialization
-- runner/market-data healthy on settled self-check/audit
+- runner and market data healthy on settled self-check/audit
 
-The service initially showed 36 canonical rows, then 37, then 39 as additional executions were appended. All remain in the verified v2 epoch.
+The service initially showed 36 canonical rows, later 37, then 39 as additional executions were appended. All remain in the verified v2 epoch.
+
+Historical repository evidence supports this mapping. The Aug. 4 handoff explicitly identified `web-production-e1796` (`splendid-creativity -> web`) as canonical and described `trading-bot-clean` as a separate state boundary that must not be combined with it.
+
+## Durable Aug. 12 Verified-Recovery Provenance
+
+GitHub history independently proves the verified successor:
+- PR #45 `9b659c88f77d5004e82ee0dda8e6d26c074621e8`: exact LRCX bad-tick recovery and creation of `stable-paper-v2-20260812-verified01`; contaminated ledger/journal archived/rotated before starting v2.
+- PR #46 `16c4c2371e46d23d15057f172a37756ff5245342`: journal-lock startup deadlock fix after recovery without changing arithmetic/authority.
+- PR #48 `b5ea9d9192f7ac7cf65d8e342d11727ac3249b2b`: successful v1→v2 successor compatibility and archived historical disposition.
+- PR #52 `d82f6eb327c90dede362fc0160167ac8c18c327f`: canonical ledger already authoritative for v2 and reporting corrected to use active successor epoch.
+
+Verified baseline constants:
+- starting cash `10768.497730982748`
+- starting equity `11885.824057382748`
+- restored LRCX `3.42486 @ 312.90`, verified mark `326.24`
+- validation hold retained.
 
 ## Authoritative v2 Account / Audit Evidence — Aug. 21
 
@@ -75,25 +93,24 @@ Settled self-check around 13:13 CDT:
 - realized today `+368.68`
 - runner enabled / no active error
 - all bounded runtime component checks passed
-- risk halted solely because persisted intraday drawdown was about 29.28%
+- risk halted solely because persisted intraday drawdown was about 29.28%.
 
 Compact daily audit around 13:37 CDT:
-- account cash `13159.073498029464`
-- equity `13541.79`
-- verified epoch `stable-paper-v2-20260812-verified01`
-- baseline type `verified_snapshot_with_open_position`
-- historical recovery decision `verified_snapshot_rollforward`
-- starting cash `10768.497730982748`
-- starting equity `11885.824057382748`
-- validation hold remains active / release blocked
+- active cash `13159.073498029464`
+- active equity `13541.79`
 - reconstructed cash `13159.07351`
 - reconstructed equity `13541.791832`
 - reconstructed positions exactly `DHR`, `GH`, `SLS`, `TOST`
+- verified epoch `stable-paper-v2-20260812-verified01`
+- baseline type `verified_snapshot_with_open_position`
+- historical recovery decision `verified_snapshot_rollforward`
+- starting cash/equity match the verified baseline
+- validation hold remains active / release blocked
 - market-data accounting complete and provider circuit clear
 - runner pass / no active error
-- ledger chain valid
+- canonical ledger chain valid.
 
-The audit's original single coverage warning was the historical TEM duplicate. Subsequent forensics proved the account/ledger could still be internally coherent while carrying economically impossible quote-derived fills.
+This showed state and ledger were mechanically coherent, but later forensics proved several quote-derived executions were economically impossible. Internal accounting consistency alone is therefore insufficient recovery evidence.
 
 ## Day-Peak Forensics — PR #104
 
@@ -108,32 +125,32 @@ Authoritative result:
 - rolling equity history maximum only `14285.11`
 - retained history does **not** contain the current risk peak
 - no current-day compiled report headline contains the current risk peak
-- diagnosis `current_risk_peak_not_proven_by_retained_equity_observations`
+- diagnosis `current_risk_peak_not_proven_by_retained_equity_observations`.
 
-The retained history did capture a transient jump from roughly `13166` to `14285.11` and immediately back near `13537`, proving at least one transient valuation spike. The later SLS evidence explains that retained jump, but not the entire unsupported `19150.44` risk peak.
+Retained history did capture a transient jump from roughly `13166` to `14285.11` and immediately back near `13537`, proving at least one transient valuation spike. SLS evidence below explains that retained jump, but not the entire unsupported `19150.44` risk peak.
 
 ## SLS Bad Execution — PRs #105 / #106
 
 SLS entry:
 - execution `4dfe9d5b3e50432c820723ea9a39dcb0`
-- canonical entry quantity about `6.497144521 @ 14.335`
+- canonical entry quantity about `6.497144521 @ 14.335`.
 
 Bad partial exit:
 - execution `b6584fe0e28744d8bfa2da26f413af70`
 - exact canonical qty `2.144057692 @ 186.2901`
-- exit reason `partial_profit_long`
+- exit reason `partial_profit_long`.
 
-Independent Alpaca IEX evidence at the execution window:
+Independent Alpaca IEX evidence around the exact execution:
 - bids roughly `14.16–14.23`
 - asks roughly `14.26–14.27`
 - nearby 1-minute range about `14.105–14.29`
-- no SLS split/reverse-split action Aug. 18–22
+- no SLS split/reverse-split action Aug. 18–22.
 
 The bogus row created about `$399.42` cash proceeds and about `$368.68` realized PnL, explaining essentially all reported `realized_today`. It also left SLS `peak=186.2901` and explains the retained equity-history spike near `14285`.
 
 PR #105 merged as `da691224875aebf1464903be6f90937ee6dfaf01`. It prospectively added symmetric favorable/adverse quote-integrity protection using the broad 0.40x..2.50x position-entry anchor at fresh/cache, valuation fallback, full-exit, and partial-exit boundaries. Runtime confirmed version `paper-exit-price-integrity-2026-08-21-v3-symmetric-position-anchor`, `position_entry_anchor_enabled=true`, `symmetric_favorable_outlier_protection=true`, overall pass.
 
-PR #106 merged as `8a42729fcf89dad5ab7de8df39073c727b8873a9`. Its read-only SLS recovery proof established that the SLS bad row was not terminal: three canonical TOST partial exits followed it.
+PR #106 merged as `8a42729fcf89dad5ab7de8df39073c727b8873a9`. Its read-only recovery proof established that the SLS bad row was not terminal: three canonical TOST partial exits followed it.
 
 ## Successor Replay / TOST Evidence — PR #107
 
@@ -146,67 +163,74 @@ Runtime result:
 - SLS signature exact
 - TEM row found once but initial expected display price `52.905` missed the immutable canonical value by one micro-dollar
 - three canonical rows after SLS were all TOST partial-profit exits
-- `state.trades` contained zero rows after SLS, showing those TOST rows were not reflected in current state economics
+- `state.trades` contained zero rows after SLS, showing those TOST rows were not reflected in current state economics.
 
-Independent Alpaca IEX checks on the three TOST rows:
-- 13:11:11 CDT: recorded `73.940002`, market roughly `36.21–36.25`
-- 14:03:17 CDT: recorded `190.244995`, market roughly `36.44–36.47`
-- 14:35:20 CDT: recorded `74.269997`, market roughly `36.39–36.44`
-- no TOST forward/reverse/unit split action Aug. 18–22
+Independent Alpaca IEX checks:
+- 13:11:11 CDT: recorded TOST `73.940002`, market roughly `36.21–36.25`
+- 14:03:17 CDT: recorded TOST `190.244995`, market roughly `36.44–36.47`
+- 14:35:20 CDT: recorded TOST `74.269997`, market roughly `36.39–36.44`
+- no TOST forward/reverse/unit split action Aug. 18–22.
 
-All three TOST rows are catastrophic favorable outliers. Their immutable rows must remain preserved, but their economic effects must not be replayed into a corrected successor state.
+All three TOST rows are catastrophic favorable outliers. Their immutable rows remain evidence but their economic effects must not be replayed into corrected successor state.
 
 ## TEM Precision Provenance — PR #109
 
-PR #109 merged as `b7f685e460ec31fa1f93987ff29704c01bed650a` after exact-head Change Safety, Architecture Debt, Repository Safety, full Refactor/Ownership/Config/Startup audit, and Gunicorn smoke passed. Both Railway deployments succeeded.
+PR #109 merged as `b7f685e460ec31fa1f93987ff29704c01bed650a` after all exact-head safety gates passed and both Railway deployments succeeded.
 
 Runtime TEM provenance:
 - execution ID, epoch, action, symbol, side, quantity all exact
 - only failed field was price
 - observed immutable canonical price `52.904999`
 - prior expected display value `52.905`
-- absolute difference about `0.000001`
+- absolute difference about one micro-dollar.
 
-This is serialization/display precision provenance, not a new economic contradiction. The successor gate must use the immutable canonical value `52.904999` and should not broadly loosen price tolerance.
+This is serialization/display precision provenance, not a new economic contradiction. The successor gate must use immutable canonical `52.904999`; do not broadly loosen tolerance merely to pass.
 
-## Consolidated Recovery-Gate Policy — Current Work
+## PR #110 — Consolidated Verified-v2 Recovery Gate
 
-Too many one-off manual tests accumulated during Aug. 21 forensics. The current work consolidates them into the existing single route:
+PR #110 merged as `bd799b71df65e457fc25a3a2d9f2609020f0da61` after exact-head Change Safety, Architecture Debt, Repository Safety, full Refactor/Ownership/Configuration/Startup, and exact Gunicorn smoke all passed. Both Railway deployment contexts subsequently reported success.
 
+Main consolidated route:
 `/paper/verified-v2-successor-replay-status`
 
-The consolidated gate:
+Version:
+`verified-v2-successor-replay-status-2026-08-21-v2-consolidated-five-invalid`
+
+The gate:
 - exact-matches all five known invalid immutable rows at canonical precision;
-- verifies ledger chain, epoch, unique execution IDs, and terminal ordering;
-- excludes only those five rows from counterfactual economics while retaining every row in the immutable ledger;
+- verifies hash chain, exact v2 epoch, unique execution IDs, and terminal ordering;
+- excludes only those five rows from counterfactual economics while retaining every historical row;
 - replays every other canonical execution in original order from the exact Aug. 12 verified baseline;
 - compares projected positions/cash/equity against current state and flags unexplained differences outside known-invalid symbols;
 - reports current risk state but does not change it;
-- sets `manual_per_event_probe_required=false` when mechanically complete;
+- requires the latest known invalid row to be terminal for a clean pass;
+- returns `verified_v2_consolidated_recovery_gate_mechanically_complete` only when all conditions are met;
+- returns `manual_per_event_probe_required=false`;
 - never writes state, rewrites the day peak, clears the halt, fabricates a fill, edits history, places orders, or changes strategy/risk/sizing/live/ML authority.
 
-The one-off SLS recovery-proof and TEM field-provenance modules remain in repository history/tests for evidence but are removed from startup route registration once the consolidated gate lands. The day-peak provenance route remains registered because the unsupported risk peak is still a separate #82 evidence boundary.
+PR #110 also removes the superseded one-off SLS and TEM provenance modules from startup route registration. Their files/tests remain in repository history as forensic evidence. The day-peak provenance route remains registered because the unsupported risk peak is a separate evidence boundary.
 
-After the consolidated gate deploys, the assistant should query it directly. Do not ask the user to run another per-event forensic endpoint. If the consolidated gate passes, proceed to design the bounded exact-signature successor-state migration under validation hold.
+## PR #111 — Automatic Runtime Capture of the Single Gate
 
-## Durable Verified-Recovery Provenance
+Active PR #111: `agent/auto-capture-recovery-gate-20260821`.
 
-GitHub history independently proves the Aug. 12 successor existed:
-- PR #45 `9b659c88f77d5004e82ee0dda8e6d26c074621e8`: exact LRCX bad-tick recovery and creation of `stable-paper-v2-20260812-verified01`
-- PR #46 `16c4c2371e46d23d15057f172a37756ff5245342`: journal-lock deadlock fix after recovery
-- PR #48 `b5ea9d9192f7ac7cf65d8e342d11727ac3249b2b`: explicit successful v1→v2 successor compatibility
-- PR #52 `d82f6eb327c90dede362fc0160167ac8c18c327f`: canonical ledger already authoritative for v2 and reporting fixed to use active successor epoch
+Purpose: remove the need for the user to manually open/paste the consolidated route after each deployment.
 
-Verified baseline constants:
-- starting cash `10768.497730982748`
-- starting equity `11885.824057382748`
-- restored LRCX `3.42486 @ 312.90`, verified mark `326.24`
+Changes:
+- `runtime_research_snapshot.py` default target is the authoritative `web-production-e1796` service rather than `trading-bot-clean`.
+- automatic snapshot adds GET-only `/paper/verified-v2-successor-replay-status`.
+- snapshot compacts diagnosis, chain/row count, five-signature exactness, terminal ordering, projection completion, candidate cash/equity, unexplained position mismatches, migration-readiness, and explicit no-write/no-halt/no-peak authority.
+- a non-pass recovery gate downgrades the research snapshot to `warn`, not a fatal collector error.
+- new `test_runtime_research_snapshot.py` covers canonical target, compact gate capture, no manual-per-event requirement, and fail/warn behavior.
+- mandatory `change_safety_audit.py` now classifies runtime-research-snapshot changes and automatically selects `test_runtime_research_snapshot.py` on exact-head audits.
+
+After PR #111 lands, post-main-push GitHub Actions should wait for Railway settle, collect the consolidated gate automatically, upload `runtime-research-snapshot` evidence, and allow the assistant to inspect that artifact directly. Do not ask the user for another per-event forensic test.
 
 ## Startup-Liveness Observation
 
-Several Aug. 21 deployments spent >60 seconds in `runtime_worker_registration` while the loader thread and heartbeat remained alive and the pre-WSGI fresh-day guard remained pass. The app eventually became ready. Treat this as slow cold start, not a proven hang, unless the same broad phase persists roughly 4–5 minutes or heartbeat stops.
+Several Aug. 21 deployments spent >60 seconds in `runtime_worker_registration` while loader thread and heartbeat remained alive and the pre-WSGI fresh-day guard remained pass. Applications eventually became ready. Treat this as slow cold start, not a proven hang, unless the same broad phase persists about 4–5 minutes or heartbeat stops.
 
-Do not guess or parallelize registration. If it becomes a real blocker, first add per-component read-only timing/progress telemetry. Consolidating superseded forensic registrations is allowed when directly replacing them with one owned route; do not use startup latency as justification for broad runtime refactors.
+Do not guess or parallelize registration. If it becomes a real blocker, first add per-component read-only timing/progress telemetry. Consolidating superseded forensic registrations is allowed because it reduces startup/diagnostic sprawl but must not be used as justification for a broad runtime refactor.
 
 ## Issue #82 — Stabilization Exit Gate
 
@@ -221,11 +245,12 @@ Already satisfied/prospectively contained:
 - sane fresh-day initialization on authoritative v2 service
 - #105 symmetric favorable/adverse quote-integrity containment
 - exact immutable provenance for TEM, SLS, and three TOST bad executions
+- #110 one owned consolidated recovery gate replacing manual per-event forensic sprawl.
 
 Still required:
-1. get the consolidated five-execution verified-v2 recovery gate mechanically complete;
+1. obtain the automated consolidated-gate runtime result and prove it mechanically complete;
 2. perform any economic recovery only through an exact-signature, archived, validation-hold successor migration; never manual edits;
-3. leave the current-day halt/peak untouched unless a separate exact evidence boundary explicitly authorizes correction;
+3. leave current-day halt/peak untouched unless a separate exact evidence boundary explicitly authorizes correction;
 4. obtain a sane next fresh-risk-day initialization from corrected economics;
 5. obtain one normal forward paper market session with runner/accounting/ledger/market-data/quote-integrity/execution healthy and no new accounting category;
 6. obtain a clean active audit with sane valuation, valid canonical chain, no active economic/coverage issue except archived predecessor evidence, and risk reflecting actual economics;
@@ -239,7 +264,7 @@ Merged shadow/parity stages:
 - #90 Stage C canonical risk engine shadow parity
 - #91 Stage D StateStore transaction boundary
 - #92 Stage E ledger-derived accounting projection
-- #93 Stage F bounded paper-canary planner, shadow only
+- #93 Stage F bounded paper-canary planner, shadow only.
 
 Stage G/cutover remains blocked by #82. Do not use shadow core to bypass stabilization.
 
@@ -253,9 +278,9 @@ PR #95 established the exact-head Change Safety Audit. Every relevant PR must pa
 - typed configuration parity
 - architecture-debt regression gate
 - exact Gunicorn bootstrap smoke
-- final exact-head decision
+- final exact-head decision.
 
-Later focused extensions cover provenance, day-peak, price-integrity, SLS recovery proof, and verified-v2 successor replay. Repository branch protection on `main` was still not enabled when last checked; the in-repo gate remains mandatory regardless.
+Later focused extensions cover verified-snapshot provenance, day-peak provenance, price integrity, SLS recovery proof, verified-v2 successor replay, and now automatic runtime-research recovery-gate capture. Repository branch protection on `main` was still not enabled when last checked; the in-repo gate remains mandatory regardless.
 
 ## Self-Diagnosing Sentinel / Issue #96
 
@@ -263,7 +288,7 @@ PR #97 remains advisory/shadow only. It may classify incidents and recommend tes
 
 ## Architecture Program
 
-Aug. 20 master audit baseline: about 250 Python files / 90,409 LOC, 34 runtime mutation overlaps, 5 env conflicts, 5 route overlaps, 80 duplicate-function groups, 540 broad exception-pass sites, 8 watchdog loops, 32 critical findings.
+Aug. 20 audit baseline: about 250 Python files / 90,409 LOC, 34 runtime mutation overlaps, 5 env conflicts, 5 route overlaps, 80 duplicate-function groups, 540 broad exception-pass sites, 8 watchdog loops, 32 critical findings.
 
 Canonical owners remain:
 - signals → `trading.signals.SignalEngine`
@@ -275,20 +300,20 @@ Canonical owners remain:
 - market data → `trading.market_data.MarketDataAdapter`
 - cycle runtime → `trading.runtime.CycleOrchestrator`
 - rotations → `trading.decision.RotationPolicy`
-- market regime → `trading.market.MarketRegimeService`
+- market regime → `trading.market.MarketRegimeService`.
 
 No big-bang rewrite. Cut over one authority boundary at a time after parity/proof and delete the legacy owner only afterward.
 
 ## Known CI / Ops Debt
 
-A separate `daily-operational-audit` workflow remains red from stale expectations that predate current runtime behavior:
+A separate `daily-operational-audit` workflow remains red from stale expectations predating current runtime behavior:
 1. old next-action/recursion fixture ordering;
 2. curated audit fixture expecting `pass` instead of current `warn`;
 3. bootstrap overlay expecting obsolete `v6-registration-heartbeat` while production is v7.
 
 Treat this as #94 governance debt. Do not change runtime accounting/risk/strategy to satisfy stale fixtures.
 
-## Current Runtime Links
+## Current Runtime / Automated Evidence Links
 
 Authoritative v2 service:
 - bootstrap: `https://web-production-e1796.up.railway.app/bootstrap-status`
@@ -297,10 +322,12 @@ Authoritative v2 service:
 - canonical ledger: `https://web-production-e1796.up.railway.app/paper/canonical-execution-ledger-status`
 - quote-integrity: `https://web-production-e1796.up.railway.app/paper/exit-price-integrity-status`
 - day-peak provenance: `https://web-production-e1796.up.railway.app/paper/day-peak-provenance-status`
-- single consolidated recovery gate after current deploy: `https://web-production-e1796.up.railway.app/paper/verified-v2-successor-replay-status`
+- single consolidated recovery gate: `https://web-production-e1796.up.railway.app/paper/verified-v2-successor-replay-status`.
+
+The `.github/workflows/refactor-audit.yml` post-main-push runtime-research job already targets `web-production-e1796`; do not change it to the clean service. PR #111 makes its collector automatically include the consolidated recovery gate.
 
 Do not use `trading-bot-clean` as authoritative economic evidence until split-volume consolidation is separately designed and proven.
 
 ## Exact Next Action
 
-Finish the consolidated recovery-gate PR under the mandatory exact-head safety gate. After authoritative Railway deployment succeeds, the assistant should query `/paper/verified-v2-successor-replay-status` directly rather than asking the user to run another one-off test. If diagnosis is `verified_v2_consolidated_recovery_gate_mechanically_complete`, use that single result as the sole forensic runtime input for a bounded successor-state migration design under validation hold. Do not clear the current halt or rewrite `day_peak_equity` during that sequence.
+Finish PR #111 under the mandatory exact-head safety gate. Merge only if Change Safety, Architecture Debt, Repository Safety, full Refactor/Ownership/Config/Startup audit, focused runtime snapshot regression, and exact Gunicorn smoke are green. After merge and Railway deployment, inspect the uploaded `runtime-research-snapshot` artifact directly. If its recovery-gate diagnosis is `verified_v2_consolidated_recovery_gate_mechanically_complete`, proceed directly to a bounded exact-signature successor-state migration design under validation hold. Do not ask the user to run another per-event forensic test, do not clear the current halt, and do not rewrite `day_peak_equity`.

--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-VERSION = "change-safety-audit-2026-08-21-v8-successor-replay"
+VERSION = "change-safety-audit-2026-08-21-v9-runtime-research-recovery-gate"
 
 CORE_TESTS = (
     "test_architecture_stage_b.py",
@@ -42,6 +42,7 @@ PRICE_INTEGRITY_TESTS = (
 )
 SLS_RECOVERY_PROOF_TESTS = ("test_sls_bad_execution_recovery_proof.py",)
 SUCCESSOR_REPLAY_TESTS = ("test_verified_v2_successor_replay_status.py",)
+RUNTIME_RESEARCH_SNAPSHOT_TESTS = ("test_runtime_research_snapshot.py",)
 
 
 @dataclass(frozen=True)
@@ -90,6 +91,10 @@ def _is_successor_replay_path(path: str) -> bool:
     return "verified_v2_successor_replay" in path.lower()
 
 
+def _is_runtime_research_snapshot_path(path: str) -> bool:
+    return "runtime_research_snapshot" in path.lower()
+
+
 def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ...]]:
     categories: set[str] = set()
     boundaries: set[str] = set()
@@ -128,6 +133,9 @@ def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ..
         if _is_sls_recovery_proof_path(path) or _is_successor_replay_path(path):
             categories.update(("state_persistence", "accounting_execution", "risk"))
             boundaries.update(("state", "accounting", "execution", "risk"))
+        if _is_runtime_research_snapshot_path(path):
+            categories.add("runtime_observability")
+            boundaries.add("runtime_observability")
         if "risk" in path:
             categories.add("risk")
             boundaries.add("risk")
@@ -167,6 +175,8 @@ def planned_regressions(paths: Iterable[str]) -> tuple[str, ...]:
         tests.extend(SLS_RECOVERY_PROOF_TESTS)
     if any(_is_successor_replay_path(path) for path in path_tuple):
         tests.extend(SUCCESSOR_REPLAY_TESTS)
+    if any(_is_runtime_research_snapshot_path(path) for path in path_tuple):
+        tests.extend(RUNTIME_RESEARCH_SNAPSHOT_TESTS)
     existing: list[str] = []
     seen: set[str] = set()
     for test in tests:

--- a/runtime_research_snapshot.py
+++ b/runtime_research_snapshot.py
@@ -3,7 +3,8 @@
 
 The collector performs concurrent GET requests only. It never calls authenticated
 cycle routes, initiates research, changes policy, mutates paper state, or places
-orders.
+orders. The authoritative verified-v2 recovery gate is captured automatically so
+manual per-event forensic requests are not required after each deployment.
 """
 from __future__ import annotations
 
@@ -15,14 +16,15 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
-DEFAULT_BASE_URL = "https://trading-bot-clean.up.railway.app"
-VERSION = "runtime-research-snapshot-2026-08-03-v3-bootstrap-aware"
+DEFAULT_BASE_URL = "https://web-production-e1796.up.railway.app"
+VERSION = "runtime-research-snapshot-2026-08-21-v4-recovery-gate"
 
 ENDPOINTS = {
     "bootstrap_status": "/bootstrap-status",
     "root": "/",
     "paper_status": "/paper/status",
     "self_check": "/paper/self-check",
+    "verified_v2_recovery_gate": "/paper/verified-v2-successor-replay-status",
     "v1_status": "/paper/performance-audit-status",
     "v2_status": "/paper/performance-audit-v2-status",
     "v2_ablation": "/paper/performance-ablation-v2",
@@ -47,7 +49,7 @@ def _fetch_json(url: str, retries: int, timeout: float) -> dict[str, Any]:
                 url,
                 headers={
                     "Accept": "application/json",
-                    "User-Agent": "Trading-bot-read-only-research-snapshot/3.0",
+                    "User-Agent": "Trading-bot-read-only-research-snapshot/4.0",
                 },
                 method="GET",
             )
@@ -104,11 +106,40 @@ def _profile_summary(payload: dict[str, Any]) -> dict[str, Any]:
     return output
 
 
+def _recovery_gate_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    readiness = _dict(payload.get("recovery_readiness"))
+    ledger = _dict(payload.get("ledger"))
+    comparison = _dict(payload.get("state_comparison"))
+    projection = _dict(payload.get("projection"))
+    return {
+        "overall": payload.get("overall"),
+        "version": payload.get("version"),
+        "diagnosis": payload.get("diagnosis"),
+        "generated_local": payload.get("generated_local"),
+        "ledger_row_count": ledger.get("row_count"),
+        "chain_valid": ledger.get("chain_valid"),
+        "known_invalid_execution_count": payload.get("known_invalid_execution_count"),
+        "all_known_invalid_signatures_exact": payload.get("all_known_invalid_signatures_exact"),
+        "latest_invalid_is_last_canonical_execution": payload.get("latest_invalid_is_last_canonical_execution"),
+        "projection_complete": projection.get("projection_complete"),
+        "candidate_cash": projection.get("candidate_cash"),
+        "candidate_equity_using_current_stored_marks": comparison.get("candidate_equity_using_current_stored_marks"),
+        "unexplained_position_mismatches": comparison.get("unexplained_position_mismatches"),
+        "mechanically_complete_for_successor_migration_design": readiness.get("mechanically_complete_for_successor_migration_design"),
+        "manual_per_event_probe_required": readiness.get("manual_per_event_probe_required"),
+        "state_write_authorized_by_probe": readiness.get("state_write_authorized_by_this_probe"),
+        "halt_clear_authorized_by_probe": readiness.get("halt_clear_authorized_by_this_probe"),
+        "risk_peak_repair_authorized_by_probe": readiness.get("risk_peak_repair_authorized_by_this_probe"),
+    }
+
+
 def _summarize(raw: dict[str, dict[str, Any]]) -> dict[str, Any]:
     bootstrap_payload = _dict(_dict(raw.get("bootstrap_status")).get("payload"))
     root_payload = _dict(_dict(raw.get("root")).get("payload"))
     paper_payload = _dict(_dict(raw.get("paper_status")).get("payload"))
     self_payload = _dict(_dict(raw.get("self_check")).get("payload"))
+    recovery_payload = _dict(_dict(raw.get("verified_v2_recovery_gate")).get("payload"))
+    recovery_gate = _recovery_gate_summary(recovery_payload)
     v1_payload = _dict(_dict(raw.get("v1_status")).get("payload"))
     v2_payload = _dict(_dict(raw.get("v2_status")).get("payload"))
     latest = _dict(v2_payload.get("latest"))
@@ -134,6 +165,7 @@ def _summarize(raw: dict[str, dict[str, Any]]) -> dict[str, Any]:
     )
     application_ready = bool(delegate_ready and ("paper_status" in reachable or "self_check" in reachable))
     self_overall = self_payload.get("overall")
+    recovery_overall = recovery_payload.get("overall")
     v2_run_status = v2_payload.get("run_status") or latest.get("status") or "unknown"
 
     if not listener_reachable:
@@ -141,6 +173,8 @@ def _summarize(raw: dict[str, dict[str, Any]]) -> dict[str, Any]:
     elif not application_ready:
         overall = "warn"
     elif self_overall not in {None, "pass"}:
+        overall = "warn"
+    elif recovery_overall not in {None, "pass"}:
         overall = "warn"
     elif str(v2_run_status).lower() == "error" or failures:
         overall = "warn"
@@ -178,6 +212,7 @@ def _summarize(raw: dict[str, dict[str, Any]]) -> dict[str, Any]:
             "last_success": _dict(self_payload.get("auto_runner")).get("last_success"),
             "runtime_shadow_capture": _dict(_dict(self_payload.get("component_checks")).get("runtime_shadow_capture")),
         },
+        "recovery_gate": recovery_gate,
         "v1": {
             "version": v1_payload.get("version"),
             "enabled": v1_payload.get("enabled"),
@@ -219,6 +254,7 @@ def _markdown(report: dict[str, Any]) -> str:
     summary = _dict(report.get("summary"))
     connectivity = _dict(summary.get("connectivity"))
     self_check = _dict(summary.get("self_check"))
+    recovery_gate = _dict(summary.get("recovery_gate"))
     v1 = _dict(summary.get("v1"))
     v2 = _dict(summary.get("v2"))
     ablation = _dict(summary.get("ablation"))
@@ -244,6 +280,20 @@ def _markdown(report: dict[str, Any]) -> str:
         f"- Equity: `{self_check.get('equity')}`",
         f"- Failing components: `{self_check.get('failing_components')}`",
         f"- Runtime shadow capture: `{self_check.get('runtime_shadow_capture')}`",
+        "",
+        "## Verified-v2 Recovery Gate",
+        "",
+        f"- Overall: `{recovery_gate.get('overall')}`",
+        f"- Diagnosis: `{recovery_gate.get('diagnosis')}`",
+        f"- Version: `{recovery_gate.get('version')}`",
+        f"- Ledger rows / chain: `{recovery_gate.get('ledger_row_count')}` / `{recovery_gate.get('chain_valid')}`",
+        f"- Invalid signatures exact: `{recovery_gate.get('all_known_invalid_signatures_exact')}`",
+        f"- Projection complete: `{recovery_gate.get('projection_complete')}`",
+        f"- Mechanically complete: `{recovery_gate.get('mechanically_complete_for_successor_migration_design')}`",
+        f"- Manual per-event probe required: `{recovery_gate.get('manual_per_event_probe_required')}`",
+        f"- Candidate cash: `{recovery_gate.get('candidate_cash')}`",
+        f"- Candidate equity from stored marks: `{recovery_gate.get('candidate_equity_using_current_stored_marks')}`",
+        f"- Unexplained position mismatches: `{recovery_gate.get('unexplained_position_mismatches')}`",
         "",
         "## Research V1",
         "",

--- a/test_change_safety_audit.py
+++ b/test_change_safety_audit.py
@@ -170,6 +170,23 @@ class ChangeSafetyAuditTests(unittest.TestCase):
         ):
             self.assertIn(core_test, tests)
 
+    def test_runtime_research_snapshot_change_selects_automatic_capture_regression(self) -> None:
+        path = "runtime_research_snapshot.py"
+        categories, boundaries = classify_paths((path,))
+        tests = planned_regressions((path,))
+
+        self.assertIn("runtime_observability", categories)
+        self.assertIn("runtime_observability", boundaries)
+        self.assertIn("test_runtime_research_snapshot.py", tests)
+        for core_test in (
+            "test_architecture_stage_b.py",
+            "test_architecture_stage_c.py",
+            "test_architecture_stage_d_state_store.py",
+            "test_architecture_stage_e_accounting.py",
+            "test_architecture_stage_f_canary.py",
+        ):
+            self.assertIn(core_test, tests)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_runtime_research_snapshot.py
+++ b/test_runtime_research_snapshot.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import unittest
+
+import runtime_research_snapshot as snapshot
+
+
+class RuntimeResearchSnapshotTests(unittest.TestCase):
+    def _raw(self, recovery_overall="pass"):
+        raw = {
+            name: {"status": "ok", "payload": {}}
+            for name in snapshot.ENDPOINTS
+        }
+        raw["bootstrap_status"]["payload"] = {
+            "status": "ready",
+            "delegate_ready": True,
+        }
+        raw["root"]["payload"] = {"status": "ok", "delegate_ready": True}
+        raw["paper_status"]["payload"] = {"status": "ok"}
+        raw["self_check"]["payload"] = {
+            "overall": "pass",
+            "version": "self-check-test",
+            "summary": {"components_checked": 9, "failing_components": []},
+            "account": {"cash": 100.0, "equity": 101.0, "positions": []},
+            "auto_runner": {"last_success": "now"},
+        }
+        raw["verified_v2_recovery_gate"]["payload"] = {
+            "overall": recovery_overall,
+            "version": "gate-test",
+            "diagnosis": (
+                "verified_v2_consolidated_recovery_gate_mechanically_complete"
+                if recovery_overall == "pass"
+                else "known_invalid_execution_signature_not_exact_recovery_gate_blocked"
+            ),
+            "known_invalid_execution_count": 5,
+            "all_known_invalid_signatures_exact": recovery_overall == "pass",
+            "latest_invalid_is_last_canonical_execution": True,
+            "ledger": {"row_count": 39, "chain_valid": True},
+            "projection": {
+                "projection_complete": recovery_overall == "pass",
+                "candidate_cash": 12759.65,
+            },
+            "state_comparison": {
+                "candidate_equity_using_current_stored_marks": 13178.63,
+                "unexplained_position_mismatches": [],
+            },
+            "recovery_readiness": {
+                "mechanically_complete_for_successor_migration_design": recovery_overall == "pass",
+                "manual_per_event_probe_required": False,
+                "state_write_authorized_by_this_probe": False,
+                "halt_clear_authorized_by_this_probe": False,
+                "risk_peak_repair_authorized_by_this_probe": False,
+            },
+        }
+        raw["v2_status"]["payload"] = {"run_status": "idle"}
+        return raw
+
+    def test_authoritative_default_and_recovery_gate_endpoint_are_canonical(self):
+        self.assertEqual(
+            snapshot.DEFAULT_BASE_URL,
+            "https://web-production-e1796.up.railway.app",
+        )
+        self.assertEqual(
+            snapshot.ENDPOINTS["verified_v2_recovery_gate"],
+            "/paper/verified-v2-successor-replay-status",
+        )
+
+    def test_recovery_gate_is_compacted_into_automatic_runtime_summary(self):
+        summary = snapshot._summarize(self._raw("pass"))
+
+        self.assertEqual(summary["overall"], "pass")
+        gate = summary["recovery_gate"]
+        self.assertEqual(gate["overall"], "pass")
+        self.assertEqual(gate["ledger_row_count"], 39)
+        self.assertEqual(gate["known_invalid_execution_count"], 5)
+        self.assertTrue(gate["all_known_invalid_signatures_exact"])
+        self.assertTrue(gate["mechanically_complete_for_successor_migration_design"])
+        self.assertFalse(gate["manual_per_event_probe_required"])
+        self.assertFalse(gate["state_write_authorized_by_probe"])
+        self.assertFalse(gate["halt_clear_authorized_by_probe"])
+        self.assertFalse(gate["risk_peak_repair_authorized_by_probe"])
+
+    def test_failed_recovery_gate_warns_snapshot_without_mutation_or_error_exit_class(self):
+        summary = snapshot._summarize(self._raw("fail"))
+
+        self.assertEqual(summary["overall"], "warn")
+        gate = summary["recovery_gate"]
+        self.assertEqual(gate["overall"], "fail")
+        self.assertFalse(gate["mechanically_complete_for_successor_migration_design"])
+        self.assertFalse(gate["manual_per_event_probe_required"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue #82 / #94 validation consolidation. Extends the existing read-only runtime research snapshot so main-push evidence automatically captures and compacts `/paper/verified-v2-successor-replay-status` from the authoritative `web-production-e1796` service. Adds focused snapshot regressions and teaches the mandatory exact-head Change Safety Audit to select them. This is intended to eliminate repeated user-run per-event forensic tests. GET-only/reporting-only: no paper state write, ledger mutation, halt clear, risk-peak rewrite, order, strategy, thresholds, sizing, hard-risk, live, or ML authority change. Merge only after exact-head Change Safety, Repository Safety, Architecture Debt, full Refactor/Ownership/Config/Startup, and exact Gunicorn smoke are green.