### PR TITLE
Restore Issue #82 validation workflow

### DIFF
--- a/.github/workflows/daily-operational-audit.yml
+++ b/.github/workflows/daily-operational-audit.yml
@@ -119,7 +119,7 @@ jobs:
 
           assert bootstrap.get("status") == "ready", bootstrap
           assert bootstrap.get("delegate_ready") is True, bootstrap
-          assert bootstrap.get("version") == "deferred-wsgi-bootstrap-2026-08-06-v6-registration-heartbeat", bootstrap
+          assert bootstrap.get("version") == "deferred-wsgi-bootstrap-2026-08-20-v7-pre-wsgi-fresh-risk-guard", bootstrap
           assert isinstance(bootstrap.get("registration_duration_seconds"), (int, float)), bootstrap
           assert daily.get("status") == "ok", daily
           assert daily.get("type") == "daily_operational_audit", daily

--- a/test_daily_data_integrity_overlay_v2.py
+++ b/test_daily_data_integrity_overlay_v2.py
@@ -218,7 +218,7 @@ class DailyDataIntegrityOverlayV2Tests(unittest.TestCase):
 
     def test_bootstrap_source_contains_registration_heartbeat_contract(self):
         source = Path("bootstrap_wsgi.py").read_text(encoding="utf-8")
-        self.assertIn("v6-registration-heartbeat", source)
+        self.assertIn("deferred-wsgi-bootstrap-2026-08-20-v7-pre-wsgi-fresh-risk-guard", source)
         self.assertIn("registration_elapsed_seconds", source)
         self.assertIn("registration_slow", source)
         self.assertIn("runtime-registration-bootstrap-heartbeat", source)

--- a/test_daily_operational_audit.py
+++ b/test_daily_operational_audit.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import daily_data_integrity_audit_overlay as integrity_overlay
 import daily_operational_audit as audit
 
 
@@ -71,7 +72,21 @@ class DailyOperationalAuditTests(unittest.TestCase):
             try_entries_and_rotations=lambda *args, **kwargs: None,
         )
 
-    def test_curated_audit_has_exactly_twelve_bounded_sections(self) -> None:
+    @staticmethod
+    def _passing_integrity_section():
+        return {
+            "status": "pass",
+            "reasons": [],
+            "provider_circuit_open": False,
+            "protected_symbols_blocked": [],
+            "active_contaminated_feature_count": 0,
+            "provider_request_accounting": {
+                "in_flight_or_unclassified_requests": 0,
+                "accounting_complete_at_snapshot": True,
+            },
+        }
+
+    def test_curated_audit_has_exactly_thirteen_bounded_sections_after_integrity_overlay(self) -> None:
         core = self._core()
         composition = {
             "stack_stable": True,
@@ -118,12 +133,16 @@ class DailyOperationalAuditTests(unittest.TestCase):
 
         with patch.object(audit, "_status_payload", side_effect=status), patch.object(
             audit, "_state_persistence", return_value=persistence
+        ), patch.object(
+            integrity_overlay,
+            "build_integrity_section",
+            return_value=self._passing_integrity_section(),
         ):
             payload = audit.build_payload(core)
 
         self.assertEqual(payload["overall"], "pass")
-        self.assertEqual(len(payload["sections"]), 12)
-        self.assertEqual(payload["sections"]["11_conclusion"]["checked_sections"], 10)
+        self.assertEqual(len(payload["sections"]), 13)
+        self.assertEqual(payload["sections"]["11_conclusion"]["checked_sections"], 11)
         self.assertEqual(payload["sections"]["12_next_action"]["status"], "none")
         self.assertEqual(payload["performance_contract"]["route_fanout_count"], 0)
         self.assertEqual(payload["performance_contract"]["external_provider_calls"], 0)
@@ -156,6 +175,10 @@ class DailyOperationalAuditTests(unittest.TestCase):
         }
         with patch.object(audit, "_status_payload", return_value={}), patch.object(
             audit, "_state_persistence", return_value=persistence
+        ), patch.object(
+            integrity_overlay,
+            "build_integrity_section",
+            return_value=self._passing_integrity_section(),
         ):
             payload = audit.build_payload(core)
 


### PR DESCRIPTION
Validation-only follow-up to PR #121. Align stale daily-audit tests and workflow assertions with the current composed audit shape and current bootstrap version. No runtime behavior change.