### PR TITLE
Prevent successor accounting from resurrecting exited positions

### DIFF
--- a/paper_accounting_integrity_guard.py
+++ b/paper_accounting_integrity_guard.py
@@ -1,8 +1,16 @@
 """Paper-accounting reconciliation and plausibility guard.
 
 Reconstructs the paper account from the execution ledger when the ledger is
-complete enough to do so, repairs malformed open-position aliases/cost basis,
-and prevents contaminated paper P&L from silently driving profit-guard state.
+complete enough to do so, repairs malformed legacy open-position aliases/cost
+basis, and prevents contaminated paper P&L from silently driving profit-guard
+state.
+
+For stable-paper successor epochs (v3+) that are still under validation hold,
+reconstruction is observational only.  Those epochs already have an explicit
+forensic baseline and immutable canonical execution history, so an accounting
+read must never repair an in-flight execution mutation before its canonical row
+is recorded.  Genuine successor mismatches remain visible as WARN/FAIL evidence
+for the existing fail-closed lifecycle controls instead of being auto-mutated.
 
 This module is paper-only. It does not place orders, change strategy thresholds,
 change sizing rules, enable live trading, or grant ML authority.
@@ -14,7 +22,7 @@ import datetime as dt
 import functools
 from typing import Any, Dict, List, Tuple
 
-VERSION = "paper-accounting-integrity-2026-08-07-v1-ledger-reconcile"
+VERSION = "paper-accounting-integrity-2026-08-26-v2-successor-validation-readonly"
 _APPLIED = False
 _PATCHED_CORE_IDS: set[int] = set()
 _REGISTERED_APP_IDS: set[int] = set()
@@ -62,6 +70,29 @@ def _paper_only() -> bool:
 def _portfolio(core: Any) -> Dict[str, Any]:
     pf = getattr(core, "portfolio", None) if core is not None else None
     return pf if isinstance(pf, dict) else {}
+
+
+def _successor_validation_hold_read_only(pf: Dict[str, Any]) -> bool:
+    """Return True for stable-paper successor generations that must not auto-repair.
+
+    Verified-v2 intentionally retains the legacy reconciler because it predates
+    the bounded successor accounting disposition.  Generation v3 and later are
+    explicit successor epochs with archived baselines and validation holds; their
+    active economics must be changed only by canonical executions or a separately
+    proven successor migration, never by a risk-control read.
+    """
+    epoch = _d(pf.get("paper_accounting_epoch"))
+    epoch_id = str(epoch.get("id") or epoch.get("epoch_id") or pf.get("accounting_epoch_id") or "")
+    if not bool(epoch.get("validation_hold", False)):
+        return False
+    parts = epoch_id.split("-")
+    if len(parts) < 3 or parts[0] != "stable" or parts[1] != "paper" or not parts[2].startswith("v"):
+        return False
+    try:
+        generation = int(parts[2][1:])
+    except Exception:
+        return False
+    return generation >= 3
 
 
 def _trade_fields(row: Dict[str, Any]) -> Tuple[str, str, float, float, str]:
@@ -220,6 +251,7 @@ def reconcile(core: Any = None, *, persist: bool = True) -> Dict[str, Any]:
     pf = _portfolio(core)
     rebuilt = reconstruct_from_ledger(pf, core)
     discrepancies = _discrepancies(pf, rebuilt)
+    successor_read_only = _successor_validation_hold_read_only(pf)
     before = {
         "cash": _f(pf.get("cash")),
         "equity": _f(pf.get("equity")),
@@ -228,7 +260,7 @@ def reconcile(core: Any = None, *, persist: bool = True) -> Dict[str, Any]:
     }
     repaired = False
 
-    if rebuilt.get("coverage_complete") and discrepancies:
+    if rebuilt.get("coverage_complete") and discrepancies and not successor_read_only:
         positions = _d(pf.get("positions"))
         for symbol, expected in _d(rebuilt.get("open_positions")).items():
             pos = dict(_d(positions.get(symbol)))
@@ -290,20 +322,27 @@ def reconcile(core: Any = None, *, persist: bool = True) -> Dict[str, Any]:
             except Exception:
                 pass
 
+    remaining = _discrepancies(pf, rebuilt)
     status = {
-        "status": "ok" if rebuilt.get("coverage_complete") and not _discrepancies(pf, rebuilt) else "warn",
-        "overall": "pass" if rebuilt.get("coverage_complete") and not _discrepancies(pf, rebuilt) else "warn",
+        "status": "ok" if rebuilt.get("coverage_complete") and not remaining else "warn",
+        "overall": "pass" if rebuilt.get("coverage_complete") and not remaining else "warn",
         "type": "paper_accounting_integrity_status",
         "version": VERSION,
         "generated_local": _now(core),
         "coverage_complete": bool(rebuilt.get("coverage_complete")),
         "repaired": repaired,
+        "successor_validation_hold_read_only": successor_read_only,
+        "automatic_repair_suppressed": bool(successor_read_only and discrepancies),
         "discrepancies_before_repair": discrepancies,
         "discrepancy_count_before_repair": len(discrepancies),
+        "discrepancies_remaining": remaining,
+        "discrepancy_count_remaining": len(remaining),
         "before": before,
         "reconstructed": rebuilt,
         "authority": {
             "paper_state_reconciliation_only": True,
+            "legacy_epoch_auto_repair_retained": True,
+            "successor_validation_hold_auto_repair": False,
             "places_orders": False,
             "changes_strategy": False,
             "changes_thresholds": False,

--- a/test_architecture_stage_f_canary.py
+++ b/test_architecture_stage_f_canary.py
@@ -5,6 +5,9 @@ import json
 from pathlib import Path
 import unittest
 
+from test_issue126_successor_accounting_reconcile_boundary import (
+    Issue126SuccessorAccountingBoundaryTests,
+)
 from trading.canary import (
     CanaryEvidence,
     CanaryInvariantError,

--- a/test_issue126_successor_accounting_reconcile_boundary.py
+++ b/test_issue126_successor_accounting_reconcile_boundary.py
@@ -1,0 +1,123 @@
+import copy
+import unittest
+from unittest import mock
+
+import paper_accounting_integrity_guard as accounting
+
+
+class FakeCore:
+    def __init__(self, *, epoch_id, validation_hold=True):
+        self.save_calls = 0
+        self.portfolio = {
+            "cash": 1059.27,
+            "equity": 1059.27,
+            "accounting_epoch_id": epoch_id,
+            "paper_accounting_epoch": {
+                "id": epoch_id,
+                "epoch_id": epoch_id,
+                "validation_hold": validation_hold,
+            },
+            "positions": {},
+            "performance": {},
+            "risk_controls": {"halted": False, "halt_reason": "", "cooldowns": {}},
+            "trades": [],
+        }
+
+    def local_ts_text(self):
+        return "2026-08-26 08:35:12 CDT"
+
+    def save_state(self, state=None):
+        self.save_calls += 1
+
+
+PRE_EXIT_RECONSTRUCTION = {
+    "status": "ok",
+    "coverage_complete": True,
+    "cash": 1000.0,
+    "equity": 1059.27,
+    "market_value": 59.27,
+    "realized_total": 0.0,
+    "realized_today": 0.0,
+    "unrealized_pnl": 0.0,
+    "open_positions": {
+        "SLS": {
+            "qty": 4.353086829,
+            "entry_price": 14.335,
+            "last_price": 13.62,
+            "market_value": 59.27,
+            "cost_basis": 62.397,
+            "unrealized_pnl": -3.127,
+            "unrealized_pnl_pct": -5.01,
+        }
+    },
+}
+
+POST_EXIT_RECONSTRUCTION = {
+    "status": "ok",
+    "coverage_complete": True,
+    "cash": 1059.27,
+    "equity": 1059.27,
+    "market_value": 0.0,
+    "realized_total": -3.127,
+    "realized_today": -3.127,
+    "unrealized_pnl": 0.0,
+    "open_positions": {},
+}
+
+
+class Issue126SuccessorAccountingBoundaryTests(unittest.TestCase):
+    def test_v3_validation_hold_does_not_resurrect_position_during_full_exit_window(self):
+        core = FakeCore(epoch_id="stable-paper-v3-20260825-successor01")
+        before = copy.deepcopy(core.portfolio)
+
+        with mock.patch.object(accounting, "reconstruct_from_ledger", return_value=PRE_EXIT_RECONSTRUCTION):
+            status = accounting.reconcile(core, persist=True)
+
+        self.assertEqual(core.save_calls, 0)
+        self.assertEqual(core.portfolio["cash"], before["cash"])
+        self.assertEqual(core.portfolio["positions"], {})
+        self.assertFalse(status["repaired"])
+        self.assertTrue(status["successor_validation_hold_read_only"])
+        self.assertTrue(status["automatic_repair_suppressed"])
+        self.assertEqual(status["overall"], "warn")
+        self.assertGreater(status["discrepancy_count_remaining"], 0)
+
+    def test_same_v3_state_passes_after_canonical_exit_is_visible(self):
+        core = FakeCore(epoch_id="stable-paper-v3-20260825-successor01")
+
+        with mock.patch.object(accounting, "reconstruct_from_ledger", return_value=POST_EXIT_RECONSTRUCTION):
+            status = accounting.reconcile(core, persist=True)
+
+        self.assertEqual(core.save_calls, 0)
+        self.assertEqual(core.portfolio["positions"], {})
+        self.assertEqual(status["overall"], "pass")
+        self.assertEqual(status["discrepancy_count_remaining"], 0)
+        self.assertTrue(status["successor_validation_hold_read_only"])
+        self.assertFalse(status["automatic_repair_suppressed"])
+
+    def test_verified_v2_legacy_repair_semantics_are_preserved(self):
+        core = FakeCore(epoch_id="stable-paper-v2-20260812-verified01")
+
+        with mock.patch.object(accounting, "reconstruct_from_ledger", return_value=PRE_EXIT_RECONSTRUCTION):
+            status = accounting.reconcile(core, persist=True)
+
+        self.assertEqual(core.save_calls, 1)
+        self.assertTrue(status["repaired"])
+        self.assertFalse(status["successor_validation_hold_read_only"])
+        self.assertIn("SLS", core.portfolio["positions"])
+        self.assertAlmostEqual(core.portfolio["positions"]["SLS"]["shares"], 4.353087)
+        self.assertAlmostEqual(core.portfolio["cash"], 1000.0)
+
+    def test_v3_without_validation_hold_retains_existing_repair_behavior(self):
+        core = FakeCore(epoch_id="stable-paper-v3-20260825-successor01", validation_hold=False)
+
+        with mock.patch.object(accounting, "reconstruct_from_ledger", return_value=PRE_EXIT_RECONSTRUCTION):
+            status = accounting.reconcile(core, persist=False)
+
+        self.assertTrue(status["repaired"])
+        self.assertFalse(status["successor_validation_hold_read_only"])
+        self.assertIn("SLS", core.portfolio["positions"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the prospective root cause proven in Issue #126. During a full paper exit, base execution mutates cash/position state and then calls set_cooldown before record_trade. set_cooldown re-enters get_risk_controls, whose legacy accounting wrapper can reconstruct from the verified baseline before the new canonical exit row exists and restore the just-closed position. The later partial exit then becomes an impossible canonical lifecycle row.

This PR keeps legacy verified-v2 reconciliation behavior intact, but makes stable-paper successor generations v3+ observational-only while their explicit validation hold is active. A successor accounting read can report the transient mismatch but cannot mutate cash/positions during an in-flight execution boundary. Once the canonical exit is visible, the same state reconciles cleanly. Focused regressions reproduce the exact pre-record window, prove SLS is not resurrected, prove post-record state passes, and prove legacy v2 behavior is unchanged. The Issue #126 regression is imported into the mandatory Stage-F core invariant suite so Change Safety runs it on this exact head.

Paper-only. No canonical row edit/delete/relabel, no manual halt/day-peak/history rewrite, no /paper/run, no strategy/signals/sizing/risk-threshold/live/ML authority change. Current contaminated v3 state is intentionally not repaired by this PR; a separate exact-evidence successor disposition will be required after prospective deployment proof.