### PR TITLE
Create bounded Issue #82 successor accounting epoch

### DIFF
--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-VERSION = "change-safety-audit-2026-08-25-v10-retired-external-paper-runner"
+VERSION = "change-safety-audit-2026-08-25-v11-issue82-successor-epoch"
 
 CORE_TESTS = (
     "test_architecture_stage_b.py",
@@ -42,6 +42,7 @@ PRICE_INTEGRITY_TESTS = (
 )
 SLS_RECOVERY_PROOF_TESTS = ("test_sls_bad_execution_recovery_proof.py",)
 SUCCESSOR_REPLAY_TESTS = ("test_verified_v2_successor_replay_status.py",)
+SUCCESSOR_EPOCH_MIGRATION_TESTS = ("test_verified_v2_successor_epoch_migration.py",)
 RUNTIME_RESEARCH_SNAPSHOT_TESTS = ("test_runtime_research_snapshot.py",)
 LEGACY_EXTERNAL_PAPER_RUNNER_TESTS = ("test_legacy_external_paper_runner_retired.py",)
 
@@ -92,6 +93,10 @@ def _is_successor_replay_path(path: str) -> bool:
     return "verified_v2_successor_replay" in path.lower()
 
 
+def _is_successor_epoch_migration_path(path: str) -> bool:
+    return "verified_v2_successor_epoch_migration" in path.lower()
+
+
 def _is_runtime_research_snapshot_path(path: str) -> bool:
     return "runtime_research_snapshot" in path.lower()
 
@@ -135,7 +140,7 @@ def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ..
         if _is_day_peak_provenance_path(path):
             categories.add("risk")
             boundaries.update(("risk", "state"))
-        if _is_sls_recovery_proof_path(path) or _is_successor_replay_path(path):
+        if _is_sls_recovery_proof_path(path) or _is_successor_replay_path(path) or _is_successor_epoch_migration_path(path):
             categories.update(("state_persistence", "accounting_execution", "risk"))
             boundaries.update(("state", "accounting", "execution", "risk"))
         if _is_runtime_research_snapshot_path(path):
@@ -180,6 +185,8 @@ def planned_regressions(paths: Iterable[str]) -> tuple[str, ...]:
         tests.extend(SLS_RECOVERY_PROOF_TESTS)
     if any(_is_successor_replay_path(path) for path in path_tuple):
         tests.extend(SUCCESSOR_REPLAY_TESTS)
+    if any(_is_successor_epoch_migration_path(path) for path in path_tuple):
+        tests.extend(SUCCESSOR_EPOCH_MIGRATION_TESTS)
     if any(_is_runtime_research_snapshot_path(path) for path in path_tuple):
         tests.extend(RUNTIME_RESEARCH_SNAPSHOT_TESTS)
     if any(_is_legacy_external_paper_runner_path(path) for path in path_tuple):

--- a/clean_epoch_successor_compatibility.py
+++ b/clean_epoch_successor_compatibility.py
@@ -16,6 +16,7 @@ from typing import Any, Dict
 VERSION = "clean-epoch-successor-compatibility-2026-08-25-v2-v3-chain"
 OLD_EPOCH_ID = "stable-paper-v1-20260810-clean01"
 VERIFIED_V2_EPOCH_ID = "stable-paper-v2-20260812-verified01"
+NEW_EPOCH_ID = VERIFIED_V2_EPOCH_ID
 ISSUE82_V3_EPOCH_ID = "stable-paper-v3-20260825-successor01"
 _APPLIED = False
 

--- a/clean_epoch_successor_compatibility.py
+++ b/clean_epoch_successor_compatibility.py
@@ -1,9 +1,10 @@
 """Compatibility guard for legitimately superseded clean accounting epochs.
 
-The 2026-08-10 clean epoch migration leaves a durable completion marker. A later,
-explicit verified-snapshot roll-forward is allowed to supersede that epoch. This
-shim teaches the old migration to treat only that exact successor relationship as
-healthy instead of reporting a missing active epoch.
+The 2026-08-10 clean epoch migration leaves a durable completion marker. Later,
+explicit verified-snapshot roll-forwards are allowed to supersede that epoch.
+This shim teaches the old migration to treat only the exact v1->v2 and
+v1->v2->v3 successor relationships as healthy instead of reporting a missing
+active epoch.
 
 It does not mutate account state, risk limits, strategy, sizing, live authority,
 or ML authority. Any unrelated epoch mismatch continues to fail closed.
@@ -12,9 +13,10 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "clean-epoch-successor-compatibility-2026-08-12-v1"
+VERSION = "clean-epoch-successor-compatibility-2026-08-25-v2-v3-chain"
 OLD_EPOCH_ID = "stable-paper-v1-20260810-clean01"
-NEW_EPOCH_ID = "stable-paper-v2-20260812-verified01"
+VERIFIED_V2_EPOCH_ID = "stable-paper-v2-20260812-verified01"
+ISSUE82_V3_EPOCH_ID = "stable-paper-v3-20260825-successor01"
 _APPLIED = False
 
 
@@ -22,16 +24,31 @@ def _d(value: Any) -> Dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
-def _is_verified_successor(core: Any) -> bool:
+def _successor_epoch(core: Any) -> str | None:
     pf = getattr(core, "portfolio", None)
     pf = pf if isinstance(pf, dict) else {}
     epoch = _d(pf.get("paper_accounting_epoch"))
-    return bool(
-        str(epoch.get("id") or "") == NEW_EPOCH_ID
+    epoch_id = str(epoch.get("id") or "")
+    if bool(
+        epoch_id == VERIFIED_V2_EPOCH_ID
         and str(epoch.get("prior_epoch_id") or "") == OLD_EPOCH_ID
         and str(epoch.get("historical_recovery_decision") or "") == "verified_snapshot_rollforward"
         and bool(epoch.get("historical_evidence_archived", False))
-    )
+    ):
+        return VERIFIED_V2_EPOCH_ID
+    if bool(
+        epoch_id == ISSUE82_V3_EPOCH_ID
+        and str(epoch.get("prior_epoch_id") or "") == VERIFIED_V2_EPOCH_ID
+        and str(epoch.get("historical_recovery_decision") or "") == "verified_v2_historical_disposition_successor_rollforward"
+        and bool(epoch.get("historical_evidence_archived", False))
+        and bool(epoch.get("validation_hold", False))
+    ):
+        return ISSUE82_V3_EPOCH_ID
+    return None
+
+
+def _is_verified_successor(core: Any) -> bool:
+    return _successor_epoch(core) is not None
 
 
 def apply(core: Any = None) -> Dict[str, Any]:
@@ -49,7 +66,8 @@ def apply(core: Any = None) -> Dict[str, Any]:
     prior = getattr(current, "_successor_compatibility_prior", current)
 
     def wrapped(runtime_core: Any = None):
-        if runtime_core is not None and _is_verified_successor(runtime_core):
+        successor = _successor_epoch(runtime_core) if runtime_core is not None else None
+        if successor:
             pf = getattr(runtime_core, "portfolio", None)
             epoch = _d(_d(pf).get("paper_accounting_epoch"))
             return {
@@ -58,7 +76,7 @@ def apply(core: Any = None) -> Dict[str, Any]:
                 "version": getattr(clean, "VERSION", None),
                 "compatibility_version": VERSION,
                 "epoch_id": OLD_EPOCH_ID,
-                "superseded_by_epoch_id": NEW_EPOCH_ID,
+                "superseded_by_epoch_id": successor,
                 "historical_recovery_decision": epoch.get("historical_recovery_decision"),
                 "historical_evidence_archived": bool(epoch.get("historical_evidence_archived", False)),
             }
@@ -72,11 +90,13 @@ def apply(core: Any = None) -> Dict[str, Any]:
 
 
 def status_payload(core: Any = None) -> Dict[str, Any]:
+    successor = _successor_epoch(core) if core is not None else None
     return {
         "status": "ok" if _APPLIED else "pending",
         "overall": "pass" if _APPLIED else "warn",
         "version": VERSION,
-        "verified_successor_present": bool(core is not None and _is_verified_successor(core)),
+        "verified_successor_present": bool(successor),
+        "successor_epoch_id": successor,
         "reporting_compatibility_only": True,
     }
 

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-21-v35-consolidated-v2-recovery-gate"
+VERSION = "data-integrity-startup-bridge-2026-08-25-v36-issue82-successor-epoch"
 MODULES = (
     "final_daily_audit_compactor",
     "daily_audit_entry_count_bridge",
@@ -55,9 +55,13 @@ MODULES = (
     # incident. It archives the contaminated epoch and starts a verified snapshot
     # epoch under a validation hold; it is not a generic loss reset.
     "verified_snapshot_epoch_recovery",
-    # Final accounting adapter so the new epoch can begin from verified cash plus
-    # the restored open LRCX lot and all future executions remain canonical.
+    # Accounting adapter must be active before the Issue #82 successor cutover so
+    # the current verified-v2 open-position baseline is reconciled exactly.
     "verified_snapshot_accounting_baseline",
+    # One-shot Issue #82 historical disposition. It archives verified-v2 evidence,
+    # preserves current economics/risk exactly, keeps the canonical ledger intact,
+    # and starts the v3 active accounting window under validation hold.
+    "verified_v2_successor_epoch_migration",
     # Issue #82 fresh-day gate: never initialize a new risk day from a
     # non-finite/non-positive persisted valuation. This guard is prospective and
     # never rewrites an already-initialized current day.

--- a/test_change_safety_audit.py
+++ b/test_change_safety_audit.py
@@ -170,6 +170,26 @@ class ChangeSafetyAuditTests(unittest.TestCase):
         ):
             self.assertIn(core_test, tests)
 
+    def test_verified_v2_successor_epoch_migration_selects_focused_regression(self) -> None:
+        path = "verified_v2_successor_epoch_migration.py"
+        categories, boundaries = classify_paths((path,))
+        tests = planned_regressions((path,))
+
+        self.assertIn("state_persistence", categories)
+        self.assertIn("accounting_execution", categories)
+        self.assertIn("risk", categories)
+        for boundary in ("state", "accounting", "execution", "risk"):
+            self.assertIn(boundary, boundaries)
+        self.assertIn("test_verified_v2_successor_epoch_migration.py", tests)
+        for core_test in (
+            "test_architecture_stage_b.py",
+            "test_architecture_stage_c.py",
+            "test_architecture_stage_d_state_store.py",
+            "test_architecture_stage_e_accounting.py",
+            "test_architecture_stage_f_canary.py",
+        ):
+            self.assertIn(core_test, tests)
+
     def test_runtime_research_snapshot_change_selects_automatic_capture_regression(self) -> None:
         path = "runtime_research_snapshot.py"
         categories, boundaries = classify_paths((path,))

--- a/test_verified_v2_successor_epoch_migration.py
+++ b/test_verified_v2_successor_epoch_migration.py
@@ -1,0 +1,162 @@
+import contextlib
+import copy
+import os
+import sys
+import types
+
+import verified_v2_successor_epoch_migration as migration
+
+
+def _portfolio():
+    return {
+        "cash": 13357.874520862653,
+        "equity": 13537.44,
+        "positions": {
+            "DHR": {"side": "long", "shares": 0.540748758, "entry": 216.960007, "last_price": 215.79},
+            "SLS": {"side": "long", "shares": 4.353086829, "entry": 14.335, "last_price": 14.45},
+        },
+        "trades": [{"execution_id": "historical-row"}],
+        "history": [13500.0, 13537.44],
+        "realized_pnl": {"today": 1.83, "total": 42.0},
+        "performance": {"realized_pnl_today": 1.83, "realized_pnl_total": 42.0},
+        "risk_controls": {
+            "date": "2026-08-25",
+            "day_start_equity": 13536.430460509137,
+            "day_peak_equity": 13546.272788435168,
+            "halted": False,
+            "halt_reason": None,
+            "intraday_drawdown_pct": 0.059,
+        },
+        "accounting_epoch_id": migration.OLD_EPOCH_ID,
+        "paper_accounting_epoch": {
+            "id": migration.OLD_EPOCH_ID,
+            "validation_hold": True,
+            "historical_evidence_archived": True,
+        },
+    }
+
+
+def test_successor_state_preserves_current_economics_and_risk_exactly():
+    before = _portfolio()
+    original = copy.deepcopy(before)
+    after = migration.build_successor_state(before, "/archive/evidence", "2026-08-25 15:05:00 CDT")
+
+    assert before == original
+    for key in ("cash", "equity", "positions", "history", "realized_pnl", "performance", "risk_controls"):
+        assert after[key] == original[key]
+    assert after["trades"] == []
+    assert after["accounting_epoch_id"] == migration.TARGET_EPOCH_ID
+    epoch = after["paper_accounting_epoch"]
+    assert epoch["id"] == migration.TARGET_EPOCH_ID
+    assert epoch["prior_epoch_id"] == migration.OLD_EPOCH_ID
+    assert epoch["validation_hold"] is True
+    assert epoch["historical_evidence_archived"] is True
+    assert epoch["forensic_archive_dir"] == "/archive/evidence"
+    assert epoch["baseline_type"] == "verified_snapshot_with_open_position"
+    snap = epoch["verified_snapshot_baseline"]
+    assert snap["cash"] == original["cash"]
+    assert snap["equity"] == original["equity"]
+    assert snap["realized_today"] == 1.83
+    assert snap["positions"]["DHR"]["qty"] == original["positions"]["DHR"]["shares"]
+
+
+def test_exact_tem_duplicate_is_the_only_allowed_active_accounting_issue(monkeypatch):
+    result = {
+        "coverage_issues": [{
+            "symbol": "TEM", "action": "exit", "reason": "exit_exceeds_reconstructed_position",
+            "requested_qty": migration.TEM_DUPLICATE_QTY, "price": migration.TEM_DUPLICATE_PRICE,
+        }],
+        "economic_issues": [{
+            "symbol": "TEM", "action": "exit", "reason": "exit_exceeds_reconstructed_position",
+            "requested_qty": migration.TEM_DUPLICATE_QTY, "price": migration.TEM_DUPLICATE_PRICE,
+        }],
+        "coverage_issue_count": 1,
+        "economic_issue_count": 1,
+        "reconstructed_cash": 13357.87452,
+        "reconstructed_equity": 13537.44,
+        "reconstructed_open_positions": ["DHR", "SLS"],
+    }
+    fake = types.SimpleNamespace(analyze_ledger=lambda pf, core: copy.deepcopy(result))
+    monkeypatch.setitem(sys.modules, "paper_bidirectional_accounting_guard", fake)
+    core = types.SimpleNamespace(portfolio=_portfolio())
+    observed, ready = migration._active_accounting_evidence(core)
+    assert ready is True
+    assert observed["coverage_issue_count"] == 1
+
+    bad = copy.deepcopy(result)
+    bad["coverage_issues"].append({"symbol": "TOST", "action": "exit", "reason": "exit_exceeds_reconstructed_position", "requested_qty": 1.0, "price": 36.0})
+    fake.analyze_ledger = lambda pf, core: copy.deepcopy(bad)
+    _, ready = migration._active_accounting_evidence(core)
+    assert ready is False
+
+
+def test_recovery_gate_must_be_exact_and_mechanically_complete(monkeypatch):
+    payload = {
+        "overall": "pass",
+        "all_known_invalid_signatures_exact": True,
+        "known_invalid_execution_count": 11,
+        "ledger": {"chain_valid": True, "epoch_ids": [migration.OLD_EPOCH_ID], "row_count": 42},
+        "recovery_readiness": {
+            "counterfactual_successor_projection_mechanically_reproducible": True,
+            "all_canonical_rows_accounted_for": True,
+            "mechanically_complete_for_successor_migration_design": True,
+        },
+    }
+    fake = types.SimpleNamespace(status_payload=lambda core: copy.deepcopy(payload))
+    monkeypatch.setitem(sys.modules, "verified_v2_successor_replay_status", fake)
+    _, ready = migration._gate_evidence(types.SimpleNamespace())
+    assert ready is True
+
+    payload["known_invalid_execution_count"] = 10
+    _, ready = migration._gate_evidence(types.SimpleNamespace())
+    assert ready is False
+
+
+def test_cutover_never_changes_or_rotates_canonical_ledger(monkeypatch, tmp_path):
+    ledger_path = tmp_path / "canonical_execution_ledger.jsonl"
+    ledger_bytes = b'{"event_hash":"immutable-row"}\n'
+    ledger_path.write_bytes(ledger_bytes)
+
+    fake_ledger = types.SimpleNamespace(LEDGER_FILE=str(ledger_path))
+    saved = {}
+
+    def write_state(core, state):
+        saved["state"] = copy.deepcopy(state)
+        return str(tmp_path / "state.json")
+
+    fake_clean = types.SimpleNamespace(
+        _runtime_locks=lambda: contextlib.nullcontext(),
+        _write_clean_state_and_backups=write_state,
+        _reset_snapshot_archive=lambda state, path: None,
+    )
+    monkeypatch.setitem(sys.modules, "canonical_execution_ledger", fake_ledger)
+    monkeypatch.setitem(sys.modules, "clean_accounting_epoch", fake_clean)
+    monkeypatch.setattr(migration, "_archive_state", lambda *args, **kwargs: {"archive_dir": str(tmp_path / "archive")})
+    monkeypatch.setattr(migration, "_rotate_journal_for_successor", lambda state: None)
+    marker = tmp_path / "marker.json"
+    monkeypatch.setattr(migration, "MARKER_FILE", str(marker))
+
+    core = types.SimpleNamespace(portfolio=_portfolio(), local_ts_text=lambda: "2026-08-25 15:05:00 CDT")
+    result = migration._cutover(core, {"ledger": {"row_count": 42}}, {})
+
+    assert ledger_path.read_bytes() == ledger_bytes
+    assert result["canonical_ledger_unchanged"] is True
+    assert core.portfolio["accounting_epoch_id"] == migration.TARGET_EPOCH_ID
+    assert saved["state"]["trades"] == []
+    assert saved["state"]["risk_controls"] == _portfolio()["risk_controls"]
+
+
+def test_status_declares_no_trading_or_risk_authority(monkeypatch, tmp_path):
+    core = types.SimpleNamespace(portfolio=_portfolio())
+    monkeypatch.setattr(migration, "MARKER_FILE", str(tmp_path / "missing.json"))
+    payload = migration.status_payload(core)
+    authority = payload["authority"]
+    assert authority["edits_or_deletes_canonical_rows"] is False
+    assert authority["rotates_or_truncates_canonical_ledger"] is False
+    assert authority["rewrites_current_day_peak"] is False
+    assert authority["clears_hard_halt"] is False
+    assert authority["places_orders"] is False
+    assert authority["changes_strategy"] is False
+    assert authority["changes_thresholds"] is False
+    assert authority["changes_risk_or_sizing"] is False
+    assert authority["changes_live_or_ml_authority"] is False

--- a/verified_v2_successor_epoch_migration.py
+++ b/verified_v2_successor_epoch_migration.py
@@ -1,0 +1,474 @@
+"""One-shot Issue #82 verified-v2 successor accounting epoch migration.
+
+This migration is deliberately accounting-only and paper-only. It archives the
+entire verified-v2 persistent state, requires the existing consolidated recovery
+gate to prove all eleven exact historical dispositions, requires the active
+bidirectional accounting result to have only the already-proven immutable TEM
+duplicate issue, and then starts a successor accounting epoch from the *current
+verified state snapshot*.
+
+Current cash, equity, positions, marks, realized statistics, history, and risk
+controls are preserved exactly. Only the active accounting window is rolled
+forward: state.trades and the mirrored journal are reset for the successor epoch,
+while the append-only canonical execution ledger is never edited, truncated,
+rotated, relabelled, or deleted. Future canonical rows naturally receive the new
+accounting epoch id through the existing ledger hook.
+
+The successor remains under validation hold. This module does not clear a halt,
+rewrite day_start/day_peak, fabricate fills, place orders, or change strategy,
+signals, sizing, hard-risk thresholds, live authority, or ML authority.
+"""
+from __future__ import annotations
+
+import copy
+import datetime as dt
+import hashlib
+import json
+import math
+import os
+import shutil
+import threading
+from typing import Any, Dict, List, Tuple
+
+VERSION = "verified-v2-successor-epoch-migration-2026-08-25-v1"
+OLD_EPOCH_ID = "stable-paper-v2-20260812-verified01"
+TARGET_EPOCH_ID = "stable-paper-v3-20260825-successor01"
+DECISION_ID = "issue-82-verified-v2-historical-disposition-2026-08-25"
+TEM_DUPLICATE_EXECUTION_ID = "3530dbf965db4894ba93b7098cec3696"
+TEM_DUPLICATE_QTY = 29.640567
+TEM_DUPLICATE_PRICE = 52.905
+STATE_DIR = os.environ.get("STATE_DIR") or os.environ.get("PERSISTENT_STATE_DIR") or os.environ.get("RAILWAY_VOLUME_MOUNT_PATH") or "."
+ARCHIVE_ROOT = os.path.join(STATE_DIR, "forensic_archives")
+MARKER_FILE = os.path.join(STATE_DIR, f"successor_epoch_{DECISION_ID}.json")
+_LOCK = threading.RLock()
+_REGISTERED_APP_IDS: set[int] = set()
+_LAST_STATUS: Dict[str, Any] = {}
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _f(value: Any) -> float | None:
+    try:
+        if value is None or isinstance(value, bool):
+            return None
+        number = float(value)
+        return number if math.isfinite(number) else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _now(core: Any = None) -> str:
+    try:
+        return str(core.local_ts_text())
+    except Exception:
+        return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _paper_only() -> bool:
+    live = os.environ.get("LIVE_TRADING_ENABLED", "false").lower() in {"1", "true", "yes", "on"}
+    broker_live = os.environ.get("BROKER_MODE", "").lower() in {"live", "real", "production"}
+    return not live and not broker_live
+
+
+def _portfolio(core: Any) -> Dict[str, Any]:
+    pf = getattr(core, "portfolio", None) if core is not None else None
+    return pf if isinstance(pf, dict) else {}
+
+
+def _atomic_json(path: str, payload: Dict[str, Any]) -> None:
+    folder = os.path.dirname(path)
+    if folder:
+        os.makedirs(folder, exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True, default=str)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def _sha256(path: str) -> str | None:
+    if not path or not os.path.isfile(path):
+        return None
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        while True:
+            block = handle.read(1024 * 1024)
+            if not block:
+                break
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _marker() -> Dict[str, Any]:
+    try:
+        with open(MARKER_FILE, "r", encoding="utf-8") as handle:
+            value = json.load(handle)
+        return value if isinstance(value, dict) else {}
+    except Exception:
+        return {}
+
+
+def _realized_snapshot(pf: Dict[str, Any]) -> Tuple[float, float]:
+    realized = _d(pf.get("realized_pnl"))
+    perf = _d(pf.get("performance"))
+    today = _f(realized.get("today", realized.get("realized_today")))
+    total = _f(realized.get("total"))
+    if today is None:
+        today = _f(perf.get("realized_pnl_today"))
+    if total is None:
+        total = _f(perf.get("realized_pnl_total"))
+    return float(today or 0.0), float(total or 0.0)
+
+
+def _verified_positions(pf: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    out: Dict[str, Dict[str, Any]] = {}
+    for raw_symbol, raw_position in _d(pf.get("positions")).items():
+        pos = _d(raw_position)
+        symbol = str(raw_symbol or pos.get("symbol") or "").upper().strip()
+        side = str(pos.get("side") or "long").lower().strip()
+        qty = _f(pos.get("shares", pos.get("qty")))
+        entry = _f(pos.get("entry", pos.get("entry_price")))
+        mark = _f(pos.get("last_price"))
+        if not symbol or side not in {"long", "short"} or qty is None or qty <= 0 or entry is None or entry <= 0 or mark is None or mark <= 0:
+            return {}
+        out[symbol] = {
+            "side": side,
+            "qty": qty,
+            "entry_price": entry,
+            "mark": mark,
+        }
+    return out
+
+
+def _gate_evidence(core: Any) -> Tuple[Dict[str, Any], bool]:
+    try:
+        import verified_v2_successor_replay_status as gate
+        payload = gate.status_payload(core)
+    except Exception as exc:
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}, False
+    readiness = _d(payload.get("recovery_readiness"))
+    ledger = _d(payload.get("ledger"))
+    ok = bool(
+        payload.get("overall") == "pass"
+        and payload.get("all_known_invalid_signatures_exact") is True
+        and int(payload.get("known_invalid_execution_count") or 0) == 11
+        and bool(ledger.get("chain_valid"))
+        and str(ledger.get("epoch_ids", [None])[0] if _l(ledger.get("epoch_ids")) else "") == OLD_EPOCH_ID
+        and bool(readiness.get("counterfactual_successor_projection_mechanically_reproducible"))
+        and bool(readiness.get("all_canonical_rows_accounted_for"))
+        and bool(readiness.get("mechanically_complete_for_successor_migration_design"))
+    )
+    return payload, ok
+
+
+def _tem_issue_exact(issue: Dict[str, Any]) -> bool:
+    qty = _f(issue.get("requested_qty", issue.get("shares")))
+    price = _f(issue.get("price"))
+    return bool(
+        str(issue.get("symbol") or "").upper() == "TEM"
+        and str(issue.get("action") or "").lower() == "exit"
+        and str(issue.get("reason") or "") == "exit_exceeds_reconstructed_position"
+        and qty is not None and abs(qty - TEM_DUPLICATE_QTY) <= 5e-6
+        and price is not None and abs(price - TEM_DUPLICATE_PRICE) <= 5e-6
+    )
+
+
+def _active_accounting_evidence(core: Any) -> Tuple[Dict[str, Any], bool]:
+    pf = _portfolio(core)
+    try:
+        import paper_bidirectional_accounting_guard as accounting
+        result = accounting.analyze_ledger(pf, core)
+    except Exception as exc:
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}, False
+    coverage = [row for row in _l(result.get("coverage_issues")) if isinstance(row, dict)]
+    economics = [row for row in _l(result.get("economic_issues")) if isinstance(row, dict)]
+    if len(coverage) != 1 or len(economics) != 1 or not _tem_issue_exact(coverage[0]) or not _tem_issue_exact(economics[0]):
+        return result, False
+    current_cash = _f(pf.get("cash")); current_equity = _f(pf.get("equity"))
+    rebuilt_cash = _f(result.get("reconstructed_cash")); rebuilt_equity = _f(result.get("reconstructed_equity"))
+    rebuilt_positions = sorted(str(v).upper() for v in _l(result.get("reconstructed_open_positions")))
+    current_positions = sorted(str(v).upper() for v in _d(pf.get("positions")).keys())
+    ok = bool(
+        current_cash is not None and current_cash > 0
+        and current_equity is not None and current_equity > 0
+        and rebuilt_cash is not None and abs(rebuilt_cash - current_cash) <= 0.01
+        and rebuilt_equity is not None and abs(rebuilt_equity - current_equity) <= 0.05
+        and rebuilt_positions == current_positions
+    )
+    return result, ok
+
+
+def _archive_state(core: Any, gate: Dict[str, Any], accounting: Dict[str, Any], ledger_path: str, ledger_digest: str | None) -> Dict[str, Any]:
+    os.makedirs(ARCHIVE_ROOT, exist_ok=True)
+    stamp = dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    archive_dir = os.path.join(ARCHIVE_ROOT, f"{stamp}_{DECISION_ID}")
+    os.makedirs(archive_dir, exist_ok=False)
+    root_abs = os.path.abspath(ARCHIVE_ROOT)
+    copied: List[Dict[str, Any]] = []
+    for name in sorted(os.listdir(STATE_DIR)):
+        src = os.path.join(STATE_DIR, name)
+        src_abs = os.path.abspath(src)
+        if src_abs == root_abs or src_abs.startswith(root_abs + os.sep):
+            continue
+        dst = os.path.join(archive_dir, name)
+        try:
+            if os.path.isdir(src):
+                shutil.copytree(src, dst)
+                copied.append({"name": name, "type": "directory"})
+            elif os.path.isfile(src):
+                shutil.copy2(src, dst)
+                copied.append({"name": name, "type": "file", "size_bytes": os.path.getsize(dst), "sha256": _sha256(dst)})
+        except Exception as exc:
+            copied.append({"name": name, "type": "copy_error", "error": f"{type(exc).__name__}: {exc}"})
+    pf = _portfolio(core)
+    manifest = {
+        "status": "ok",
+        "type": "issue_82_verified_v2_successor_archive",
+        "version": VERSION,
+        "decision_id": DECISION_ID,
+        "prior_epoch_id": OLD_EPOCH_ID,
+        "target_epoch_id": TARGET_EPOCH_ID,
+        "created_local": _now(core),
+        "archive_dir": archive_dir,
+        "canonical_ledger": {
+            "path": ledger_path,
+            "sha256_before_cutover": ledger_digest,
+            "immutable_history_retained_in_place": True,
+            "rotated_or_truncated": False,
+            "row_count": _d(gate.get("ledger")).get("row_count"),
+            "chain_valid": _d(gate.get("ledger")).get("chain_valid"),
+        },
+        "historical_disposition": {
+            "known_invalid_execution_count": gate.get("known_invalid_execution_count"),
+            "all_known_invalid_signatures_exact": gate.get("all_known_invalid_signatures_exact"),
+            "known_invalid_execution_disposition": gate.get("known_invalid_execution_disposition"),
+            "projection_complete": _d(gate.get("projection")).get("projection_complete"),
+            "decision": "archive_verified_v2_history_and_roll_current_verified_state_into_successor_epoch_without_rewriting_historical_economics",
+        },
+        "active_accounting_before_cutover": {
+            "coverage_issue_count": accounting.get("coverage_issue_count"),
+            "economic_issue_count": accounting.get("economic_issue_count"),
+            "coverage_issues": accounting.get("coverage_issues"),
+            "reconstructed_cash": accounting.get("reconstructed_cash"),
+            "reconstructed_equity": accounting.get("reconstructed_equity"),
+            "reconstructed_open_positions": accounting.get("reconstructed_open_positions"),
+        },
+        "pre_cutover_account": {
+            "cash": pf.get("cash"), "equity": pf.get("equity"),
+            "positions": copy.deepcopy(_d(pf.get("positions"))),
+            "trade_rows": len(_l(pf.get("trades"))),
+            "risk_controls": copy.deepcopy(_d(pf.get("risk_controls"))),
+        },
+        "copied_entries": copied,
+    }
+    _atomic_json(os.path.join(archive_dir, "issue_82_successor_archive_manifest.json"), manifest)
+    return manifest
+
+
+def build_successor_state(pf: Dict[str, Any], archive_dir: str, started_local: str) -> Dict[str, Any]:
+    state = copy.deepcopy(pf)
+    cash = _f(state.get("cash")); equity = _f(state.get("equity"))
+    positions = _verified_positions(state)
+    if cash is None or cash <= 0 or equity is None or equity <= 0:
+        raise RuntimeError("current account snapshot is not sane")
+    if _d(state.get("positions")) and not positions:
+        raise RuntimeError("current open-position snapshot is not fully verifiable")
+    realized_today, realized_total = _realized_snapshot(state)
+    snapshot = {
+        "verified": True,
+        "version": VERSION,
+        "started_local": started_local,
+        "cash": cash,
+        "equity": equity,
+        "realized_today": realized_today,
+        "realized_total": realized_total,
+        "positions": positions,
+        "source": "current_verified_state_after_issue_82_forward_session_and_exact_historical_disposition",
+    }
+    state["trades"] = []
+    state["accounting_epoch_id"] = TARGET_EPOCH_ID
+    state["paper_accounting_epoch"] = {
+        "version": VERSION,
+        "id": TARGET_EPOCH_ID,
+        "decision_id": DECISION_ID,
+        "started_local": started_local,
+        "starting_cash": cash,
+        "starting_equity": equity,
+        "clean_start": False,
+        "zero_trade_baseline": not bool(positions),
+        "baseline_type": "verified_snapshot_with_open_position" if positions else "verified_snapshot_zero_position",
+        "verified_snapshot_baseline": snapshot,
+        "historical_recovery_decision": "verified_v2_historical_disposition_successor_rollforward",
+        "prior_epoch_id": OLD_EPOCH_ID,
+        "prior_epoch_disposition": "archived_with_exact_eleven_row_historical_disposition_and_immutable_canonical_ledger_retained",
+        "historical_evidence_archived": True,
+        "forensic_archive_dir": archive_dir,
+        "validation_hold": True,
+        "validation_hold_reason": "issue 82 successor epoch clean-active-audit validation hold",
+        "validation_release_status": "blocked",
+        "validation_released": False,
+        "forward_validation_required": True,
+        "valid_path_rows_baseline": 0,
+    }
+    return state
+
+
+def _rotate_journal_for_successor(state: Dict[str, Any]) -> None:
+    try:
+        import trade_journal as tj
+    except Exception:
+        return
+    factory = getattr(tj, "_empty_journal", None)
+    try:
+        journal = factory() if callable(factory) else {"trades": [], "recent_trades": [], "snapshots": [], "event_hook_events": []}
+    except Exception:
+        journal = {"trades": [], "recent_trades": [], "snapshots": [], "event_hook_events": []}
+    if not isinstance(journal, dict):
+        journal = {"trades": [], "recent_trades": [], "snapshots": [], "event_hook_events": []}
+    journal["accounting_epoch_id"] = TARGET_EPOCH_ID
+    journal["successor_epoch_started_local"] = _now()
+    for attr in ("TRADE_JOURNAL_FILE", "TRADE_JOURNAL_BACKUP_FILE"):
+        path = str(getattr(tj, attr, "") or "")
+        if path:
+            _atomic_json(path, journal)
+
+
+def _cutover(core: Any, gate: Dict[str, Any], accounting: Dict[str, Any]) -> Dict[str, Any]:
+    global _LAST_STATUS
+    import canonical_execution_ledger as ledger
+    import clean_accounting_epoch as clean
+    ledger_path = str(getattr(ledger, "LEDGER_FILE", "") or "")
+    digest_before = _sha256(ledger_path)
+    archive = _archive_state(core, gate, accounting, ledger_path, digest_before)
+    started = _now(core)
+    started_marker = {
+        "status": "cutover_started", "version": VERSION, "decision_id": DECISION_ID,
+        "prior_epoch_id": OLD_EPOCH_ID, "target_epoch_id": TARGET_EPOCH_ID,
+        "archive_dir": archive.get("archive_dir"), "started_local": started,
+        "canonical_ledger_sha256_before": digest_before,
+    }
+    _atomic_json(MARKER_FILE, started_marker)
+    successor = build_successor_state(_portfolio(core), str(archive.get("archive_dir") or ""), started)
+    with clean._runtime_locks():
+        state_file = clean._write_clean_state_and_backups(core, successor)
+        _rotate_journal_for_successor(successor)
+        clean._reset_snapshot_archive(successor, state_file)
+        pf = _portfolio(core)
+        pf.clear(); pf.update(successor)
+    digest_after = _sha256(ledger_path)
+    if digest_before != digest_after:
+        raise RuntimeError("canonical ledger changed during successor cutover")
+    completed = dict(started_marker)
+    completed.update({
+        "status": "completed", "overall": "pass", "completed_local": _now(core),
+        "state_file": state_file, "validation_hold": True,
+        "canonical_ledger_sha256_after": digest_after,
+        "canonical_ledger_unchanged": True,
+        "successor_cash": successor.get("cash"), "successor_equity": successor.get("equity"),
+        "successor_positions": sorted(_d(successor.get("positions")).keys()),
+        "successor_trade_rows": len(_l(successor.get("trades"))),
+        "current_risk_state_preserved": True,
+    })
+    _atomic_json(MARKER_FILE, completed)
+    _LAST_STATUS = completed
+    return completed
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _LAST_STATUS
+    if core is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+    if not _paper_only():
+        return {"status": "blocked", "overall": "fail", "version": VERSION, "reason": "paper_runtime_only"}
+    with _LOCK:
+        pf = _portfolio(core)
+        epoch = _d(pf.get("paper_accounting_epoch"))
+        active_epoch = str(epoch.get("id") or pf.get("accounting_epoch_id") or "")
+        marker = _marker()
+        if active_epoch == TARGET_EPOCH_ID:
+            return {
+                "status": "validation_hold", "overall": "pass", "version": VERSION,
+                "epoch_id": TARGET_EPOCH_ID, "prior_epoch_id": OLD_EPOCH_ID,
+                "historical_evidence_archived": bool(epoch.get("historical_evidence_archived")),
+                "forensic_archive_dir": epoch.get("forensic_archive_dir") or marker.get("archive_dir"),
+                "validation_hold": bool(epoch.get("validation_hold", False)),
+                "canonical_ledger_unchanged": bool(marker.get("canonical_ledger_unchanged", False)),
+            }
+        if marker.get("status") == "completed" and active_epoch != TARGET_EPOCH_ID:
+            return {"status": "error", "overall": "fail", "version": VERSION, "reason": "completed_marker_present_but_successor_epoch_not_active", "marker": marker}
+        if active_epoch != OLD_EPOCH_ID:
+            return {"status": "not_applicable", "overall": "pass", "version": VERSION, "reason": "verified_v2_epoch_not_active", "active_epoch_id": active_epoch}
+        gate, gate_ready = _gate_evidence(core)
+        accounting, accounting_ready = _active_accounting_evidence(core)
+        positions = _verified_positions(pf)
+        state_snapshot_ready = bool(_f(pf.get("cash")) and _f(pf.get("equity")) and (not _d(pf.get("positions")) or positions))
+        if not gate_ready or not accounting_ready or not state_snapshot_ready:
+            status = {
+                "status": "blocked", "overall": "warn", "version": VERSION,
+                "reason": "successor_epoch_preconditions_not_met",
+                "preconditions": {"consolidated_recovery_gate_ready": gate_ready, "active_accounting_only_known_tem_issue": accounting_ready, "current_state_snapshot_sane": state_snapshot_ready},
+                "gate_diagnosis": gate.get("diagnosis"),
+                "known_invalid_execution_count": gate.get("known_invalid_execution_count"),
+                "accounting_coverage_issue_count": accounting.get("coverage_issue_count"),
+                "accounting_economic_issue_count": accounting.get("economic_issue_count"),
+            }
+            _LAST_STATUS = status
+            return status
+        try:
+            return _cutover(core, gate, accounting)
+        except Exception as exc:
+            status = {"status": "error", "overall": "fail", "version": VERSION, "error": f"{type(exc).__name__}: {exc}"}
+            _LAST_STATUS = status
+            return status
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    pf = _portfolio(core) if core is not None else {}
+    epoch = _d(pf.get("paper_accounting_epoch"))
+    marker = _marker()
+    active = str(epoch.get("id") or pf.get("accounting_epoch_id") or "") == TARGET_EPOCH_ID
+    return {
+        "status": "validation_hold" if active else _LAST_STATUS.get("status", "pending"),
+        "overall": "pass" if active else _LAST_STATUS.get("overall", "warn"),
+        "type": "verified_v2_successor_epoch_migration_status",
+        "version": VERSION,
+        "epoch_id": TARGET_EPOCH_ID,
+        "active": active,
+        "prior_epoch_id": OLD_EPOCH_ID,
+        "historical_evidence_archived": bool(epoch.get("historical_evidence_archived", False)) if active else False,
+        "forensic_archive_dir": epoch.get("forensic_archive_dir") or marker.get("archive_dir"),
+        "validation_hold": bool(epoch.get("validation_hold", False)) if active else False,
+        "marker_status": marker.get("status"),
+        "canonical_ledger_unchanged": bool(marker.get("canonical_ledger_unchanged", False)),
+        "authority": {
+            "paper_only": True, "one_time_accounting_epoch_rollforward": True,
+            "preserves_current_cash_equity_positions_and_risk": True,
+            "archives_prior_epoch": True, "clears_active_state_trade_window": True,
+            "edits_or_deletes_canonical_rows": False, "rotates_or_truncates_canonical_ledger": False,
+            "rewrites_current_day_peak": False, "clears_hard_halt": False,
+            "places_orders": False, "changes_strategy": False, "changes_thresholds": False,
+            "changes_risk_or_sizing": False, "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    result = apply(core)
+    if flask_app is None:
+        return result
+    app_id = id(flask_app)
+    if app_id not in _REGISTERED_APP_IDS:
+        from flask import jsonify
+        path = "/paper/verified-v2-successor-epoch-status"
+        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+        if path not in existing:
+            flask_app.add_url_rule(path, "verified_v2_successor_epoch_status", lambda: jsonify(status_payload(core)))
+        _REGISTERED_APP_IDS.add(app_id)
+    return status_payload(core)


### PR DESCRIPTION
Direct Issue #82 historical-accounting disposition and clean-active-audit work only.

This PR adds a one-shot paper-only verified-v2 successor accounting epoch migration. It requires the consolidated recovery gate to be fully green with all 11 exact historical dispositions and requires the active accounting validator to show only the already-proven immutable TEM duplicate issue. It then archives the prior persistent state and rolls the current verified account snapshot into `stable-paper-v3-20260825-successor01` under validation hold.

The migration preserves current cash, equity, positions, marks, realized statistics, history, and risk controls exactly. It clears only the active `state.trades`/mirrored-journal accounting window for the successor epoch. The canonical execution ledger is explicitly left in place, hash bytes unchanged, and future executions naturally append under the new epoch id.

Also extends the existing clean-epoch successor compatibility guard so the exact v1->v2->v3 chain remains healthy after cutover, and registers the migration only after the verified-snapshot accounting adapter is active.

No canonical row edit/delete/relabel/rotation, no `/paper/run`, no halt clear, no day-peak rewrite, no strategy/signals/sizing/risk-threshold change, and no live/ML authority change.

Must pass focused successor regressions, exact-head Change Safety Audit, Repository Safety, Architecture Debt, full ownership/config/state/runtime/startup checks, and exact Gunicorn smoke before merge.