### PR TITLE
Separate replay quantity serialization tolerance from strict signatures

### DIFF
--- a/test_verified_v2_replay_quantity_tolerance.py
+++ b/test_verified_v2_replay_quantity_tolerance.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import verified_v2_successor_replay_status as replay
+
+
+def _row(execution_id, action, symbol, side, price, shares, recorded_local, exit_reason=None):
+    return {
+        "execution_id": execution_id,
+        "accounting_epoch_id": replay.TARGET_EPOCH_ID,
+        "action": action,
+        "symbol": symbol,
+        "side": side,
+        "price": price,
+        "shares": shares,
+        "recorded_local": recorded_local,
+        "exit_reason": exit_reason,
+        "event_hash": f"hash-{execution_id}",
+    }
+
+
+def test_sub_micro_share_exit_residue_is_reconciled_only_in_replay_arithmetic():
+    rows = [
+        _row(
+            "qqq-entry",
+            "entry",
+            "QQQ",
+            "long",
+            700.0,
+            2.218802876,
+            "2026-08-19 09:30:00 CDT",
+        ),
+        _row(
+            "qqq-exit",
+            "exit",
+            "QQQ",
+            "long",
+            718.015015,
+            2.218803,
+            "2026-08-19 10:07:22 CDT",
+            "market_regime_protection",
+        ),
+    ]
+
+    projection = replay._project(rows)
+
+    assert projection["projection_complete"] is True
+    assert projection["errors"] == []
+    assert projection["quantity_residue_adjustment_count"] == 1
+    adjustment = projection["quantity_residue_adjustments"][0]
+    assert adjustment["execution_id"] == "qqq-exit"
+    assert 0 < adjustment["unmatched_qty"] < replay.REPLAY_QTY_TOLERANCE
+    assert adjustment["disposition"] == "accepted_as_canonical_quantity_serialization_residue_only"
+    assert all(row["symbol"] != "QQQ" for row in projection["candidate_positions"])
+
+
+def test_material_exit_quantity_gap_still_fails_closed():
+    rows = [
+        _row(
+            "qqq-entry",
+            "entry",
+            "QQQ",
+            "long",
+            700.0,
+            2.21879,
+            "2026-08-19 09:30:00 CDT",
+        ),
+        _row(
+            "qqq-exit",
+            "exit",
+            "QQQ",
+            "long",
+            718.015015,
+            2.218803,
+            "2026-08-19 10:07:22 CDT",
+            "market_regime_protection",
+        ),
+    ]
+
+    projection = replay._project(rows)
+
+    assert projection["projection_complete"] is False
+    assert projection["errors"][0]["reason"] == "exit_exceeds_projected_position"
+    assert projection["errors"][0]["unmatched_qty"] > replay.REPLAY_QTY_TOLERANCE
+
+
+def test_known_invalid_signature_quantity_tolerance_remains_strict():
+    expected = dict(replay.KNOWN_INVALID_EXECUTIONS[0])
+    observed = dict(expected)
+    observed["shares"] = float(expected["shares"]) + 1e-7
+
+    checks = replay._signature_checks(observed, expected)
+
+    assert replay.QTY_TOLERANCE == 5e-9
+    assert replay.REPLAY_QTY_TOLERANCE == 5e-6
+    assert replay.QTY_TOLERANCE < replay.REPLAY_QTY_TOLERANCE
+    assert checks["shares"] is False

--- a/verified_v2_successor_replay_status.py
+++ b/verified_v2_successor_replay_status.py
@@ -25,7 +25,7 @@ import datetime as dt
 import math
 from typing import Any, Dict, List, Tuple
 
-VERSION = "verified-v2-successor-replay-status-2026-08-21-v4-uctt-canonical-precision"
+VERSION = "verified-v2-successor-replay-status-2026-08-21-v5-replay-quantity-serialization-tolerance"
 ROUTE = "/paper/verified-v2-successor-replay-status"
 TARGET_EPOCH_ID = "stable-paper-v2-20260812-verified01"
 TODAY = "2026-08-21"
@@ -47,8 +47,11 @@ TOST_BAD_1_EXECUTION_ID = "fd685aa6387247ff99a05e7386c325e9"
 TOST_BAD_2_EXECUTION_ID = "cb10928f441148aaa3faf041a84bc4c8"
 TOST_BAD_3_EXECUTION_ID = "1451d91c06b34b199364b56f72ad376f"
 
+# Known-invalid row signatures remain exact. Replay arithmetic separately permits
+# only sub-five-micro-share residue caused by canonical quantity serialization.
 PRICE_TOLERANCE = 1e-9
 QTY_TOLERANCE = 5e-9
+REPLAY_QTY_TOLERANCE = 5e-6
 CASH_TOLERANCE = 2.0
 _REGISTERED_APP_IDS: set[int] = set()
 
@@ -276,6 +279,7 @@ def _project(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
     realized_today_delta = 0.0
     applied: List[Dict[str, Any]] = []
     excluded: List[Dict[str, Any]] = []
+    quantity_residue_adjustments: List[Dict[str, Any]] = []
     errors: List[Dict[str, Any]] = []
 
     for index, row in enumerate(rows):
@@ -322,7 +326,7 @@ def _project(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
         opposite = "short" if side == "long" else "long"
 
         if action == "entry":
-            if _book_qty(side_books[opposite]) > QTY_TOLERANCE:
+            if _book_qty(side_books[opposite]) > REPLAY_QTY_TOLERANCE:
                 errors.append(
                     {
                         "ledger_index": index,
@@ -353,7 +357,7 @@ def _project(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
         remaining = qty
         release = 0.0
         realized = 0.0
-        while remaining > QTY_TOLERANCE and book:
+        while remaining > REPLAY_QTY_TOLERANCE and book:
             lot_qty, lot_price = book[0]
             used = min(remaining, lot_qty)
             if side == "long":
@@ -365,21 +369,36 @@ def _project(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
                 realized += pnl
             lot_qty -= used
             remaining -= used
-            if lot_qty <= QTY_TOLERANCE:
+            if lot_qty <= REPLAY_QTY_TOLERANCE:
                 book.pop(0)
             else:
                 book[0][0] = lot_qty
 
-        if remaining > QTY_TOLERANCE:
+        if remaining > REPLAY_QTY_TOLERANCE:
             errors.append(
                 {
                     "ledger_index": index,
                     "reason": "exit_exceeds_projected_position",
                     "unmatched_qty": remaining,
+                    "replay_quantity_tolerance": REPLAY_QTY_TOLERANCE,
                     "row": _row_view(row, index),
                 }
             )
             break
+
+        if remaining > 0:
+            quantity_residue_adjustments.append(
+                {
+                    "ledger_index": index,
+                    "execution_id": execution_id,
+                    "symbol": symbol,
+                    "side": side,
+                    "action": action,
+                    "unmatched_qty": remaining,
+                    "tolerance": REPLAY_QTY_TOLERANCE,
+                    "disposition": "accepted_as_canonical_quantity_serialization_residue_only",
+                }
+            )
 
         cash += release
         realized_delta += realized
@@ -393,7 +412,7 @@ def _project(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
             open_sides = [
                 side
                 for side in ("long", "short")
-                if _book_qty(side_books[side]) > QTY_TOLERANCE
+                if _book_qty(side_books[side]) > REPLAY_QTY_TOLERANCE
             ]
             if len(open_sides) > 1:
                 errors.append({"reason": "opposing_books_remain", "symbol": symbol})
@@ -433,6 +452,9 @@ def _project(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
         "applied_execution_count": len(applied),
         "excluded_execution_count": len(excluded),
         "excluded_executions": excluded,
+        "replay_quantity_tolerance": REPLAY_QTY_TOLERANCE,
+        "quantity_residue_adjustment_count": len(quantity_residue_adjustments),
+        "quantity_residue_adjustments": quantity_residue_adjustments,
         "candidate_cash": round(cash, 9),
         "candidate_realized_delta_from_verified_baseline": round(realized_delta, 9),
         "candidate_realized_today_delta": round(realized_today_delta, 9),
@@ -738,6 +760,9 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
             "latest_known_invalid_is_terminal": latest_invalid_is_last_canonical_execution,
             "only_known_invalid_symbols_explain_position_differences": bool(comparison.get("only_known_invalid_symbols_differ", False)),
             "mechanically_complete_for_successor_migration_design": mechanically_complete,
+            "strict_invalid_signature_quantity_tolerance": QTY_TOLERANCE,
+            "replay_quantity_serialization_tolerance": REPLAY_QTY_TOLERANCE,
+            "replay_quantity_residue_adjustment_count": int(projection.get("quantity_residue_adjustment_count") or 0),
             "historical_execution_edit_required": False,
             "immutable_invalid_rows_must_remain_in_ledger": True,
             "state_write_authorized_by_this_probe": False,


### PR DESCRIPTION
Issue #82 narrow accounting-recovery follow-up. The automated settled consolidated recovery gate on main (`b5ab827a096e4695ca14e99586e1d730ca525bf4`) reached canonical QQQ exit `91a4c5f0038b48dd880011e9d33d37fb` and failed because the exit quantity exceeded the replayed position by only `1.2400000004575418e-07` shares. That is below the existing state-comparison tolerance and is canonical quantity serialization residue, not a new economic defect. This PR keeps known-invalid execution signatures strict at `5e-9`, adds a separate replay-only quantity residue tolerance of `5e-6`, records every accepted residue explicitly in the read-only projection, and continues to fail closed on larger quantity mismatches. It changes no ledger rows, account state, risk state, halt, day peak, strategy, thresholds, sizing, hard-risk, live, or ML authority. No new runtime endpoint is added. Merge only after exact-head Change Safety Audit, focused replay regressions, Repository Safety, Architecture Debt, Refactor/Ownership/Config/Startup, and exact Gunicorn smoke are green.