### PR TITLE
Auto-capture fresh-day and active-audit stabilization evidence

### DIFF
--- a/runtime_research_snapshot.py
+++ b/runtime_research_snapshot.py
@@ -3,8 +3,9 @@
 
 The collector performs concurrent GET requests only. It never calls authenticated
 cycle routes, initiates research, changes policy, mutates paper state, or places
-orders. The authoritative verified-v2 recovery gate is captured automatically so
-manual per-event forensic requests are not required after each deployment.
+orders. The authoritative verified-v2 recovery gate, fresh-day gate, and compact
+active audit are captured automatically so manual per-event forensic requests are
+not required during Issue #82 stabilization.
 """
 from __future__ import annotations
 
@@ -17,13 +18,15 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_BASE_URL = "https://web-production-e1796.up.railway.app"
-VERSION = "runtime-research-snapshot-2026-08-21-v4-recovery-gate"
+VERSION = "runtime-research-snapshot-2026-08-24-v5-market-open-stabilization"
 
 ENDPOINTS = {
     "bootstrap_status": "/bootstrap-status",
     "root": "/",
     "paper_status": "/paper/status",
     "self_check": "/paper/self-check",
+    "fresh_day_check": "/paper/fresh-day-check",
+    "daily_audit": "/paper/daily-audit",
     "verified_v2_recovery_gate": "/paper/verified-v2-successor-replay-status",
     "v1_status": "/paper/performance-audit-status",
     "v2_status": "/paper/performance-audit-v2-status",
@@ -49,7 +52,7 @@ def _fetch_json(url: str, retries: int, timeout: float) -> dict[str, Any]:
                 url,
                 headers={
                     "Accept": "application/json",
-                    "User-Agent": "Trading-bot-read-only-research-snapshot/4.0",
+                    "User-Agent": "Trading-bot-read-only-research-snapshot/5.0",
                 },
                 method="GET",
             )
@@ -119,17 +122,88 @@ def _recovery_gate_summary(payload: dict[str, Any]) -> dict[str, Any]:
         "ledger_row_count": ledger.get("row_count"),
         "chain_valid": ledger.get("chain_valid"),
         "known_invalid_execution_count": payload.get("known_invalid_execution_count"),
-        "all_known_invalid_signatures_exact": payload.get("all_known_invalid_signatures_exact"),
-        "latest_invalid_is_last_canonical_execution": payload.get("latest_invalid_is_last_canonical_execution"),
+        "all_known_invalid_signatures_exact": payload.get(
+            "all_known_invalid_signatures_exact"
+        ),
+        "latest_invalid_is_last_canonical_execution": payload.get(
+            "latest_invalid_is_last_canonical_execution"
+        ),
         "projection_complete": projection.get("projection_complete"),
         "candidate_cash": projection.get("candidate_cash"),
-        "candidate_equity_using_current_stored_marks": comparison.get("candidate_equity_using_current_stored_marks"),
-        "unexplained_position_mismatches": comparison.get("unexplained_position_mismatches"),
-        "mechanically_complete_for_successor_migration_design": readiness.get("mechanically_complete_for_successor_migration_design"),
-        "manual_per_event_probe_required": readiness.get("manual_per_event_probe_required"),
-        "state_write_authorized_by_probe": readiness.get("state_write_authorized_by_this_probe"),
-        "halt_clear_authorized_by_probe": readiness.get("halt_clear_authorized_by_this_probe"),
-        "risk_peak_repair_authorized_by_probe": readiness.get("risk_peak_repair_authorized_by_this_probe"),
+        "candidate_equity_using_current_stored_marks": comparison.get(
+            "candidate_equity_using_current_stored_marks"
+        ),
+        "unexplained_position_mismatches": comparison.get(
+            "unexplained_position_mismatches"
+        ),
+        "mechanically_complete_for_successor_migration_design": readiness.get(
+            "mechanically_complete_for_successor_migration_design"
+        ),
+        "manual_per_event_probe_required": readiness.get(
+            "manual_per_event_probe_required"
+        ),
+        "state_write_authorized_by_probe": readiness.get(
+            "state_write_authorized_by_this_probe"
+        ),
+        "halt_clear_authorized_by_probe": readiness.get(
+            "halt_clear_authorized_by_this_probe"
+        ),
+        "risk_peak_repair_authorized_by_probe": readiness.get(
+            "risk_peak_repair_authorized_by_this_probe"
+        ),
+    }
+
+
+def _fresh_day_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    risk = _dict(payload.get("risk"))
+    return {
+        "overall": payload.get("overall"),
+        "baseline_status": payload.get("baseline_status"),
+        "date": payload.get("date") or risk.get("date"),
+        "current_equity": payload.get("current_equity"),
+        "day_start_equity": payload.get("day_start_equity")
+        if payload.get("day_start_equity") is not None
+        else risk.get("day_start_equity"),
+        "day_peak_equity": payload.get("day_peak_equity")
+        if payload.get("day_peak_equity") is not None
+        else risk.get("day_peak_equity"),
+        "fresh_day_reset_pending": payload.get("fresh_day_reset_pending"),
+        "halted": payload.get("halted")
+        if payload.get("halted") is not None
+        else risk.get("halted"),
+        "halt_reason": payload.get("halt_reason") or risk.get("halt_reason"),
+        "intraday_drawdown_pct": payload.get("intraday_drawdown_pct")
+        if payload.get("intraday_drawdown_pct") is not None
+        else risk.get("intraday_drawdown_pct"),
+    }
+
+
+def _daily_audit_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    accounting = _dict(payload.get("accounting_integrity"))
+    ledger = _dict(payload.get("execution_ledger"))
+    market = _dict(payload.get("market_data"))
+    runner = _dict(payload.get("runner"))
+    risk = _dict(payload.get("risk"))
+    epoch = _dict(payload.get("accounting_epoch"))
+    return {
+        "overall": payload.get("overall"),
+        "generated_local": payload.get("generated_local"),
+        "epoch_id": epoch.get("epoch_id"),
+        "validation_hold": epoch.get("validation_hold"),
+        "accounting_integrity_status": accounting.get("status"),
+        "coverage_issue_count": accounting.get("coverage_issue_count"),
+        "economic_issue_count": accounting.get("economic_issue_count"),
+        "canonical_chain_valid": ledger.get("chain_valid"),
+        "canonical_row_count": ledger.get("row_count"),
+        "canonical_epoch_id": ledger.get("current_epoch_id"),
+        "market_data_status": market.get("status"),
+        "runner_status": runner.get("status"),
+        "runner_active_error": runner.get("active_error"),
+        "runner_last_successful_run": runner.get("last_successful_run"),
+        "risk_status": risk.get("status"),
+        "risk_halted": risk.get("halted"),
+        "risk_halt_reason": risk.get("halt_reason"),
+        "risk_intraday_drawdown_pct": risk.get("intraday_drawdown_pct"),
     }
 
 
@@ -138,7 +212,13 @@ def _summarize(raw: dict[str, dict[str, Any]]) -> dict[str, Any]:
     root_payload = _dict(_dict(raw.get("root")).get("payload"))
     paper_payload = _dict(_dict(raw.get("paper_status")).get("payload"))
     self_payload = _dict(_dict(raw.get("self_check")).get("payload"))
-    recovery_payload = _dict(_dict(raw.get("verified_v2_recovery_gate")).get("payload"))
+    fresh_payload = _dict(_dict(raw.get("fresh_day_check")).get("payload"))
+    audit_payload = _dict(_dict(raw.get("daily_audit")).get("payload"))
+    recovery_payload = _dict(
+        _dict(raw.get("verified_v2_recovery_gate")).get("payload")
+    )
+    fresh_day = _fresh_day_summary(fresh_payload)
+    daily_audit = _daily_audit_summary(audit_payload)
     recovery_gate = _recovery_gate_summary(recovery_payload)
     v1_payload = _dict(_dict(raw.get("v1_status")).get("payload"))
     v2_payload = _dict(_dict(raw.get("v2_status")).get("payload"))
@@ -156,16 +236,22 @@ def _summarize(raw: dict[str, dict[str, Any]]) -> dict[str, Any]:
     profiles = _profile_summary(latest) or _profile_summary(regime_payload)
     reachable = sorted(name for name, row in raw.items() if row.get("status") == "ok")
     failures = sorted(set(raw) - set(reachable))
-    listener_reachable = any(name in reachable for name in ("bootstrap_status", "root"))
+    listener_reachable = any(
+        name in reachable for name in ("bootstrap_status", "root")
+    )
     delegate_ready = bool(
         bootstrap_payload.get("delegate_ready")
         or root_payload.get("delegate_ready")
         or "paper_status" in reachable
         or "self_check" in reachable
     )
-    application_ready = bool(delegate_ready and ("paper_status" in reachable or "self_check" in reachable))
+    application_ready = bool(
+        delegate_ready and ("paper_status" in reachable or "self_check" in reachable)
+    )
     self_overall = self_payload.get("overall")
     recovery_overall = recovery_payload.get("overall")
+    fresh_baseline_status = fresh_payload.get("baseline_status")
+    audit_overall = audit_payload.get("overall")
     v2_run_status = v2_payload.get("run_status") or latest.get("status") or "unknown"
 
     if not listener_reachable:
@@ -173,6 +259,10 @@ def _summarize(raw: dict[str, dict[str, Any]]) -> dict[str, Any]:
     elif not application_ready:
         overall = "warn"
     elif self_overall not in {None, "pass"}:
+        overall = "warn"
+    elif fresh_baseline_status not in {None, "pass"}:
+        overall = "warn"
+    elif audit_overall not in {None, "pass"}:
         overall = "warn"
     elif recovery_overall not in {None, "pass"}:
         overall = "warn"
@@ -203,20 +293,36 @@ def _summarize(raw: dict[str, dict[str, Any]]) -> dict[str, Any]:
             "overall": self_overall,
             "version": self_payload.get("version"),
             "generated_local": self_payload.get("generated_local"),
-            "components_checked": _dict(self_payload.get("summary")).get("components_checked"),
-            "failing_components": _dict(self_payload.get("summary")).get("failing_components"),
-            "base_failures": _dict(self_payload.get("summary")).get("base_failures"),
+            "components_checked": _dict(self_payload.get("summary")).get(
+                "components_checked"
+            ),
+            "failing_components": _dict(self_payload.get("summary")).get(
+                "failing_components"
+            ),
+            "base_failures": _dict(self_payload.get("summary")).get(
+                "base_failures"
+            ),
             "positions": _dict(self_payload.get("account")).get("positions"),
             "equity": _dict(self_payload.get("account")).get("equity"),
             "cash": _dict(self_payload.get("account")).get("cash"),
-            "last_success": _dict(self_payload.get("auto_runner")).get("last_success"),
-            "runtime_shadow_capture": _dict(_dict(self_payload.get("component_checks")).get("runtime_shadow_capture")),
+            "last_success": _dict(self_payload.get("auto_runner")).get(
+                "last_success"
+            ),
+            "runtime_shadow_capture": _dict(
+                _dict(self_payload.get("component_checks")).get(
+                    "runtime_shadow_capture"
+                )
+            ),
         },
+        "fresh_day": fresh_day,
+        "daily_audit": daily_audit,
         "recovery_gate": recovery_gate,
         "v1": {
             "version": v1_payload.get("version"),
             "enabled": v1_payload.get("enabled"),
-            "auto_backtest_enabled": _dict(v1_payload.get("settings")).get("auto_backtest_enabled"),
+            "auto_backtest_enabled": _dict(v1_payload.get("settings")).get(
+                "auto_backtest_enabled"
+            ),
             "backtest_status": _dict(v1_payload.get("backtest")).get("status"),
             "forward_rows": _dict(v1_payload.get("forward_test")).get("rows_total"),
         },
@@ -254,6 +360,8 @@ def _markdown(report: dict[str, Any]) -> str:
     summary = _dict(report.get("summary"))
     connectivity = _dict(summary.get("connectivity"))
     self_check = _dict(summary.get("self_check"))
+    fresh_day = _dict(summary.get("fresh_day"))
+    daily_audit = _dict(summary.get("daily_audit"))
     recovery_gate = _dict(summary.get("recovery_gate"))
     v1 = _dict(summary.get("v1"))
     v2 = _dict(summary.get("v2"))
@@ -280,6 +388,26 @@ def _markdown(report: dict[str, Any]) -> str:
         f"- Equity: `{self_check.get('equity')}`",
         f"- Failing components: `{self_check.get('failing_components')}`",
         f"- Runtime shadow capture: `{self_check.get('runtime_shadow_capture')}`",
+        "",
+        "## Fresh Risk Day",
+        "",
+        f"- Baseline status: `{fresh_day.get('baseline_status')}`",
+        f"- Date: `{fresh_day.get('date')}`",
+        f"- Day start / peak: `{fresh_day.get('day_start_equity')}` / `{fresh_day.get('day_peak_equity')}`",
+        f"- Reset pending: `{fresh_day.get('fresh_day_reset_pending')}`",
+        f"- Halted / reason: `{fresh_day.get('halted')}` / `{fresh_day.get('halt_reason')}`",
+        f"- Intraday drawdown: `{fresh_day.get('intraday_drawdown_pct')}`",
+        "",
+        "## Compact Active Audit",
+        "",
+        f"- Overall: `{daily_audit.get('overall')}`",
+        f"- Accounting integrity: `{daily_audit.get('accounting_integrity_status')}`",
+        f"- Coverage / economic issues: `{daily_audit.get('coverage_issue_count')}` / `{daily_audit.get('economic_issue_count')}`",
+        f"- Canonical chain / rows: `{daily_audit.get('canonical_chain_valid')}` / `{daily_audit.get('canonical_row_count')}`",
+        f"- Market data: `{daily_audit.get('market_data_status')}`",
+        f"- Runner / active error: `{daily_audit.get('runner_status')}` / `{daily_audit.get('runner_active_error')}`",
+        f"- Risk / halted: `{daily_audit.get('risk_status')}` / `{daily_audit.get('risk_halted')}`",
+        f"- Risk halt reason: `{daily_audit.get('risk_halt_reason')}`",
         "",
         "## Verified-v2 Recovery Gate",
         "",
@@ -357,7 +485,9 @@ def main() -> int:
 
     base_url = args.base_url.rstrip("/")
     raw: dict[str, dict[str, Any]] = {}
-    with ThreadPoolExecutor(max_workers=max(1, min(args.workers, len(ENDPOINTS)))) as executor:
+    with ThreadPoolExecutor(
+        max_workers=max(1, min(args.workers, len(ENDPOINTS)))
+    ) as executor:
         futures = {
             executor.submit(
                 _fetch_json,
@@ -372,7 +502,10 @@ def main() -> int:
             try:
                 raw[name] = future.result()
             except Exception as exc:
-                raw[name] = {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
+                raw[name] = {
+                    "status": "error",
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
 
     summary = _summarize(raw)
     status = str(summary.get("overall") or "error")
@@ -397,7 +530,9 @@ def main() -> int:
         },
     }
 
-    Path(args.json).write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    Path(args.json).write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     Path(args.markdown).write_text(_markdown(report) + "\n", encoding="utf-8")
     print(json.dumps({"status": status, "summary": summary}, indent=2, sort_keys=True))
     return 1 if status == "error" else 0

--- a/test_runtime_research_snapshot.py
+++ b/test_runtime_research_snapshot.py
@@ -6,7 +6,12 @@ import runtime_research_snapshot as snapshot
 
 
 class RuntimeResearchSnapshotTests(unittest.TestCase):
-    def _raw(self, recovery_overall="pass"):
+    def _raw(
+        self,
+        recovery_overall="pass",
+        fresh_baseline_status="pass",
+        audit_overall="pass",
+    ):
         raw = {
             name: {"status": "ok", "payload": {}}
             for name in snapshot.ENDPOINTS
@@ -24,6 +29,48 @@ class RuntimeResearchSnapshotTests(unittest.TestCase):
             "account": {"cash": 100.0, "equity": 101.0, "positions": []},
             "auto_runner": {"last_success": "now"},
         }
+        raw["fresh_day_check"]["payload"] = {
+            "overall": "pass" if fresh_baseline_status == "pass" else "fail",
+            "baseline_status": fresh_baseline_status,
+            "date": "2026-08-24",
+            "current_equity": 101.0,
+            "day_start_equity": 100.0,
+            "day_peak_equity": 101.0,
+            "fresh_day_reset_pending": False,
+            "halted": False,
+            "halt_reason": None,
+            "intraday_drawdown_pct": 0.0,
+        }
+        raw["daily_audit"]["payload"] = {
+            "overall": audit_overall,
+            "generated_local": "2026-08-24 10:30:00 CDT",
+            "accounting_epoch": {
+                "epoch_id": "stable-paper-v2-20260812-verified01",
+                "validation_hold": True,
+            },
+            "accounting_integrity": {
+                "status": "pass" if audit_overall == "pass" else "warn",
+                "coverage_issue_count": 0 if audit_overall == "pass" else 1,
+                "economic_issue_count": 0 if audit_overall == "pass" else 1,
+            },
+            "execution_ledger": {
+                "chain_valid": True,
+                "row_count": 39,
+                "current_epoch_id": "stable-paper-v2-20260812-verified01",
+            },
+            "market_data": {"status": "pass"},
+            "runner": {
+                "status": "pass",
+                "active_error": False,
+                "last_successful_run": "2026-08-24 10:25:00 CDT",
+            },
+            "risk": {
+                "status": "pass",
+                "halted": False,
+                "halt_reason": None,
+                "intraday_drawdown_pct": 0.0,
+            },
+        }
         raw["verified_v2_recovery_gate"]["payload"] = {
             "overall": recovery_overall,
             "version": "gate-test",
@@ -32,7 +79,7 @@ class RuntimeResearchSnapshotTests(unittest.TestCase):
                 if recovery_overall == "pass"
                 else "known_invalid_execution_signature_not_exact_recovery_gate_blocked"
             ),
-            "known_invalid_execution_count": 5,
+            "known_invalid_execution_count": 7,
             "all_known_invalid_signatures_exact": recovery_overall == "pass",
             "latest_invalid_is_last_canonical_execution": True,
             "ledger": {"row_count": 39, "chain_valid": True},
@@ -55,7 +102,7 @@ class RuntimeResearchSnapshotTests(unittest.TestCase):
         raw["v2_status"]["payload"] = {"run_status": "idle"}
         return raw
 
-    def test_authoritative_default_and_recovery_gate_endpoint_are_canonical(self):
+    def test_authoritative_default_and_stabilization_endpoints_are_canonical(self):
         self.assertEqual(
             snapshot.DEFAULT_BASE_URL,
             "https://web-production-e1796.up.railway.app",
@@ -64,15 +111,23 @@ class RuntimeResearchSnapshotTests(unittest.TestCase):
             snapshot.ENDPOINTS["verified_v2_recovery_gate"],
             "/paper/verified-v2-successor-replay-status",
         )
+        self.assertEqual(
+            snapshot.ENDPOINTS["fresh_day_check"],
+            "/paper/fresh-day-check",
+        )
+        self.assertEqual(
+            snapshot.ENDPOINTS["daily_audit"],
+            "/paper/daily-audit",
+        )
 
-    def test_recovery_gate_is_compacted_into_automatic_runtime_summary(self):
-        summary = snapshot._summarize(self._raw("pass"))
+    def test_recovery_fresh_day_and_active_audit_are_compacted_together(self):
+        summary = snapshot._summarize(self._raw())
 
         self.assertEqual(summary["overall"], "pass")
         gate = summary["recovery_gate"]
         self.assertEqual(gate["overall"], "pass")
         self.assertEqual(gate["ledger_row_count"], 39)
-        self.assertEqual(gate["known_invalid_execution_count"], 5)
+        self.assertEqual(gate["known_invalid_execution_count"], 7)
         self.assertTrue(gate["all_known_invalid_signatures_exact"])
         self.assertTrue(gate["mechanically_complete_for_successor_migration_design"])
         self.assertFalse(gate["manual_per_event_probe_required"])
@@ -80,8 +135,49 @@ class RuntimeResearchSnapshotTests(unittest.TestCase):
         self.assertFalse(gate["halt_clear_authorized_by_probe"])
         self.assertFalse(gate["risk_peak_repair_authorized_by_probe"])
 
-    def test_failed_recovery_gate_warns_snapshot_without_mutation_or_error_exit_class(self):
-        summary = snapshot._summarize(self._raw("fail"))
+        fresh = summary["fresh_day"]
+        self.assertEqual(fresh["baseline_status"], "pass")
+        self.assertEqual(fresh["date"], "2026-08-24")
+        self.assertEqual(fresh["day_start_equity"], 100.0)
+        self.assertEqual(fresh["day_peak_equity"], 101.0)
+        self.assertFalse(fresh["fresh_day_reset_pending"])
+        self.assertFalse(fresh["halted"])
+
+        audit = summary["daily_audit"]
+        self.assertEqual(audit["overall"], "pass")
+        self.assertEqual(audit["accounting_integrity_status"], "pass")
+        self.assertEqual(audit["coverage_issue_count"], 0)
+        self.assertEqual(audit["economic_issue_count"], 0)
+        self.assertTrue(audit["canonical_chain_valid"])
+        self.assertEqual(audit["canonical_row_count"], 39)
+        self.assertEqual(audit["market_data_status"], "pass")
+        self.assertEqual(audit["runner_status"], "pass")
+        self.assertFalse(audit["runner_active_error"])
+        self.assertFalse(audit["risk_halted"])
+
+    def test_failed_fresh_day_gate_warns_snapshot_without_mutation(self):
+        summary = snapshot._summarize(
+            self._raw(fresh_baseline_status="fail")
+        )
+
+        self.assertEqual(summary["overall"], "warn")
+        self.assertEqual(summary["fresh_day"]["baseline_status"], "fail")
+        self.assertFalse(
+            summary["recovery_gate"]["state_write_authorized_by_probe"]
+        )
+
+    def test_failed_active_audit_warns_snapshot_without_error_exit_class(self):
+        summary = snapshot._summarize(
+            self._raw(audit_overall="fail")
+        )
+
+        self.assertEqual(summary["overall"], "warn")
+        self.assertEqual(summary["daily_audit"]["overall"], "fail")
+        self.assertEqual(summary["daily_audit"]["coverage_issue_count"], 1)
+        self.assertEqual(summary["daily_audit"]["economic_issue_count"], 1)
+
+    def test_failed_recovery_gate_warns_snapshot_without_manual_probe_regression(self):
+        summary = snapshot._summarize(self._raw(recovery_overall="fail"))
 
         self.assertEqual(summary["overall"], "warn")
         gate = summary["recovery_gate"]


### PR DESCRIPTION
Issue #82 / #94 validation consolidation. Now that the market is open again, extend the existing read-only runtime research snapshot so every automatic capture includes the compact `/paper/fresh-day-check` and `/paper/daily-audit` alongside self-check and the consolidated verified-v2 recovery gate. This directly observes the remaining stabilization criteria without adding another runtime endpoint or requiring the user to run more manual tests. The snapshot now compacts fresh-day baseline/date/start/peak/halt state plus active accounting, canonical ledger, market-data, runner, and risk status. It remains GET-only/reporting-only and does not call cycle routes, write state/files in the service, edit/relabel/delete ledger rows, clear a halt, rewrite day peak, place orders, start research, or change strategy/threshold/sizing/hard-risk/live/ML authority. Focused tests cover healthy compaction and fail-to-warn behavior for fresh-day, audit, and recovery-gate failures. Merge only after final exact-head Change Safety Audit, Repository Safety, Architecture Debt, Refactor/Ownership/Config/Startup, and exact Gunicorn smoke are green.