### PR TITLE
Use exact canonical precision for UCTT recovery signature

### DIFF
--- a/test_verified_v2_successor_replay_status.py
+++ b/test_verified_v2_successor_replay_status.py
@@ -41,7 +41,7 @@ class FakeCore:
         }
 
     def local_ts_text(self):
-        return "2026-08-21 17:10:00 CDT"
+        return "2026-08-21 17:20:00 CDT"
 
 
 def _row(
@@ -72,6 +72,8 @@ def _row(
 def _rows(
     sls_bad_price=replay.SLS_BAD_PRICE,
     tost_bad_2_price=190.244995,
+    uctt_partial_price=337.540009,
+    uctt_partial_shares=5.74554981,
     uctt_partial_hash="c7e23d77ecc86e6521f702b814828815a9f17e8f697c9baf07490be0e96ee41b",
 ):
     return [
@@ -128,8 +130,8 @@ def _rows(
             "partial_exit",
             "UCTT",
             "long",
-            337.54,
-            5.74555,
+            uctt_partial_price,
+            uctt_partial_shares,
             "2026-08-13 14:37:13 CDT",
             "partial_profit_long",
             uctt_partial_hash,
@@ -281,16 +283,22 @@ def test_tem_canonical_precision_is_exact_and_display_rounding_is_not_accepted_a
     assert rounded["known_invalid_execution_disposition"]["tem_duplicate"]["failed_checks"] == ["price"]
 
 
-def test_uctt_partial_uses_exact_canonical_event_hash_and_economic_signature():
+def test_uctt_partial_uses_exact_canonical_precision_and_event_hash():
     payload = _payload(_rows())
     uctt = payload["known_invalid_execution_disposition"]["uctt_bad_partial_exit"]
     assert uctt["signature_exact"] is True
     assert uctt["failed_checks"] == []
+    assert uctt["observed_row"]["price"] == 337.540009
+    assert uctt["observed_row"]["shares"] == 5.74554981
 
-    changed = _payload(_rows(uctt_partial_hash="wrong-hash"))
-    assert changed["overall"] == "fail"
-    assert changed["known_invalid_execution_disposition"]["uctt_bad_partial_exit"]["failed_checks"] == ["event_hash"]
-    assert changed["projection"]["projection_complete"] is False
+    rounded = _payload(_rows(uctt_partial_price=337.54, uctt_partial_shares=5.74555))
+    assert rounded["overall"] == "fail"
+    assert rounded["known_invalid_execution_disposition"]["uctt_bad_partial_exit"]["failed_checks"] == ["price", "shares"]
+
+    changed_hash = _payload(_rows(uctt_partial_hash="wrong-hash"))
+    assert changed_hash["overall"] == "fail"
+    assert changed_hash["known_invalid_execution_disposition"]["uctt_bad_partial_exit"]["failed_checks"] == ["event_hash"]
+    assert changed_hash["projection"]["projection_complete"] is False
 
 
 def test_sls_signature_mismatch_fails_closed_before_projection():

--- a/verified_v2_successor_replay_status.py
+++ b/verified_v2_successor_replay_status.py
@@ -25,7 +25,7 @@ import datetime as dt
 import math
 from typing import Any, Dict, List, Tuple
 
-VERSION = "verified-v2-successor-replay-status-2026-08-21-v3-consolidated-seven-invalid"
+VERSION = "verified-v2-successor-replay-status-2026-08-21-v4-uctt-canonical-precision"
 ROUTE = "/paper/verified-v2-successor-replay-status"
 TARGET_EPOCH_ID = "stable-paper-v2-20260812-verified01"
 TODAY = "2026-08-21"
@@ -74,11 +74,11 @@ KNOWN_INVALID_EXECUTIONS: tuple[dict[str, Any], ...] = (
         "action": "partial_exit",
         "symbol": "UCTT",
         "side": "long",
-        "price": 337.54,
-        "shares": 5.74555,
+        "price": 337.540009,
+        "shares": 5.74554981,
         "event_hash": "c7e23d77ecc86e6521f702b814828815a9f17e8f697c9baf07490be0e96ee41b",
         "reason": "proven_catastrophic_quote_outlier_retained_immutably_but_excluded_from_counterfactual_economics",
-        "evidence": "independent_alpaca_iex_one_minute_bars_near_94_at_2026-08-13T19:37Z_and_no_split",
+        "evidence": "exact_canonical_precision_from_automated_gate_plus_independent_alpaca_iex_one_minute_bars_near_94_at_2026-08-13T19:37Z_and_no_split",
     },
     {
         "key": "uctt_bad_duplicate_exit",


### PR DESCRIPTION
Issue #82 narrow follow-up to the automated settled runtime evidence from PR #112. The consolidated gate proved the UCTT invalid partial execution identity/event hash but failed closed only because the earlier displayed values were rounded. The authoritative canonical row is exactly `337.540009` and `5.74554981`; all other signature fields and the canonical event hash matched. This PR changes only those expected immutable signature constants and focused regression fixtures. It does not broaden tolerances, add a route, write state, edit/relabel/delete ledger rows, fabricate fills, clear the halt, rewrite the day peak, place orders, or change strategy/threshold/sizing/hard-risk/live/ML authority. Merge only after exact-head Change Safety, focused replay regression, Repository Safety, Architecture Debt, Refactor/Ownership/Config/Startup, and exact Gunicorn smoke are green.