### PR TITLE
Retire split-brain legacy external paper runner

### DIFF
--- a/.github/workflows/paper-run.yml
+++ b/.github/workflows/paper-run.yml
@@ -1,29 +1,18 @@
-name: Scheduled Paper Trading Run
+name: Retired Legacy External Paper Runner
 
 on:
-  schedule:
-    # Runs about every 5 minutes. GitHub may delay cron jobs slightly.
-    - cron: "*/5 * * * *"
+  # Intentionally manual-only and non-mutating. The former five-minute scheduler
+  # targeted the non-authoritative Dazzling Railway state boundary and could
+  # create split-brain paper-cycle ownership. Canonical Splendid owns its own
+  # internal automatic runner; do not repoint this workflow to another service.
   workflow_dispatch:
 
-concurrency:
-  group: paper-trading-runner
-  cancel-in-progress: true
-
 jobs:
-  run-paper-engine:
+  retired:
     runs-on: ubuntu-latest
-    timeout-minutes: 3
     steps:
-      - name: Trigger Railway paper engine
-        env:
-          RUN_KEY: ${{ secrets.RUN_KEY }}
-          BOT_BASE_URL: https://trading-bot-clean.up.railway.app
+      - name: Explain retired runner
         run: |
-          if [ -z "$RUN_KEY" ]; then
-            echo "Missing RUN_KEY secret. Add it in GitHub repo Settings > Secrets and variables > Actions."
-            exit 1
-          fi
-
-          RESPONSE=$(curl -sS --fail --max-time 120 "$BOT_BASE_URL/paper/run?key=$RUN_KEY")
-          echo "$RESPONSE"
+          echo "Legacy external paper-cycle scheduler is retired."
+          echo "This workflow intentionally performs no HTTP request and owns no trading cycle."
+          echo "Canonical paper-cycle ownership remains with the Splendid service internal runner."

--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-VERSION = "change-safety-audit-2026-08-21-v9-runtime-research-recovery-gate"
+VERSION = "change-safety-audit-2026-08-25-v10-retired-external-paper-runner"
 
 CORE_TESTS = (
     "test_architecture_stage_b.py",
@@ -43,6 +43,7 @@ PRICE_INTEGRITY_TESTS = (
 SLS_RECOVERY_PROOF_TESTS = ("test_sls_bad_execution_recovery_proof.py",)
 SUCCESSOR_REPLAY_TESTS = ("test_verified_v2_successor_replay_status.py",)
 RUNTIME_RESEARCH_SNAPSHOT_TESTS = ("test_runtime_research_snapshot.py",)
+LEGACY_EXTERNAL_PAPER_RUNNER_TESTS = ("test_legacy_external_paper_runner_retired.py",)
 
 
 @dataclass(frozen=True)
@@ -93,6 +94,10 @@ def _is_successor_replay_path(path: str) -> bool:
 
 def _is_runtime_research_snapshot_path(path: str) -> bool:
     return "runtime_research_snapshot" in path.lower()
+
+
+def _is_legacy_external_paper_runner_path(path: str) -> bool:
+    return path.lower() == ".github/workflows/paper-run.yml"
 
 
 def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ...]]:
@@ -177,6 +182,8 @@ def planned_regressions(paths: Iterable[str]) -> tuple[str, ...]:
         tests.extend(SUCCESSOR_REPLAY_TESTS)
     if any(_is_runtime_research_snapshot_path(path) for path in path_tuple):
         tests.extend(RUNTIME_RESEARCH_SNAPSHOT_TESTS)
+    if any(_is_legacy_external_paper_runner_path(path) for path in path_tuple):
+        tests.extend(LEGACY_EXTERNAL_PAPER_RUNNER_TESTS)
     existing: list[str] = []
     seen: set[str] = set()
     for test in tests:

--- a/test_legacy_external_paper_runner_retired.py
+++ b/test_legacy_external_paper_runner_retired.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+WORKFLOW = Path(".github/workflows/paper-run.yml")
+
+
+class LegacyExternalPaperRunnerRetiredTests(unittest.TestCase):
+    def test_legacy_external_runner_cannot_schedule_or_trigger_a_paper_cycle(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+        lowered = text.lower()
+
+        self.assertIn("retired legacy external paper runner", lowered)
+        self.assertIn("workflow_dispatch:", text)
+        self.assertNotIn("schedule:", text)
+        self.assertNotIn("/paper/run", text)
+        self.assertNotIn("trading-bot-clean.up.railway.app", text)
+        self.assertNotIn("RUN_KEY", text)
+        self.assertNotIn("curl ", lowered)
+
+    def test_retired_workflow_does_not_claim_canonical_cycle_ownership(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8").lower()
+
+        self.assertIn("canonical paper-cycle ownership remains with the splendid service internal runner", text)
+        self.assertIn("intentionally performs no http request", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue #82 newly proven safety regression. The scheduled `.github/workflows/paper-run.yml` was still calling authenticated `/paper/run` about every five minutes on the non-authoritative Dazzling Railway boundary (`trading-bot-clean`), while the authoritative Splendid service already owns its internal automatic paper runner. That creates split-brain cycle ownership and can continue mutating the wrong historical state boundary.

This PR retires that legacy external runner instead of repointing it. The workflow becomes manual-only and no-op: no schedule, no service URL, no RUN_KEY, no curl, and no `/paper/run`. Canonical Splendid internal runner ownership is left unchanged. A focused static regression prevents the legacy workflow from reacquiring a schedule, the Dazzling target, query-key secret usage, or a paper-cycle HTTP call, and the exact-head Change Safety Audit selects that regression for future changes to this workflow.

Safety boundaries: paper-only governance change; no portfolio/risk/ledger/state mutation, no halt clear, no day-peak rewrite, no strategy/signals/thresholds/sizing changes, no live/ML authority change, and no manual `/paper/run` call. Merge only after exact-head Change Safety Audit, Repository Safety, Architecture Debt, Refactor/Ownership/Configuration/State/Decision/Runtime/Startup audit, focused regression, and exact Gunicorn smoke are green.