### PR TITLE
Extend consolidated recovery gate for UCTT defects

### DIFF
--- a/test_verified_v2_successor_replay_status.py
+++ b/test_verified_v2_successor_replay_status.py
@@ -41,7 +41,7 @@ class FakeCore:
         }
 
     def local_ts_text(self):
-        return "2026-08-21 16:40:00 CDT"
+        return "2026-08-21 17:10:00 CDT"
 
 
 def _row(
@@ -53,6 +53,7 @@ def _row(
     shares,
     recorded_local,
     exit_reason=None,
+    event_hash=None,
 ):
     return {
         "execution_id": execution_id,
@@ -64,11 +65,15 @@ def _row(
         "shares": shares,
         "recorded_local": recorded_local,
         "exit_reason": exit_reason,
-        "event_hash": f"hash-{execution_id}",
+        "event_hash": event_hash or f"hash-{execution_id}",
     }
 
 
-def _rows(sls_bad_price=replay.SLS_BAD_PRICE, tost_bad_2_price=190.244995):
+def _rows(
+    sls_bad_price=replay.SLS_BAD_PRICE,
+    tost_bad_2_price=190.244995,
+    uctt_partial_hash="c7e23d77ecc86e6521f702b814828815a9f17e8f697c9baf07490be0e96ee41b",
+):
     return [
         _row(
             "lrcx-valid-exit",
@@ -108,6 +113,47 @@ def _rows(sls_bad_price=replay.SLS_BAD_PRICE, tost_bad_2_price=190.244995):
             replay.TEM_DUPLICATE_QTY,
             "2026-08-14 08:48:37 CDT",
             "stop_loss",
+        ),
+        _row(
+            "uctt-entry",
+            "entry",
+            "UCTT",
+            "long",
+            93.22,
+            17.410757,
+            "2026-08-13 11:01:06 CDT",
+        ),
+        _row(
+            replay.UCTT_BAD_PARTIAL_EXECUTION_ID,
+            "partial_exit",
+            "UCTT",
+            "long",
+            337.54,
+            5.74555,
+            "2026-08-13 14:37:13 CDT",
+            "partial_profit_long",
+            uctt_partial_hash,
+        ),
+        _row(
+            "uctt-valid-exit",
+            "exit",
+            "UCTT",
+            "long",
+            94.025,
+            11.665207,
+            "2026-08-13 14:45:10 CDT",
+            "normal_exit",
+        ),
+        _row(
+            replay.UCTT_BAD_DUPLICATE_EXIT_EXECUTION_ID,
+            "exit",
+            "UCTT",
+            "long",
+            39.145,
+            11.665207,
+            "2026-08-13 14:59:04 CDT",
+            "stop_loss",
+            "d928b227f1f800b38e1b31fed9c35c9e62f2417f58c28b2d602a7c4104b71812",
         ),
         _row(
             "sls-entry",
@@ -177,12 +223,12 @@ def _payload(rows):
         return replay.status_payload(FakeCore())
 
 
-def test_consolidated_gate_excludes_exact_five_invalid_rows_and_replays_everything_else():
+def test_consolidated_gate_excludes_exact_seven_invalid_rows_and_replays_everything_else():
     payload = _payload(_rows())
 
     assert payload["overall"] == "pass"
     assert payload["diagnosis"] == "verified_v2_consolidated_recovery_gate_mechanically_complete"
-    assert payload["known_invalid_execution_count"] == 5
+    assert payload["known_invalid_execution_count"] == 7
     assert payload["all_known_invalid_signatures_exact"] is True
     assert payload["latest_invalid_is_last_canonical_execution"] is True
     assert payload["canonical_rows_after_last_known_invalid_count"] == 0
@@ -190,6 +236,8 @@ def test_consolidated_gate_excludes_exact_five_invalid_rows_and_replays_everythi
     disposition = payload["known_invalid_execution_disposition"]
     assert set(disposition) == {
         "tem_duplicate",
+        "uctt_bad_partial_exit",
+        "uctt_bad_duplicate_exit",
         "sls_bad_partial_exit",
         "tost_bad_partial_exit_1",
         "tost_bad_partial_exit_2",
@@ -200,9 +248,10 @@ def test_consolidated_gate_excludes_exact_five_invalid_rows_and_replays_everythi
 
     projection = payload["projection"]
     assert projection["projection_complete"] is True
-    assert projection["applied_execution_count"] == 5
-    assert projection["excluded_execution_count"] == 5
+    assert projection["applied_execution_count"] == 7
+    assert projection["excluded_execution_count"] == 7
     projected = {row["symbol"]: row for row in projection["candidate_positions"]}
+    assert abs(projected["UCTT"]["shares"] - 5.74555) < 1e-9
     assert abs(projected["SLS"]["shares"] - 6.497144521) < 1e-9
     assert abs(projected["TOST"]["shares"] - 3.767684364) < 1e-9
 
@@ -230,6 +279,18 @@ def test_tem_canonical_precision_is_exact_and_display_rounding_is_not_accepted_a
     rounded = _payload(rounded_rows)
     assert rounded["overall"] == "fail"
     assert rounded["known_invalid_execution_disposition"]["tem_duplicate"]["failed_checks"] == ["price"]
+
+
+def test_uctt_partial_uses_exact_canonical_event_hash_and_economic_signature():
+    payload = _payload(_rows())
+    uctt = payload["known_invalid_execution_disposition"]["uctt_bad_partial_exit"]
+    assert uctt["signature_exact"] is True
+    assert uctt["failed_checks"] == []
+
+    changed = _payload(_rows(uctt_partial_hash="wrong-hash"))
+    assert changed["overall"] == "fail"
+    assert changed["known_invalid_execution_disposition"]["uctt_bad_partial_exit"]["failed_checks"] == ["event_hash"]
+    assert changed["projection"]["projection_complete"] is False
 
 
 def test_sls_signature_mismatch_fails_closed_before_projection():

--- a/verified_v2_successor_replay_status.py
+++ b/verified_v2_successor_replay_status.py
@@ -1,16 +1,18 @@
 """Consolidated read-only recovery gate for the verified v2 paper epoch.
 
-Issue #82 now has five immutable canonical executions with durable evidence that
+Issue #82 now has seven immutable canonical executions with durable evidence that
 their economic effects must not be used in a successor projection:
 
 * TEM duplicate full exit ``3530dbf965db4894ba93b7098cec3696``;
+* two UCTT invalid exits, including a catastrophic favorable partial exit and a
+  later unmatched/adverse exit inconsistent with independent market evidence;
 * SLS catastrophic favorable partial exit ``b6584fe0e28744d8bfa2da26f413af70``;
 * three TOST catastrophic favorable partial exits recorded after the SLS event.
 
 The canonical ledger remains immutable. This module verifies the hash chain and
 exact row signatures, starts from the mechanically verified 2026-08-12 v2
-baseline, excludes only the five proven-invalid economic effects, and replays
-every other canonical execution in original order.
+baseline, excludes only the proven-invalid economic effects, and replays every
+other canonical execution in original order.
 
 This is the single compact forensic/recovery gate. It never writes state, edits
 or relabels ledger rows, fabricates replacement fills, clears a halt, rewrites
@@ -23,7 +25,7 @@ import datetime as dt
 import math
 from typing import Any, Dict, List, Tuple
 
-VERSION = "verified-v2-successor-replay-status-2026-08-21-v2-consolidated-five-invalid"
+VERSION = "verified-v2-successor-replay-status-2026-08-21-v3-consolidated-seven-invalid"
 ROUTE = "/paper/verified-v2-successor-replay-status"
 TARGET_EPOCH_ID = "stable-paper-v2-20260812-verified01"
 TODAY = "2026-08-21"
@@ -35,6 +37,8 @@ BASELINE_LRCX_ENTRY = 312.90
 TEM_DUPLICATE_EXECUTION_ID = "3530dbf965db4894ba93b7098cec3696"
 TEM_DUPLICATE_PRICE = 52.904999
 TEM_DUPLICATE_QTY = 29.640567
+UCTT_BAD_PARTIAL_EXECUTION_ID = "e604e478d0df47ed9c7da1c7b290cba8"
+UCTT_BAD_DUPLICATE_EXIT_EXECUTION_ID = "b8062fa9c2464251b661957d0694bbfa"
 SLS_BAD_EXECUTION_ID = "b6584fe0e28744d8bfa2da26f413af70"
 SLS_BAD_PRICE = 186.2901
 SLS_BAD_QTY = 2.144057692
@@ -62,6 +66,34 @@ KNOWN_INVALID_EXECUTIONS: tuple[dict[str, Any], ...] = (
         "exit_reason": "stop_loss",
         "reason": "proven_duplicate_full_exit_retained_immutably_but_excluded_from_counterfactual_economics",
         "evidence": "prior_full_exit_closed_the_same_long_quantity_before_this_row",
+    },
+    {
+        "key": "uctt_bad_partial_exit",
+        "execution_id": UCTT_BAD_PARTIAL_EXECUTION_ID,
+        "accounting_epoch_id": TARGET_EPOCH_ID,
+        "action": "partial_exit",
+        "symbol": "UCTT",
+        "side": "long",
+        "price": 337.54,
+        "shares": 5.74555,
+        "event_hash": "c7e23d77ecc86e6521f702b814828815a9f17e8f697c9baf07490be0e96ee41b",
+        "reason": "proven_catastrophic_quote_outlier_retained_immutably_but_excluded_from_counterfactual_economics",
+        "evidence": "independent_alpaca_iex_one_minute_bars_near_94_at_2026-08-13T19:37Z_and_no_split",
+    },
+    {
+        "key": "uctt_bad_duplicate_exit",
+        "execution_id": UCTT_BAD_DUPLICATE_EXIT_EXECUTION_ID,
+        "accounting_epoch_id": TARGET_EPOCH_ID,
+        "action": "exit",
+        "symbol": "UCTT",
+        "side": "long",
+        "price": 39.145,
+        "shares": 11.665207,
+        "recorded_local": "2026-08-13 14:59:04 CDT",
+        "exit_reason": "stop_loss",
+        "event_hash": "d928b227f1f800b38e1b31fed9c35c9e62f2417f58c28b2d602a7c4104b71812",
+        "reason": "proven_unmatched_duplicate_and_catastrophic_quote_outlier_retained_immutably_but_excluded_from_counterfactual_economics",
+        "evidence": "prior_valid_uctt_exit_closed_the_remaining_quantity_and_independent_alpaca_iex_quote_at_2026-08-13T19:59:04Z_was_93.10x93.23_with_no_split",
     },
     {
         "key": "sls_bad_partial_exit",
@@ -175,7 +207,7 @@ def _row_view(row: Dict[str, Any], index: int | None = None) -> Dict[str, Any]:
 
 
 def _signature_checks(row: Dict[str, Any], expected: Dict[str, Any]) -> Dict[str, bool]:
-    return {
+    checks = {
         "execution_id": str(row.get("execution_id") or "") == str(expected["execution_id"]),
         "accounting_epoch_id": str(row.get("accounting_epoch_id") or "") == str(expected["accounting_epoch_id"]),
         "action": str(row.get("action") or "").lower() == str(expected["action"]),
@@ -183,9 +215,14 @@ def _signature_checks(row: Dict[str, Any], expected: Dict[str, Any]) -> Dict[str
         "side": str(row.get("side") or "long").lower() == str(expected["side"]),
         "price": _close(row.get("price"), float(expected["price"]), PRICE_TOLERANCE),
         "shares": _close(row.get("shares", row.get("qty")), float(expected["shares"]), QTY_TOLERANCE),
-        "recorded_local": str(row.get("recorded_local") or "") == str(expected["recorded_local"]),
-        "exit_reason": str(row.get("exit_reason") or "") == str(expected["exit_reason"]),
     }
+    if "recorded_local" in expected:
+        checks["recorded_local"] = str(row.get("recorded_local") or "") == str(expected["recorded_local"])
+    if "exit_reason" in expected:
+        checks["exit_reason"] = str(row.get("exit_reason") or "") == str(expected["exit_reason"])
+    if "event_hash" in expected:
+        checks["event_hash"] = str(row.get("event_hash") or "") == str(expected["event_hash"])
+    return checks
 
 
 def _signature_exact(row: Dict[str, Any], expected: Dict[str, Any]) -> bool:
@@ -697,7 +734,7 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "recovery_readiness": {
             "counterfactual_successor_projection_mechanically_reproducible": bool(projection.get("projection_complete")),
             "all_canonical_rows_accounted_for": bool(projection.get("projection_complete")),
-            "all_five_known_invalid_rows_exact": all_invalid_signatures_exact,
+            "all_seven_known_invalid_rows_exact": all_invalid_signatures_exact,
             "latest_known_invalid_is_terminal": latest_invalid_is_last_canonical_execution,
             "only_known_invalid_symbols_explain_position_differences": bool(comparison.get("only_known_invalid_symbols_differ", False)),
             "mechanically_complete_for_successor_migration_design": mechanically_complete,


### PR DESCRIPTION
Issue #82 accounting/recovery evidence follow-up. The automated consolidated recovery snapshot on main stopped at canonical UCTT execution `b8062fa9c2464251b661957d0694bbfa` (`11.665207 @ 39.145`, 2026-08-13 14:59:04 CDT) because it exceeded the replayed UCTT position. Existing preserved v2 evidence also contains UCTT partial execution `e604e478d0df47ed9c7da1c7b290cba8` (`5.74555 @ 337.54`) followed by a normal `11.665207 @ 94.025` exit. Independent Alpaca IEX evidence for the incident window shows UCTT around 93–94, including 19:59:04Z bid/ask 93.10/93.23, one-minute bars near 94, and no forward/reverse/unit split. This PR folds those two proven-invalid UCTT economic effects into the same immutable-ledger counterfactual gate; it does not add another runtime endpoint. The UCTT partial is pinned by execution ID + canonical event hash + economic fields; the later UCTT exit is pinned by full metadata + canonical event hash. Existing five invalid rows remain exact. No state write, ledger edit/relabel/delete, replacement fill, halt clear, day-peak rewrite, order, strategy/threshold/sizing/hard-risk/live/ML authority change. Merge only after exact-head Change Safety, focused replay regression, Repository Safety, Architecture Debt, Refactor/Ownership/Config/Startup, and exact Gunicorn smoke are all green.