### PR TITLE
Add same-gate lineage evidence for unexplained positions

### DIFF
--- a/test_verified_v2_unexplained_position_lineage.py
+++ b/test_verified_v2_unexplained_position_lineage.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import copy
+
+import verified_v2_successor_replay_status as replay
+
+
+def _trade(execution_id, action, symbol, price=100.0, shares=1.0):
+    return {
+        "execution_id": execution_id,
+        "accounting_epoch_id": replay.TARGET_EPOCH_ID,
+        "action": action,
+        "symbol": symbol,
+        "side": "long",
+        "price": price,
+        "shares": shares,
+        "recorded_local": "2026-08-21 10:00:00 CDT",
+        "exit_reason": "normal_exit" if action != "entry" else None,
+        "event_hash": f"hash-{execution_id}",
+    }
+
+
+def test_state_only_exit_is_exposed_without_mutation():
+    ledger_rows = [_trade("crwd-entry", "entry", "CRWD")]
+    portfolio = {
+        "positions": {},
+        "trades": [
+            _trade("crwd-entry", "entry", "CRWD"),
+            _trade("crwd-state-only-exit", "exit", "CRWD", price=101.0),
+        ],
+    }
+    before_portfolio = copy.deepcopy(portfolio)
+    before_ledger = copy.deepcopy(ledger_rows)
+
+    lineage = replay._unexplained_position_lineage(portfolio, ledger_rows, ["CRWD"])
+    crwd = lineage["CRWD"]
+
+    assert crwd["state_only_exit_present"] is True
+    assert crwd["state_only_execution_ids"] == ["crwd-state-only-exit"]
+    assert crwd["ledger_only_execution_ids"] == []
+    assert crwd["interpretation"] == "state_contains_exit_execution_not_present_in_canonical_ledger"
+    assert portfolio == before_portfolio
+    assert ledger_rows == before_ledger
+
+
+def test_ledger_only_execution_is_exposed_without_state_only_exit():
+    ledger_rows = [_trade("panw-entry", "entry", "PANW")]
+    portfolio = {"positions": {}, "trades": []}
+
+    lineage = replay._unexplained_position_lineage(portfolio, ledger_rows, ["PANW"])
+    panw = lineage["PANW"]
+
+    assert panw["ledger_only_execution_present"] is True
+    assert panw["ledger_only_execution_ids"] == ["panw-entry"]
+    assert panw["state_only_exit_present"] is False
+    assert panw["interpretation"] == "ledger_and_state_execution_sets_differ_without_state_only_exit"
+
+
+def test_matching_execution_sets_but_missing_position_is_classified_separately():
+    entry = _trade("path-entry", "entry", "PATH")
+    ledger_rows = [entry]
+    portfolio = {"positions": {}, "trades": [copy.deepcopy(entry)]}
+
+    lineage = replay._unexplained_position_lineage(portfolio, ledger_rows, ["PATH"])
+    path = lineage["PATH"]
+
+    assert path["same_execution_id_sets"] is True
+    assert path["state_only_execution_ids"] == []
+    assert path["ledger_only_execution_ids"] == []
+    assert path["interpretation"] == "execution_id_sets_match_but_position_state_differs"
+
+
+def test_lineage_scope_is_only_requested_unexplained_symbols():
+    ledger_rows = [
+        _trade("snow-entry", "entry", "SNOW"),
+        _trade("other-entry", "entry", "OTHER"),
+    ]
+    portfolio = {"positions": {}, "trades": []}
+
+    lineage = replay._unexplained_position_lineage(portfolio, ledger_rows, ["SNOW"])
+
+    assert set(lineage) == {"SNOW"}
+    assert lineage["SNOW"]["ledger_execution_ids"] == ["snow-entry"]

--- a/verified_v2_successor_replay_status.py
+++ b/verified_v2_successor_replay_status.py
@@ -25,7 +25,7 @@ import datetime as dt
 import math
 from typing import Any, Dict, List, Tuple
 
-VERSION = "verified-v2-successor-replay-status-2026-08-21-v5-replay-quantity-serialization-tolerance"
+VERSION = "verified-v2-successor-replay-status-2026-08-21-v6-unexplained-position-lineage"
 ROUTE = "/paper/verified-v2-successor-replay-status"
 TARGET_EPOCH_ID = "stable-paper-v2-20260812-verified01"
 TODAY = "2026-08-21"
@@ -207,6 +207,23 @@ def _row_view(row: Dict[str, Any], index: int | None = None) -> Dict[str, Any]:
     if index is not None:
         out["ledger_index"] = index
     return out
+
+
+def _state_trade_view(row: Dict[str, Any], index: int) -> Dict[str, Any]:
+    return {
+        "state_trade_index": index,
+        "execution_id": row.get("execution_id"),
+        "accounting_epoch_id": row.get("accounting_epoch_id"),
+        "recorded_local": row.get("recorded_local"),
+        "time": row.get("time"),
+        "action": row.get("action"),
+        "symbol": row.get("symbol"),
+        "side": row.get("side"),
+        "price": _f(row.get("price")),
+        "shares": _f(row.get("shares", row.get("qty"))),
+        "exit_reason": row.get("exit_reason"),
+        "event_hash": row.get("event_hash"),
+    }
 
 
 def _signature_checks(row: Dict[str, Any], expected: Dict[str, Any]) -> Dict[str, bool]:
@@ -604,6 +621,75 @@ def _state_comparison(portfolio: Dict[str, Any], projection: Dict[str, Any]) -> 
     }
 
 
+def _unexplained_position_lineage(
+    portfolio: Dict[str, Any],
+    ledger_rows: List[Dict[str, Any]],
+    symbols: List[str],
+) -> Dict[str, Any]:
+    current_positions = _d(portfolio.get("positions"))
+    state_trades = [row for row in _l(portfolio.get("trades")) if isinstance(row, dict)]
+    output: Dict[str, Any] = {}
+
+    for raw_symbol in sorted(set(symbols)):
+        symbol = str(raw_symbol or "").upper()
+        if not symbol:
+            continue
+        ledger_matches = [
+            (index, row)
+            for index, row in enumerate(ledger_rows)
+            if str(row.get("symbol") or "").upper() == symbol
+        ]
+        state_matches = [
+            (index, row)
+            for index, row in enumerate(state_trades)
+            if str(row.get("symbol") or "").upper() == symbol
+        ]
+        ledger_ids = [str(row.get("execution_id") or "") for _, row in ledger_matches]
+        state_ids = [str(row.get("execution_id") or "") for _, row in state_matches]
+        ledger_id_set = {value for value in ledger_ids if value}
+        state_id_set = {value for value in state_ids if value}
+        state_only_rows = [
+            _state_trade_view(row, index)
+            for index, row in state_matches
+            if str(row.get("execution_id") or "") not in ledger_id_set
+        ]
+        ledger_only_rows = [
+            _row_view(row, index)
+            for index, row in ledger_matches
+            if str(row.get("execution_id") or "") not in state_id_set
+        ]
+        state_only_exit_rows = [
+            row
+            for row in state_only_rows
+            if str(row.get("action") or "").lower() in {"exit", "partial_exit"}
+        ]
+
+        output[symbol] = {
+            "current_position_exists": symbol in current_positions,
+            "ledger_row_count": len(ledger_matches),
+            "state_trade_row_count": len(state_matches),
+            "ledger_execution_ids": ledger_ids,
+            "state_execution_ids": state_ids,
+            "same_execution_id_sets": ledger_id_set == state_id_set,
+            "ledger_only_execution_ids": sorted(ledger_id_set - state_id_set),
+            "state_only_execution_ids": sorted(state_id_set - ledger_id_set),
+            "ledger_only_rows": ledger_only_rows,
+            "state_only_rows": state_only_rows,
+            "state_only_exit_rows": state_only_exit_rows,
+            "state_only_exit_present": bool(state_only_exit_rows),
+            "ledger_only_execution_present": bool(ledger_only_rows),
+            "interpretation": (
+                "state_contains_exit_execution_not_present_in_canonical_ledger"
+                if state_only_exit_rows
+                else "ledger_and_state_execution_sets_differ_without_state_only_exit"
+                if ledger_id_set != state_id_set
+                else "execution_id_sets_match_but_position_state_differs"
+            ),
+        }
+
+    return output
+
+
 def _known_invalid_disposition(rows: List[Dict[str, Any]]) -> tuple[Dict[str, Any], bool]:
     disposition: Dict[str, Any] = {}
     all_exact = True
@@ -700,6 +786,16 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         if ledger_ready and bool(projection.get("projection_complete"))
         else {}
     )
+    unexplained_symbols = [
+        str(symbol)
+        for symbol in _l(comparison.get("unexplained_position_mismatches"))
+        if symbol
+    ]
+    unexplained_lineage = (
+        _unexplained_position_lineage(portfolio, rows, unexplained_symbols)
+        if unexplained_symbols
+        else {}
+    )
 
     if not chain_valid or ledger_errors:
         diagnosis = "canonical_ledger_invalid_recovery_gate_blocked"
@@ -752,6 +848,7 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "canonical_rows_after_last_known_invalid_count": len(rows_after_last_invalid),
         "projection": projection,
         "state_comparison": comparison,
+        "unexplained_position_lineage": unexplained_lineage,
         "current_risk": _risk_snapshot(portfolio),
         "recovery_readiness": {
             "counterfactual_successor_projection_mechanically_reproducible": bool(projection.get("projection_complete")),
@@ -763,6 +860,7 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
             "strict_invalid_signature_quantity_tolerance": QTY_TOLERANCE,
             "replay_quantity_serialization_tolerance": REPLAY_QTY_TOLERANCE,
             "replay_quantity_residue_adjustment_count": int(projection.get("quantity_residue_adjustment_count") or 0),
+            "unexplained_position_lineage_in_same_gate": bool(unexplained_lineage),
             "historical_execution_edit_required": False,
             "immutable_invalid_rows_must_remain_in_ledger": True,
             "state_write_authorized_by_this_probe": False,
@@ -773,6 +871,8 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
             "next_step": (
                 "use this consolidated gate as the sole forensic runtime input for a bounded exact-signature successor-state migration under validation hold; do not request another per-event manual probe"
                 if mechanically_complete
+                else "inspect unexplained_position_lineage in this same consolidated gate; do not request another manual endpoint or mutate state or ledger"
+                if unexplained_lineage
                 else "stop at the named gate failure; do not mutate state or ledger"
             ),
         },


### PR DESCRIPTION
Issue #82 accounting/recovery follow-up. The automated settled consolidated gate on main (`bcc3e3fee1b5b07d380a37c15594917a2f2b4756`) now replays all 39 canonical v2 rows successfully, with only a documented sub-micro-share QQQ serialization residue, but it correctly remains blocked because projected open positions CRWD, PANW, PATH, and SNOW are absent from current state. This PR extends the existing consolidated read-only gate—no new endpoint—to show, for only those unexplained symbols, canonical-ledger execution IDs versus current `state.trades` execution IDs, ledger-only rows, state-only rows, and whether a state-only exit exists. This distinguishes canonical coverage gaps from stale-state/persistence divergence without mutating anything. It writes no state/files, edits no ledger rows, clears no halt, rewrites no day peak, calls no market-data provider, places no orders, and changes no strategy/threshold/sizing/hard-risk/live/ML authority. Focused tests prove state-only-exit, ledger-only, matching-ID/different-position classifications and non-mutation. Merge only after exact-head Change Safety, Repository Safety, Architecture Debt, Refactor/Ownership/Config/Startup, and exact Gunicorn smoke are green.