### PR TITLE
Accept bounded state-trade quantity serialization residue

### DIFF
--- a/paper_bidirectional_accounting_guard.py
+++ b/paper_bidirectional_accounting_guard.py
@@ -21,7 +21,11 @@ import copy
 import datetime as dt
 from typing import Any, Dict, List, Tuple
 
-VERSION = "paper-bidirectional-accounting-2026-08-10-v1"
+VERSION = "paper-bidirectional-accounting-2026-08-25-v2-state-trade-qty-tolerance"
+# state.trades serializes execution quantities to six decimals. Accept only the
+# bounded sub-five-micro-share residue already proven safe by canonical replay;
+# material quantity gaps remain coverage failures and cannot create cash.
+STATE_TRADE_QTY_SERIALIZATION_TOLERANCE = 5e-6
 _APPLIED = False
 _REGISTERED_APP_IDS: set[int] = set()
 
@@ -229,7 +233,7 @@ def analyze_ledger(pf: Dict[str, Any], core: Any = None) -> Dict[str, Any]:
         if timestamp[:10] == today:
             realized_today += trade_realized
 
-        if remaining > 1e-6:
+        if remaining > STATE_TRADE_QTY_SERIALIZATION_TOLERANCE:
             ignored += 1
             coverage_issues.append({
                 "trade_index": index,
@@ -420,6 +424,7 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "applied": _APPLIED,
         "supports_long_short": True,
         "short_margin_model": "entry_notional_reserved_and_released_with_pnl",
+        "state_trade_qty_serialization_tolerance": STATE_TRADE_QTY_SERIALIZATION_TOLERANCE,
         "coverage_complete": bool(rebuilt.get("coverage_complete")),
         "baseline_type": rebuilt.get("baseline_type"),
         "parsed_trade_rows": int(rebuilt.get("parsed_trade_rows") or 0),

--- a/test_bidirectional_accounting_quantity_tolerance.py
+++ b/test_bidirectional_accounting_quantity_tolerance.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import paper_bidirectional_accounting_guard as accounting
+
+
+def _trade(action, shares, price=36.0):
+    return {
+        "action": action,
+        "symbol": "TOST",
+        "side": "long",
+        "shares": shares,
+        "price": price,
+        "timestamp": "2026-08-25 10:00:00 CDT",
+    }
+
+
+def test_six_decimal_state_trade_residue_is_accepted_as_serialization_only():
+    portfolio = {
+        "initial_cash": 10000.0,
+        "trades": [
+            _trade("entry", 3.767684, 36.0501),
+            _trade("partial_exit", 1.243336, 36.87),
+            _trade("exit", 2.524349, 36.775),
+        ],
+        "positions": {},
+    }
+
+    rebuilt = accounting.analyze_ledger(portfolio)
+
+    assert rebuilt["coverage_complete"] is True
+    assert rebuilt["coverage_issue_count"] == 0
+    assert rebuilt["ignored_trade_rows"] == 0
+    assert rebuilt["open_positions"] == {}
+
+
+def test_material_state_trade_quantity_gap_still_fails_closed():
+    portfolio = {
+        "initial_cash": 10000.0,
+        "trades": [
+            _trade("entry", 3.767684, 36.0501),
+            _trade("partial_exit", 1.243336, 36.87),
+            _trade("exit", 2.524354, 36.775),
+        ],
+        "positions": {},
+    }
+
+    rebuilt = accounting.analyze_ledger(portfolio)
+
+    assert rebuilt["coverage_complete"] is False
+    assert rebuilt["coverage_issue_count"] == 1
+    issue = rebuilt["coverage_issues"][0]
+    assert issue["reason"] == "exit_exceeds_reconstructed_position"
+    assert issue["unmatched_qty"] > accounting.STATE_TRADE_QTY_SERIALIZATION_TOLERANCE


### PR DESCRIPTION
Direct Issue #82 stabilization fix for the newly proven active-audit TOST false positive.

Settled authoritative Splendid evidence after PR #119 shows canonical TOST economics close exactly at full precision, while the six-decimal state-trade mirror creates an approximately one-micro-share apparent overshoot. The active bidirectional accounting validator currently fails at a strict `1e-6` residual check even though the canonical verified-v2 replay already uses a bounded `5e-6` serialization tolerance and still fails materially larger gaps closed.

This PR changes only the state-trade accounting coverage tolerance to the same bounded `5e-6`, adds explicit telemetry for that tolerance, and adds focused regressions proving the observed six-decimal TOST lifecycle passes while a material quantity gap still fails with `exit_exceeds_reconstructed_position`.

No canonical ledger row is edited/deleted/relabelled. No account/risk state is rewritten by this change. No halt or day peak is cleared. No `/paper/run`. No strategy, signals, sizing, thresholds, live authority, or ML authority changes.

Must pass exact-head Change Safety, Repository Safety, Architecture Debt, ownership/config/state/runtime/startup checks, focused regression, and exact Gunicorn smoke before merge.