### PR TITLE
Recover Issue #126 into deterministic v4 successor epoch

### DIFF
--- a/clean_epoch_successor_compatibility.py
+++ b/clean_epoch_successor_compatibility.py
@@ -2,9 +2,8 @@
 
 The 2026-08-10 clean epoch migration leaves a durable completion marker. Later,
 explicit verified-snapshot roll-forwards are allowed to supersede that epoch.
-This shim teaches the old migration to treat only the exact v1->v2 and
-v1->v2->v3 successor relationships as healthy instead of reporting a missing
-active epoch.
+This shim teaches the old migration to treat only the exact v1->v2->v3->v4
+successor relationships as healthy instead of reporting a missing active epoch.
 
 It does not mutate account state, risk limits, strategy, sizing, live authority,
 or ML authority. Any unrelated epoch mismatch continues to fail closed.
@@ -13,11 +12,13 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "clean-epoch-successor-compatibility-2026-08-25-v2-v3-chain"
+VERSION = "clean-epoch-successor-compatibility-2026-08-26-v3-v4-chain"
 OLD_EPOCH_ID = "stable-paper-v1-20260810-clean01"
 VERIFIED_V2_EPOCH_ID = "stable-paper-v2-20260812-verified01"
 NEW_EPOCH_ID = VERIFIED_V2_EPOCH_ID
 ISSUE82_V3_EPOCH_ID = "stable-paper-v3-20260825-successor01"
+ISSUE126_V4_EPOCH_ID = "stable-paper-v4-20260826-successor01"
+ISSUE126_V4_DECISION = "issue126_sls_reentrant_accounting_successor_rollforward"
 _APPLIED = False
 
 
@@ -45,6 +46,14 @@ def _successor_epoch(core: Any) -> str | None:
         and bool(epoch.get("validation_hold", False))
     ):
         return ISSUE82_V3_EPOCH_ID
+    if bool(
+        epoch_id == ISSUE126_V4_EPOCH_ID
+        and str(epoch.get("prior_epoch_id") or "") == ISSUE82_V3_EPOCH_ID
+        and str(epoch.get("historical_recovery_decision") or "") == ISSUE126_V4_DECISION
+        and bool(epoch.get("historical_evidence_archived", False))
+        and bool(epoch.get("validation_hold", False))
+    ):
+        return ISSUE126_V4_EPOCH_ID
     return None
 
 

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-25-v38-issue82-successor-finalizer"
+VERSION = "data-integrity-startup-bridge-2026-08-26-v39-issue126-v4-successor"
 MODULES = (
     "final_daily_audit_compactor",
     "daily_audit_entry_count_bridge",
@@ -83,9 +83,14 @@ MODULES = (
     "multi_asset_shadow_ranker",
     # Final Issue #82 consistency owner. Production proved that later startup
     # composition could restore verified-v2 after the v3 cutover completed. This
-    # exact-marker finalizer runs last in both apply and route-registration passes
-    # and can retry only that proven interrupted-completion shape.
+    # exact-marker finalizer can retry only that proven interrupted-completion shape.
     "verified_v2_successor_epoch_migration_finalizer",
+    # Final Issue #126 state owner. It accepts only the exact post-PR-127 v3
+    # three-row lifecycle evidence, archives v3, replays the two valid rows, and
+    # starts v4 while preserving the lifecycle halt. Keeping this module last in
+    # both apply/register passes also makes the v4 cutover sticky against any
+    # earlier legacy startup registration that restores a stale v3 snapshot.
+    "verified_v3_successor_epoch_migration",
 )
 
 

--- a/test_architecture_stage_f_canary.py
+++ b/test_architecture_stage_f_canary.py
@@ -8,6 +8,8 @@ import unittest
 from test_issue126_successor_accounting_reconcile_boundary import (
     Issue126SuccessorAccountingBoundaryTests,
 )
+from test_issue126_successor_compatibility import Issue126SuccessorCompatibilityTests
+from test_verified_v3_successor_epoch_migration import Issue126V3V4SuccessorMigrationTests
 from trading.canary import (
     CanaryEvidence,
     CanaryInvariantError,

--- a/test_issue126_successor_compatibility.py
+++ b/test_issue126_successor_compatibility.py
@@ -12,7 +12,7 @@ import verified_v2_successor_epoch_migration_precondition_compatibility as v2_co
 
 class Issue126SuccessorCompatibilityTests(unittest.TestCase):
     @staticmethod
-    def _v4_core():
+    def _v4_core(*, canonical_history_retained_immutably=True):
         return types.SimpleNamespace(portfolio={
             "accounting_epoch_id": clean_compat.ISSUE126_V4_EPOCH_ID,
             "paper_accounting_epoch": {
@@ -21,7 +21,7 @@ class Issue126SuccessorCompatibilityTests(unittest.TestCase):
                 "historical_recovery_decision": clean_compat.ISSUE126_V4_DECISION,
                 "historical_evidence_archived": True,
                 "validation_hold": True,
-                "canonical_history_retained_immutably": True,
+                "canonical_history_retained_immutably": canonical_history_retained_immutably,
             },
         })
 
@@ -61,8 +61,7 @@ class Issue126SuccessorCompatibilityTests(unittest.TestCase):
         self.assertFalse(result["writes_state"])
 
     def test_v2_migration_compatibility_fails_closed_on_v4_lineage_mismatch(self):
-        core = self._v4_core()
-        core.portfolio["paper_accounting_epoch"]["canonical_history_retained_immutably"] = False
+        core = self._v4_core(canonical_history_retained_immutably=False)
         self.assertFalse(v2_compat._exact_issue126_v4_successor(v2_migration, core))
 
     def test_compatibility_adds_no_trading_or_state_authority(self):

--- a/test_issue126_successor_compatibility.py
+++ b/test_issue126_successor_compatibility.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import copy
+import types
+import unittest
+from unittest import mock
+
+import clean_epoch_successor_compatibility as clean_compat
+import verified_v2_successor_epoch_migration as v2_migration
+import verified_v2_successor_epoch_migration_precondition_compatibility as v2_compat
+
+
+class Issue126SuccessorCompatibilityTests(unittest.TestCase):
+    @staticmethod
+    def _v4_core():
+        return types.SimpleNamespace(portfolio={
+            "accounting_epoch_id": clean_compat.ISSUE126_V4_EPOCH_ID,
+            "paper_accounting_epoch": {
+                "id": clean_compat.ISSUE126_V4_EPOCH_ID,
+                "prior_epoch_id": clean_compat.ISSUE82_V3_EPOCH_ID,
+                "historical_recovery_decision": clean_compat.ISSUE126_V4_DECISION,
+                "historical_evidence_archived": True,
+                "validation_hold": True,
+                "canonical_history_retained_immutably": True,
+            },
+        })
+
+    def test_clean_epoch_compatibility_accepts_only_exact_v4_successor(self):
+        core = self._v4_core()
+        self.assertEqual(clean_compat._successor_epoch(core), clean_compat.ISSUE126_V4_EPOCH_ID)
+        self.assertTrue(clean_compat._is_verified_successor(core))
+
+        for field, bad in (
+            ("prior_epoch_id", "wrong-prior"),
+            ("historical_recovery_decision", "wrong-decision"),
+            ("historical_evidence_archived", False),
+            ("validation_hold", False),
+        ):
+            changed = copy.deepcopy(core.portfolio)
+            changed["paper_accounting_epoch"][field] = bad
+            self.assertFalse(clean_compat._is_verified_successor(types.SimpleNamespace(portfolio=changed)))
+
+    def test_v2_migration_compatibility_treats_exact_v4_as_superseded_without_write(self):
+        core = self._v4_core()
+        self.assertTrue(v2_compat._exact_issue126_v4_successor(v2_migration, core))
+        before = copy.deepcopy(core.portfolio)
+        calls = {"original": 0}
+
+        def original(runtime_core=None):
+            calls["original"] += 1
+            return {"status": "error", "overall": "fail", "reason": "should_not_run"}
+
+        with mock.patch.object(v2_migration, "apply", original):
+            v2_compat._install_migration_apply_compatibility(v2_migration)
+            result = v2_migration.apply(core)
+
+        self.assertEqual(result["status"], "superseded")
+        self.assertEqual(result["active_epoch_id"], clean_compat.ISSUE126_V4_EPOCH_ID)
+        self.assertEqual(calls["original"], 0)
+        self.assertEqual(core.portfolio, before)
+        self.assertFalse(result["writes_state"])
+
+    def test_v2_migration_compatibility_fails_closed_on_v4_lineage_mismatch(self):
+        core = self._v4_core()
+        core.portfolio["paper_accounting_epoch"]["canonical_history_retained_immutably"] = False
+        self.assertFalse(v2_compat._exact_issue126_v4_successor(v2_migration, core))
+
+    def test_compatibility_adds_no_trading_or_state_authority(self):
+        authority = v2_compat.status_payload(None)["authority"]
+        self.assertFalse(authority["writes_state"])
+        self.assertFalse(authority["edits_or_deletes_canonical_rows"])
+        self.assertFalse(authority["rewrites_current_day_peak"])
+        self.assertFalse(authority["clears_hard_halt"])
+        self.assertFalse(authority["places_orders"])
+        self.assertFalse(authority["changes_strategy"])
+        self.assertFalse(authority["changes_thresholds"])
+        self.assertFalse(authority["changes_risk_or_sizing"])
+        self.assertFalse(authority["changes_live_or_ml_authority"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_verified_v3_successor_epoch_migration.py
+++ b/test_verified_v3_successor_epoch_migration.py
@@ -62,7 +62,7 @@ class Issue126V3V4SuccessorMigrationTests(unittest.TestCase):
         equity = cash + dhr_qty * 215.79
         return cash, dhr_qty, equity
 
-    def _portfolio(self):
+    def _portfolio(self, *, halt_reason="canonical execution lifecycle integrity halt"):
         projected_cash, dhr_qty, _ = self._projection_numbers()
         invalid_notional = float(migration.EXPECTED_V3_ROWS[2]["shares"]) * 16.04
         rows = self._rows()[-3:]
@@ -101,7 +101,7 @@ class Issue126V3V4SuccessorMigrationTests(unittest.TestCase):
                 "day_start_equity": 13535.962581344369,
                 "day_peak_equity": 13618.111792229607,
                 "halted": True,
-                "halt_reason": "canonical execution lifecycle integrity halt",
+                "halt_reason": halt_reason,
                 "intraday_drawdown_pct": 0.121,
             },
             "accounting_epoch_id": migration.OLD_EPOCH_ID,
@@ -230,8 +230,7 @@ class Issue126V3V4SuccessorMigrationTests(unittest.TestCase):
     def test_preconditions_do_not_accept_a_different_halt(self):
         import canonical_execution_ledger as ledger
         import paper_bidirectional_accounting_guard as accounting
-        core = types.SimpleNamespace(portfolio=self._portfolio())
-        core.portfolio["risk_controls"]["halt_reason"] = "different halt"
+        core = types.SimpleNamespace(portfolio=self._portfolio(halt_reason="different halt"))
         expected_cash, expected_qty, expected_equity = self._projection_numbers()
         accounting_result = {
             "coverage_issues": [{"action": "partial_exit", "symbol": "SLS", "side": "long", "reason": "exit_exceeds_reconstructed_position", "requested_qty": 1.436519, "price": 16.04}],

--- a/test_verified_v3_successor_epoch_migration.py
+++ b/test_verified_v3_successor_epoch_migration.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import contextlib
+import copy
+import sys
+import types
+import unittest
+from unittest import mock
+
+import verified_v3_successor_epoch_migration as migration
+
+
+class Issue126V3V4SuccessorMigrationTests(unittest.TestCase):
+    def _baseline_snapshot(self):
+        return {
+            "verified": True,
+            "cash": migration.EXPECTED_BASELINE_CASH,
+            "equity": migration.EXPECTED_BASELINE_EQUITY,
+            "realized_today": 0.0,
+            "realized_total": 42.0,
+            "positions": {
+                "DHR": {"side": "long", "qty": 0.540748758, "entry_price": 216.960007, "mark": 215.79},
+                "SLS": {"side": "long", "qty": migration.EXPECTED_BASELINE_SLS_QTY, "entry_price": 14.335, "mark": 14.45},
+            },
+        }
+
+    def _rows(self):
+        rows = [
+            {
+                "execution_id": f"legacy-{index}",
+                "accounting_epoch_id": migration.PRIOR_EPOCH_ID,
+                "action": "entry",
+                "symbol": f"LEG{index}",
+                "side": "long",
+                "price": 1.0,
+                "shares": 1.0,
+                "event_hash": f"legacy-hash-{index}",
+            }
+            for index in range(migration.EXPECTED_V3_START_INDEX)
+        ]
+        rows.extend([
+            {
+                **migration.EXPECTED_V3_ROWS[0],
+                "shares": migration.EXPECTED_BASELINE_SLS_QTY,
+            },
+            {
+                **migration.EXPECTED_V3_ROWS[1],
+                "shares": 0.178447,
+            },
+            dict(migration.EXPECTED_V3_ROWS[2]),
+        ])
+        for row in rows:
+            row.pop("ledger_index", None)
+            row.pop("economic_disposition", None)
+        return rows
+
+    def _projection_numbers(self):
+        cash = migration.EXPECTED_BASELINE_CASH
+        cash += migration.EXPECTED_BASELINE_SLS_QTY * 13.62
+        cash += 0.178447 * 242.4872
+        dhr_qty = 0.540748758 - 0.178447
+        equity = cash + dhr_qty * 215.79
+        return cash, dhr_qty, equity
+
+    def _portfolio(self):
+        projected_cash, dhr_qty, _ = self._projection_numbers()
+        invalid_notional = float(migration.EXPECTED_V3_ROWS[2]["shares"]) * 16.04
+        rows = self._rows()[-3:]
+        trades = []
+        for row in rows:
+            trades.append({
+                "execution_id": row["execution_id"],
+                "accounting_epoch_id": migration.OLD_EPOCH_ID,
+                "action": row["action"],
+                "symbol": row["symbol"],
+                "side": row["side"],
+                "price": row["price"],
+                "shares": round(float(row["shares"]), 6),
+                "canonical_ledger_event_hash": row["event_hash"],
+            })
+        return {
+            "cash": projected_cash + invalid_notional,
+            "equity": 13601.69,
+            "positions": {
+                "DHR": {"side": "long", "shares": dhr_qty, "qty": dhr_qty, "entry": 216.960007, "last_price": 215.79},
+                "SLS": {
+                    "side": "long",
+                    "shares": migration.EXPECTED_BASELINE_SLS_QTY - float(migration.EXPECTED_V3_ROWS[2]["shares"]),
+                    "qty": migration.EXPECTED_BASELINE_SLS_QTY,
+                    "entry": 14.335,
+                    "last_price": 16.04,
+                    "accounting_integrity_quarantined": True,
+                },
+            },
+            "trades": trades,
+            "history": [13535.96, 13618.11, 13601.69],
+            "realized_pnl": {"today": 3.9, "total": 45.9},
+            "performance": {"realized_pnl_today": 3.9, "realized_pnl_total": 45.9, "unrealized_pnl": -2.33},
+            "risk_controls": {
+                "date": "2026-08-26",
+                "day_start_equity": 13535.962581344369,
+                "day_peak_equity": 13618.111792229607,
+                "halted": True,
+                "halt_reason": "canonical execution lifecycle integrity halt",
+                "intraday_drawdown_pct": 0.121,
+            },
+            "accounting_epoch_id": migration.OLD_EPOCH_ID,
+            "paper_accounting_epoch": {
+                "id": migration.OLD_EPOCH_ID,
+                "prior_epoch_id": migration.PRIOR_EPOCH_ID,
+                "historical_recovery_decision": "verified_v2_historical_disposition_successor_rollforward",
+                "historical_evidence_archived": True,
+                "validation_hold": True,
+                "baseline_type": "verified_snapshot_with_open_position",
+                "starting_cash": migration.EXPECTED_BASELINE_CASH,
+                "starting_equity": migration.EXPECTED_BASELINE_EQUITY,
+                "verified_snapshot_baseline": self._baseline_snapshot(),
+            },
+        }
+
+    def _canonical(self, rows=None):
+        rows = rows or self._rows()
+        return {
+            "status": "ok",
+            "row_count": len(rows),
+            "chain_valid": True,
+            "v3_rows_exact": True,
+            "all_execution_ids_unique": True,
+            "raw_rows": rows,
+        }
+
+    def test_exact_production_rows_project_only_dhr_and_exclude_invalid_sls_partial(self):
+        core = types.SimpleNamespace(portfolio=self._portfolio())
+        projection = migration._project(core, self._baseline_snapshot(), self._canonical())
+        expected_cash, expected_qty, expected_equity = self._projection_numbers()
+
+        self.assertEqual(projection["status"], "ok")
+        self.assertEqual(projection["open_symbols"], ["DHR"])
+        self.assertEqual(projection["excluded_execution_ids"], [migration.INVALID_EXECUTION_ID])
+        self.assertEqual(projection["valid_execution_ids"], [
+            migration.EXPECTED_V3_ROWS[0]["execution_id"],
+            migration.EXPECTED_V3_ROWS[1]["execution_id"],
+        ])
+        self.assertAlmostEqual(projection["cash"], expected_cash, places=6)
+        self.assertAlmostEqual(projection["positions"]["DHR"]["shares"], expected_qty, places=9)
+        self.assertAlmostEqual(projection["equity"], expected_equity, places=6)
+        self.assertNotIn("SLS", projection["positions"])
+
+    def test_exact_canonical_signature_fails_closed_on_hash_mismatch_or_extra_v3_row(self):
+        import canonical_execution_ledger as ledger
+        rows = self._rows()
+        with mock.patch.object(ledger, "_read_rows", return_value=(rows, [])), mock.patch.object(ledger, "_verify_rows", return_value=(True, [])):
+            observed, ready = migration._canonical_evidence(types.SimpleNamespace())
+        self.assertTrue(ready)
+        self.assertTrue(observed["v3_rows_exact"])
+
+        bad = copy.deepcopy(rows)
+        bad[-1]["event_hash"] = "wrong"
+        with mock.patch.object(ledger, "_read_rows", return_value=(bad, [])), mock.patch.object(ledger, "_verify_rows", return_value=(True, [])):
+            _, ready = migration._canonical_evidence(types.SimpleNamespace())
+        self.assertFalse(ready)
+
+        extra = copy.deepcopy(rows)
+        extra.append({
+            "execution_id": "unexpected",
+            "accounting_epoch_id": migration.OLD_EPOCH_ID,
+            "action": "exit",
+            "symbol": "DHR",
+            "side": "long",
+            "price": 220.0,
+            "shares": 0.1,
+            "event_hash": "unexpected-hash",
+        })
+        with mock.patch.object(ledger, "_read_rows", return_value=(extra, [])), mock.patch.object(ledger, "_verify_rows", return_value=(True, [])):
+            _, ready = migration._canonical_evidence(types.SimpleNamespace())
+        self.assertFalse(ready)
+
+    def test_successor_state_preserves_risk_day_halt_and_history(self):
+        before = self._portfolio()
+        original_risk = copy.deepcopy(before["risk_controls"])
+        original_history = copy.deepcopy(before["history"])
+        projection = migration._project(types.SimpleNamespace(portfolio=before), self._baseline_snapshot(), self._canonical())
+        after = migration.build_successor_state(before, projection, "/archive/issue126", "2026-08-26 14:00:00 CDT")
+
+        self.assertEqual(before["accounting_epoch_id"], migration.OLD_EPOCH_ID)
+        self.assertEqual(after["accounting_epoch_id"], migration.TARGET_EPOCH_ID)
+        self.assertEqual(after["trades"], [])
+        self.assertEqual(sorted(after["positions"]), ["DHR"])
+        self.assertEqual(after["risk_controls"], original_risk)
+        self.assertEqual(after["history"], original_history)
+        epoch = after["paper_accounting_epoch"]
+        self.assertTrue(epoch["validation_hold"])
+        self.assertFalse(epoch["validation_released"])
+        self.assertEqual(epoch["invalid_execution_id"], migration.INVALID_EXECUTION_ID)
+        self.assertTrue(epoch["canonical_history_retained_immutably"])
+
+    def test_exact_authoritative_contamination_shape_satisfies_preconditions(self):
+        import canonical_execution_ledger as ledger
+        import paper_bidirectional_accounting_guard as accounting
+        core = types.SimpleNamespace(portfolio=self._portfolio())
+        expected_cash, expected_qty, expected_equity = self._projection_numbers()
+        accounting_result = {
+            "status": "partial",
+            "coverage_complete": False,
+            "coverage_issues": [{
+                "action": "partial_exit",
+                "symbol": "SLS",
+                "side": "long",
+                "reason": "exit_exceeds_reconstructed_position",
+                "requested_qty": 1.436519,
+                "matched_qty": 0.0,
+                "unmatched_qty": 1.436519,
+                "price": 16.04,
+            }],
+            "coverage_issue_count": 1,
+            "economic_issues": [],
+            "economic_issue_count": 0,
+            "cash": expected_cash,
+            "equity": expected_equity,
+            "open_positions": {
+                "DHR": {"side": "long", "qty": expected_qty, "entry_price": 216.960007, "last_price": 215.79}
+            },
+        }
+        rows = self._rows()
+        with mock.patch.object(ledger, "_read_rows", return_value=(rows, [])), mock.patch.object(ledger, "_verify_rows", return_value=(True, [])), mock.patch.object(accounting, "analyze_ledger", return_value=accounting_result):
+            pre = migration._preconditions(core)
+        self.assertEqual(pre["failed"], [])
+        self.assertTrue(all(pre["checks"].values()))
+
+    def test_preconditions_do_not_accept_a_different_halt(self):
+        import canonical_execution_ledger as ledger
+        import paper_bidirectional_accounting_guard as accounting
+        core = types.SimpleNamespace(portfolio=self._portfolio())
+        core.portfolio["risk_controls"]["halt_reason"] = "different halt"
+        expected_cash, expected_qty, expected_equity = self._projection_numbers()
+        accounting_result = {
+            "coverage_issues": [{"action": "partial_exit", "symbol": "SLS", "side": "long", "reason": "exit_exceeds_reconstructed_position", "requested_qty": 1.436519, "price": 16.04}],
+            "economic_issues": [],
+            "cash": expected_cash,
+            "equity": expected_equity,
+            "open_positions": {"DHR": {"qty": expected_qty}},
+        }
+        rows = self._rows()
+        with mock.patch.object(ledger, "_read_rows", return_value=(rows, [])), mock.patch.object(ledger, "_verify_rows", return_value=(True, [])), mock.patch.object(accounting, "analyze_ledger", return_value=accounting_result):
+            pre = migration._preconditions(core)
+        self.assertIn("existing_lifecycle_halt_preserved", pre["failed"])
+
+    def test_cutover_never_changes_canonical_bytes_or_risk_history(self):
+        import canonical_execution_ledger as ledger
+        import clean_accounting_epoch as clean
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as folder:
+            ledger_path = Path(folder) / "canonical_execution_ledger.jsonl"
+            ledger_bytes = b'{"immutable":"canonical"}\n'
+            ledger_path.write_bytes(ledger_bytes)
+            marker = Path(folder) / "marker.json"
+            core = types.SimpleNamespace(portfolio=self._portfolio(), local_ts_text=lambda: "2026-08-26 14:00:00 CDT")
+            projection = migration._project(core, self._baseline_snapshot(), self._canonical())
+            pre = {"projection": projection, "canonical": {"row_count": 45, "chain_valid": True}}
+            risk_before = copy.deepcopy(core.portfolio["risk_controls"])
+            history_before = copy.deepcopy(core.portfolio["history"])
+            saved = {}
+
+            def write_state(runtime_core, state):
+                saved["state"] = copy.deepcopy(state)
+                return str(Path(folder) / "state.json")
+
+            with mock.patch.object(ledger, "LEDGER_FILE", str(ledger_path)), \
+                 mock.patch.object(clean, "_runtime_locks", return_value=contextlib.nullcontext()), \
+                 mock.patch.object(clean, "_write_clean_state_and_backups", side_effect=write_state), \
+                 mock.patch.object(clean, "_reset_snapshot_archive", return_value=None), \
+                 mock.patch.object(migration, "_archive_state", return_value={"archive_dir": str(Path(folder) / "archive")}), \
+                 mock.patch.object(migration, "_rotate_journal_for_successor", return_value=None), \
+                 mock.patch.object(migration, "MARKER_FILE", str(marker)):
+                result = migration._cutover(core, pre)
+
+            self.assertEqual(ledger_path.read_bytes(), ledger_bytes)
+            self.assertTrue(result["canonical_ledger_unchanged"])
+            self.assertEqual(core.portfolio["risk_controls"], risk_before)
+            self.assertEqual(core.portfolio["history"], history_before)
+            self.assertEqual(core.portfolio["accounting_epoch_id"], migration.TARGET_EPOCH_ID)
+            self.assertEqual(saved["state"]["trades"], [])
+
+    def test_authority_never_clears_halt_or_edits_ledger(self):
+        authority = migration.status_payload(None)["authority"]
+        self.assertFalse(authority["edits_or_deletes_canonical_rows"])
+        self.assertFalse(authority["rotates_or_truncates_canonical_ledger"])
+        self.assertFalse(authority["rewrites_current_day_peak"])
+        self.assertFalse(authority["rewrites_history"])
+        self.assertFalse(authority["clears_hard_halt"])
+        self.assertFalse(authority["places_orders"])
+        self.assertFalse(authority["changes_strategy"])
+        self.assertFalse(authority["changes_thresholds"])
+        self.assertFalse(authority["changes_risk_or_sizing"])
+        self.assertFalse(authority["changes_live_or_ml_authority"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verified_v2_successor_epoch_migration_precondition_compatibility.py
+++ b/verified_v2_successor_epoch_migration_precondition_compatibility.py
@@ -12,8 +12,13 @@ state can be restored by later registration before the final startup consistency
 owner runs. The migration correctly reports that mismatch as an error, but doing
 so inside the bridge prevents the finalizer from getting the chance to repair the
 already-proven interrupted completion. This compatibility layer therefore defers
-only that exact error shape to the dedicated finalizer. It never performs the
-cutover itself and leaves every other migration error unchanged.
+only that exact error shape to the dedicated finalizer.
+
+Issue #126 introduces one later exact successor relationship: v3 may be archived
+into the verified v4 accounting epoch. Once that exact v4 epoch is active, the
+older v2->v3 migration is legitimately superseded and must not report its durable
+v3 completion marker as an active-epoch error. This compatibility is reporting
+only; the v4 migration remains the sole v3->v4 write owner.
 
 No state, ledger, risk, order, strategy, sizing, threshold, live, or ML authority
 is added here.
@@ -22,10 +27,12 @@ from __future__ import annotations
 
 from typing import Any, Dict, Tuple
 
-VERSION = "verified-v2-successor-precondition-production-shape-2026-08-25-v2-finalizer-deferral"
+VERSION = "verified-v2-successor-precondition-production-shape-2026-08-26-v3-v4-supersession"
 EQUITY_MARK_DRIFT_TOLERANCE = 2.0
 QTY_SERIALIZATION_TOLERANCE = 5e-6
 ENTRY_PRICE_TOLERANCE = 1e-4
+ISSUE126_V4_EPOCH_ID = "stable-paper-v4-20260826-successor01"
+ISSUE126_V4_DECISION = "issue126_sls_reentrant_accounting_successor_rollforward"
 _APPLIED = False
 
 
@@ -101,9 +108,23 @@ def _exact_interrupted_completion(migration: Any, core: Any) -> bool:
     )
 
 
-def _defer_exact_interrupted_completion_error(
-    migration: Any, core: Any, result: Any
-) -> Any:
+def _exact_issue126_v4_successor(migration: Any, core: Any) -> bool:
+    if core is None:
+        return False
+    pf = migration._portfolio(core)
+    epoch = migration._d(pf.get("paper_accounting_epoch"))
+    active_epoch = str(epoch.get("id") or pf.get("accounting_epoch_id") or "")
+    return bool(
+        active_epoch == ISSUE126_V4_EPOCH_ID
+        and str(epoch.get("prior_epoch_id") or "") == migration.TARGET_EPOCH_ID
+        and str(epoch.get("historical_recovery_decision") or "") == ISSUE126_V4_DECISION
+        and bool(epoch.get("historical_evidence_archived", False))
+        and bool(epoch.get("validation_hold", False))
+        and bool(epoch.get("canonical_history_retained_immutably", False))
+    )
+
+
+def _defer_exact_interrupted_completion_error(migration: Any, core: Any, result: Any) -> Any:
     if not isinstance(result, dict):
         return result
     if not (
@@ -135,6 +156,16 @@ def _install_migration_apply_compatibility(migration: Any) -> None:
     original = current
 
     def interrupted_completion_compatible_apply(runtime_core: Any = None) -> Any:
+        if _exact_issue126_v4_successor(migration, runtime_core):
+            return {
+                "status": "superseded",
+                "overall": "pass",
+                "version": VERSION,
+                "active_epoch_id": ISSUE126_V4_EPOCH_ID,
+                "superseded_epoch_id": migration.TARGET_EPOCH_ID,
+                "reason": "exact_issue126_v4_successor_active",
+                "writes_state": False,
+            }
         result = original(runtime_core)
         return _defer_exact_interrupted_completion_error(migration, runtime_core, result)
 
@@ -170,12 +201,14 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "version": VERSION,
         "production_accounting_payload_shape_supported": bool(_APPLIED),
         "exact_interrupted_completion_error_deferred_to_finalizer": bool(_APPLIED),
+        "exact_issue126_v4_successor_supersession_supported": bool(_APPLIED),
         "equity_mark_drift_tolerance_dollars": EQUITY_MARK_DRIFT_TOLERANCE,
         "authority": {
             "precondition_only": True,
             "writes_state": False,
             "defers_only_exact_completed_v3_marker_with_verified_v2_reversion": True,
-            "finalizer_remains_only_retry_owner": True,
+            "accepts_only_exact_issue126_v4_successor_as_v3_supersession": True,
+            "finalizer_remains_only_v2_to_v3_retry_owner": True,
             "edits_or_deletes_canonical_rows": False,
             "rewrites_current_day_peak": False,
             "clears_hard_halt": False,

--- a/verified_v3_successor_epoch_migration.py
+++ b/verified_v3_successor_epoch_migration.py
@@ -1,0 +1,886 @@
+"""Exact-evidence Issue #126 v3 -> v4 successor accounting migration.
+
+The active v3 paper epoch contains one proven immutable lifecycle artifact. A
+valid SLS full exit was followed by a re-entrant legacy accounting read before
+its canonical row was mirrored into state. That read restored the just-closed
+SLS position, allowing one later SLS partial exit that cannot be matched to any
+remaining canonical quantity.
+
+This module never changes the append-only canonical ledger. It requires the
+exact three-row v3 canonical shape proven by the post-PR-127 Splendid snapshot,
+excludes only the exact invalid SLS partial row from successor economics, replays
+the two valid rows from the verified v3 snapshot baseline, archives the complete
+v3 persistence, and starts a v4 verified-snapshot accounting epoch.
+
+The existing canonical lifecycle halt and current-day risk peak are preserved.
+The v4 epoch remains under validation hold. No strategy, signal, sizing, risk
+threshold, live authority, ML authority, or order authority is changed.
+"""
+from __future__ import annotations
+
+import copy
+import datetime as dt
+import hashlib
+import json
+import math
+import os
+import shutil
+import threading
+from typing import Any, Dict, List, Tuple
+
+VERSION = "verified-v3-successor-epoch-migration-2026-08-26-v1-issue126-sls-disposition"
+OLD_EPOCH_ID = "stable-paper-v3-20260825-successor01"
+TARGET_EPOCH_ID = "stable-paper-v4-20260826-successor01"
+PRIOR_EPOCH_ID = "stable-paper-v2-20260812-verified01"
+DECISION_ID = "issue-126-sls-reentrant-accounting-disposition-2026-08-26"
+HISTORICAL_DECISION = "issue126_sls_reentrant_accounting_successor_rollforward"
+EXPECTED_LEDGER_ROW_COUNT = 45
+EXPECTED_V3_START_INDEX = 42
+EXPECTED_BASELINE_CASH = 13357.874520862653
+EXPECTED_BASELINE_EQUITY = 13535.962581344369
+EXPECTED_BASELINE_SLS_QTY = 4.353086829
+QTY_TOLERANCE = 5e-6
+PRICE_TOLERANCE = 1e-9
+MONEY_TOLERANCE = 0.01
+EQUITY_TOLERANCE = 0.05
+STATE_DIR = os.environ.get("STATE_DIR") or os.environ.get("PERSISTENT_STATE_DIR") or os.environ.get("RAILWAY_VOLUME_MOUNT_PATH") or "."
+ARCHIVE_ROOT = os.path.join(STATE_DIR, "forensic_archives")
+MARKER_FILE = os.path.join(STATE_DIR, f"successor_epoch_{DECISION_ID}.json")
+_LOCK = threading.RLock()
+_REGISTERED_APP_IDS: set[int] = set()
+_LAST: Dict[str, Any] = {}
+
+EXPECTED_V3_ROWS: tuple[dict[str, Any], ...] = (
+    {
+        "ledger_index": 42,
+        "execution_id": "9ab93335faff4e3293d24ebe0bad4e87",
+        "accounting_epoch_id": OLD_EPOCH_ID,
+        "action": "exit",
+        "symbol": "SLS",
+        "side": "long",
+        "price": 13.62,
+        "shares": EXPECTED_BASELINE_SLS_QTY,
+        "event_hash": "d4564210ff39029aeea4727ccc121a18445fe7c79c21fa96bc5f4a8874e4b725",
+        "economic_disposition": "valid_replay",
+    },
+    {
+        "ledger_index": 43,
+        "execution_id": "26702f252870490c8f1ddab86ce794f5",
+        "accounting_epoch_id": OLD_EPOCH_ID,
+        "action": "partial_exit",
+        "symbol": "DHR",
+        "side": "long",
+        "price": 242.4872,
+        "shares": 0.178447,
+        "event_hash": "f29532b852bca42c7ee690643e167d9c2a1229a8b44d6dcc9eb1089a1939ddd2",
+        "economic_disposition": "valid_replay",
+    },
+    {
+        "ledger_index": 44,
+        "execution_id": "90b22aad76074031906e0c6459dfa0bc",
+        "accounting_epoch_id": OLD_EPOCH_ID,
+        "action": "partial_exit",
+        "symbol": "SLS",
+        "side": "long",
+        "price": 16.04,
+        "shares": 1.43651871,
+        "event_hash": "d39e877f34bcf9d5a720a8bfd94a66ebace9d8cfa30987bedce29a1112db8774",
+        "economic_disposition": "exclude_exact_invalid_reentrant_artifact",
+    },
+)
+INVALID_EXECUTION_ID = EXPECTED_V3_ROWS[2]["execution_id"]
+INVALID_EVENT_HASH = EXPECTED_V3_ROWS[2]["event_hash"]
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _f(value: Any) -> float | None:
+    try:
+        if value is None or isinstance(value, bool):
+            return None
+        number = float(value)
+        return number if math.isfinite(number) else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _close(value: Any, expected: float, tolerance: float) -> bool:
+    number = _f(value)
+    return number is not None and abs(number - expected) <= tolerance
+
+
+def _now(core: Any = None) -> str:
+    try:
+        return str(core.local_ts_text())
+    except Exception:
+        return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _paper_only() -> bool:
+    live = os.environ.get("LIVE_TRADING_ENABLED", "false").lower() in {"1", "true", "yes", "on"}
+    broker_live = os.environ.get("BROKER_MODE", "").lower() in {"live", "real", "production"}
+    return not live and not broker_live
+
+
+def _portfolio(core: Any) -> Dict[str, Any]:
+    pf = getattr(core, "portfolio", None) if core is not None else None
+    return pf if isinstance(pf, dict) else {}
+
+
+def _atomic_json(path: str, payload: Dict[str, Any]) -> None:
+    folder = os.path.dirname(path)
+    if folder:
+        os.makedirs(folder, exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True, default=str)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def _sha256(path: str) -> str | None:
+    if not path or not os.path.isfile(path):
+        return None
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _marker() -> Dict[str, Any]:
+    try:
+        with open(MARKER_FILE, "r", encoding="utf-8") as handle:
+            value = json.load(handle)
+        return value if isinstance(value, dict) else {}
+    except Exception:
+        return {}
+
+
+def _epoch_id(pf: Dict[str, Any]) -> str:
+    epoch = _d(pf.get("paper_accounting_epoch"))
+    return str(epoch.get("id") or epoch.get("epoch_id") or pf.get("accounting_epoch_id") or "")
+
+
+def _baseline_snapshot(pf: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
+    issues: List[str] = []
+    epoch = _d(pf.get("paper_accounting_epoch"))
+    snap = _d(epoch.get("verified_snapshot_baseline"))
+    if _epoch_id(pf) != OLD_EPOCH_ID:
+        issues.append("active_epoch_not_exact_v3")
+    if str(epoch.get("prior_epoch_id") or "") != PRIOR_EPOCH_ID:
+        issues.append("v3_prior_epoch_mismatch")
+    if str(epoch.get("historical_recovery_decision") or "") != "verified_v2_historical_disposition_successor_rollforward":
+        issues.append("v3_historical_decision_mismatch")
+    if not bool(epoch.get("historical_evidence_archived", False)):
+        issues.append("v3_historical_evidence_not_archived")
+    if not bool(epoch.get("validation_hold", False)):
+        issues.append("v3_validation_hold_not_active")
+    if str(epoch.get("baseline_type") or "") != "verified_snapshot_with_open_position":
+        issues.append("v3_baseline_type_mismatch")
+    if not bool(snap.get("verified", False)):
+        issues.append("v3_verified_snapshot_missing")
+    if not _close(snap.get("cash", epoch.get("starting_cash")), EXPECTED_BASELINE_CASH, MONEY_TOLERANCE):
+        issues.append("v3_baseline_cash_mismatch")
+    if not _close(snap.get("equity", epoch.get("starting_equity")), EXPECTED_BASELINE_EQUITY, EQUITY_TOLERANCE):
+        issues.append("v3_baseline_equity_mismatch")
+
+    positions = _d(snap.get("positions"))
+    if set(str(symbol).upper() for symbol in positions) != {"DHR", "SLS"}:
+        issues.append("v3_baseline_position_set_mismatch")
+    sls = _d(positions.get("SLS"))
+    if str(sls.get("side") or "long").lower() != "long":
+        issues.append("v3_baseline_sls_side_mismatch")
+    if not _close(sls.get("qty", sls.get("shares")), EXPECTED_BASELINE_SLS_QTY, QTY_TOLERANCE):
+        issues.append("v3_baseline_sls_qty_mismatch")
+    return snap, issues
+
+
+def _signature_checks(row: Dict[str, Any], expected: Dict[str, Any], index: int) -> Dict[str, bool]:
+    checks = {
+        "ledger_index": index == int(expected["ledger_index"]),
+        "execution_id": str(row.get("execution_id") or "") == str(expected["execution_id"]),
+        "accounting_epoch_id": str(row.get("accounting_epoch_id") or "") == OLD_EPOCH_ID,
+        "action": str(row.get("action") or "").lower() == str(expected["action"]),
+        "symbol": str(row.get("symbol") or "").upper() == str(expected["symbol"]),
+        "side": str(row.get("side") or "long").lower() == str(expected["side"]),
+        "price": _close(row.get("price"), float(expected["price"]), PRICE_TOLERANCE),
+        "event_hash": str(row.get("event_hash") or "") == str(expected["event_hash"]),
+    }
+    if "shares" in expected:
+        checks["shares"] = _close(row.get("shares"), float(expected["shares"]), QTY_TOLERANCE)
+    return checks
+
+
+def _canonical_evidence(core: Any) -> Tuple[Dict[str, Any], bool]:
+    try:
+        import canonical_execution_ledger as ledger
+        with ledger._LOCK:
+            rows, parse_errors = ledger._read_rows()
+            chain_valid, chain_errors = ledger._verify_rows(rows)
+    except Exception as exc:
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}, False
+
+    v3_rows = [(index, row) for index, row in enumerate(rows) if str(row.get("accounting_epoch_id") or "") == OLD_EPOCH_ID]
+    exact_rows: List[Dict[str, Any]] = []
+    exact = len(rows) == EXPECTED_LEDGER_ROW_COUNT and len(v3_rows) == len(EXPECTED_V3_ROWS)
+    for offset, expected in enumerate(EXPECTED_V3_ROWS):
+        if offset >= len(v3_rows):
+            exact_rows.append({"expected": dict(expected), "checks": {}, "exact": False})
+            exact = False
+            continue
+        index, row = v3_rows[offset]
+        checks = _signature_checks(row, expected, index)
+        row_exact = all(checks.values())
+        exact = exact and row_exact
+        exact_rows.append({
+            "ledger_index": index,
+            "execution_id": row.get("execution_id"),
+            "event_hash": row.get("event_hash"),
+            "checks": checks,
+            "exact": row_exact,
+            "economic_disposition": expected["economic_disposition"],
+        })
+    payload = {
+        "status": "ok" if not parse_errors and chain_valid and exact else "fail",
+        "row_count": len(rows),
+        "expected_row_count": EXPECTED_LEDGER_ROW_COUNT,
+        "parse_errors": parse_errors[:5],
+        "chain_valid": bool(chain_valid),
+        "chain_errors": chain_errors[:5],
+        "v3_row_count": len(v3_rows),
+        "v3_rows_exact": bool(exact),
+        "rows": exact_rows,
+        "all_execution_ids_unique": len({str(row.get("execution_id") or "") for row in rows}) == len(rows),
+    }
+    ready = bool(not parse_errors and chain_valid and exact and payload["all_execution_ids_unique"])
+    if ready:
+        payload["raw_rows"] = rows
+    return payload, ready
+
+
+def _state_trade_evidence(pf: Dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
+    trades = [row for row in _l(pf.get("trades")) if isinstance(row, dict)]
+    checks: List[Dict[str, Any]] = []
+    exact = len(trades) == len(EXPECTED_V3_ROWS)
+    for index, expected in enumerate(EXPECTED_V3_ROWS):
+        row = trades[index] if index < len(trades) else {}
+        row_checks = {
+            "execution_id": str(row.get("execution_id") or "") == str(expected["execution_id"]),
+            "accounting_epoch_id": str(row.get("accounting_epoch_id") or "") == OLD_EPOCH_ID,
+            "action": str(row.get("action") or "").lower() == str(expected["action"]),
+            "symbol": str(row.get("symbol") or "").upper() == str(expected["symbol"]),
+            "side": str(row.get("side") or "long").lower() == str(expected["side"]),
+            "price": _close(row.get("price"), float(expected["price"]), 1e-6),
+            "canonical_ledger_event_hash": str(row.get("canonical_ledger_event_hash") or "") == str(expected["event_hash"]),
+        }
+        row_exact = bool(row and all(row_checks.values()))
+        exact = exact and row_exact
+        checks.append({"trade_index": index, "execution_id": row.get("execution_id"), "checks": row_checks, "exact": row_exact})
+    return {"state_trade_count": len(trades), "state_trade_rows_exact": bool(exact), "rows": checks}, bool(exact)
+
+
+def _opening_books(snapshot: Dict[str, Any]) -> Tuple[float, Dict[str, Dict[str, float]], float, float, List[str]]:
+    issues: List[str] = []
+    cash = _f(snapshot.get("cash"))
+    if cash is None or cash <= 0:
+        return 0.0, {}, 0.0, 0.0, ["baseline_cash_invalid"]
+    books: Dict[str, Dict[str, float]] = {}
+    for raw_symbol, raw in _d(snapshot.get("positions")).items():
+        pos = _d(raw)
+        symbol = str(raw_symbol or "").upper().strip()
+        side = str(pos.get("side") or "long").lower().strip()
+        qty = _f(pos.get("qty", pos.get("shares")))
+        entry = _f(pos.get("entry_price", pos.get("entry")))
+        if not symbol or side not in {"long", "short"} or qty is None or qty <= 0 or entry is None or entry <= 0:
+            issues.append(f"invalid_baseline_position:{symbol or 'unknown'}")
+            continue
+        books[symbol] = {"side": side, "qty": qty, "entry_price": entry}
+    realized_today = float(_f(snapshot.get("realized_today")) or 0.0)
+    realized_total = float(_f(snapshot.get("realized_total")) or 0.0)
+    return float(cash), books, realized_today, realized_total, issues
+
+
+def _apply_execution(cash: float, books: Dict[str, Dict[str, float]], realized_today: float, realized_total: float, row: Dict[str, Any]) -> Tuple[float, float, float, List[str]]:
+    issues: List[str] = []
+    action = str(row.get("action") or "").lower().strip()
+    symbol = str(row.get("symbol") or "").upper().strip()
+    side = str(row.get("side") or "long").lower().strip()
+    qty = _f(row.get("shares"))
+    price = _f(row.get("price"))
+    if action not in {"entry", "exit", "partial_exit"} or not symbol or side not in {"long", "short"} or qty is None or qty <= 0 or price is None or price <= 0:
+        return cash, realized_today, realized_total, [f"unsupported_execution:{row.get('execution_id')}"]
+
+    if action == "entry":
+        if symbol in books and books[symbol].get("qty", 0.0) > QTY_TOLERANCE:
+            return cash, realized_today, realized_total, [f"entry_against_open_position:{symbol}"]
+        cash -= qty * price
+        if cash < -MONEY_TOLERANCE:
+            issues.append(f"negative_cash_after_entry:{symbol}")
+        books[symbol] = {"side": side, "qty": qty, "entry_price": price}
+        return cash, realized_today, realized_total, issues
+
+    pos = books.get(symbol)
+    if not pos:
+        return cash, realized_today, realized_total, [f"exit_without_open_position:{symbol}"]
+    if str(pos.get("side") or "") != side:
+        return cash, realized_today, realized_total, [f"exit_side_mismatch:{symbol}"]
+    available = float(pos.get("qty") or 0.0)
+    if qty > available + QTY_TOLERANCE:
+        return cash, realized_today, realized_total, [f"exit_exceeds_open_quantity:{symbol}"]
+    used = min(qty, available)
+    entry = float(pos.get("entry_price") or 0.0)
+    if side == "long":
+        pnl = (price - entry) * used
+        cash += price * used
+    else:
+        pnl = (entry - price) * used
+        cash += (entry * used) + pnl
+    realized_today += pnl
+    realized_total += pnl
+    remaining = available - used
+    if remaining <= QTY_TOLERANCE:
+        books.pop(symbol, None)
+    else:
+        pos["qty"] = remaining
+        books[symbol] = pos
+    return cash, realized_today, realized_total, issues
+
+
+def _project(core: Any, snapshot: Dict[str, Any], canonical: Dict[str, Any]) -> Dict[str, Any]:
+    cash, books, realized_today, realized_total, issues = _opening_books(snapshot)
+    rows = _l(canonical.get("raw_rows"))
+    valid_ids: List[str] = []
+    excluded_ids: List[str] = []
+    for index in range(EXPECTED_V3_START_INDEX, EXPECTED_LEDGER_ROW_COUNT):
+        row = _d(rows[index]) if index < len(rows) else {}
+        execution_id = str(row.get("execution_id") or "")
+        if execution_id == INVALID_EXECUTION_ID:
+            excluded_ids.append(execution_id)
+            continue
+        cash, realized_today, realized_total, row_issues = _apply_execution(cash, books, realized_today, realized_total, row)
+        issues.extend(row_issues)
+        valid_ids.append(execution_id)
+
+    current_positions = _d(_portfolio(core).get("positions"))
+    projected_positions: Dict[str, Dict[str, Any]] = {}
+    market_value = 0.0
+    unrealized = 0.0
+    for symbol, economic in sorted(books.items()):
+        current = _d(current_positions.get(symbol))
+        baseline = _d(_d(snapshot.get("positions")).get(symbol))
+        mark = _f(current.get("last_price", current.get("mark")))
+        if mark is None or mark <= 0:
+            mark = _f(baseline.get("mark", baseline.get("last_price")))
+        if mark is None or mark <= 0:
+            issues.append(f"projected_mark_missing:{symbol}")
+            continue
+        side = str(economic.get("side") or "long")
+        qty = float(economic.get("qty") or 0.0)
+        entry = float(economic.get("entry_price") or 0.0)
+        if side == "short":
+            upnl = (entry - mark) * qty
+            value = (entry * qty) + upnl
+            pnl_pct = ((entry - mark) / entry * 100.0) if entry else 0.0
+        else:
+            upnl = (mark - entry) * qty
+            value = mark * qty
+            pnl_pct = ((mark - entry) / entry * 100.0) if entry else 0.0
+        template = copy.deepcopy(current or baseline)
+        for stale in ("accounting_integrity_quarantined", "accounting_integrity_reason"):
+            template.pop(stale, None)
+        template.update({
+            "symbol": symbol,
+            "side": side,
+            "qty": qty,
+            "shares": qty,
+            "entry": entry,
+            "entry_price": entry,
+            "last_price": mark,
+            "cost_basis": entry * qty,
+            "market_value": value,
+            "unrealized_pnl": upnl,
+            "pnl_dollars": upnl,
+            "unrealized_pnl_pct": pnl_pct,
+            "pnl_pct": pnl_pct,
+        })
+        if side == "short":
+            template["margin"] = entry * qty
+        projected_positions[symbol] = template
+        market_value += value
+        unrealized += upnl
+
+    equity = cash + market_value
+    return {
+        "status": "ok" if not issues else "fail",
+        "issues": issues,
+        "cash": cash,
+        "equity": equity,
+        "market_value": market_value,
+        "unrealized_pnl": unrealized,
+        "realized_today": realized_today,
+        "realized_total": realized_total,
+        "positions": projected_positions,
+        "open_symbols": sorted(projected_positions),
+        "valid_execution_ids": valid_ids,
+        "excluded_execution_ids": excluded_ids,
+    }
+
+
+def _accounting_cross_check(core: Any, projection: Dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
+    try:
+        import paper_bidirectional_accounting_guard as accounting
+        result = accounting.analyze_ledger(_portfolio(core), core)
+    except Exception as exc:
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}, False
+    coverage = [row for row in _l(result.get("coverage_issues")) if isinstance(row, dict)]
+    economics = [row for row in _l(result.get("economic_issues")) if isinstance(row, dict)]
+    all_issues = coverage + economics
+
+    def exact_issue(row: Dict[str, Any]) -> bool:
+        return bool(
+            str(row.get("reason") or "") == "exit_exceeds_reconstructed_position"
+            and str(row.get("symbol") or "").upper() == "SLS"
+            and str(row.get("action") or "").lower() == "partial_exit"
+            and _close(row.get("requested_qty", row.get("shares")), 1.436519, QTY_TOLERANCE)
+            and _close(row.get("price"), 16.04, 1e-6)
+        )
+
+    issue_shape = bool(len(coverage) == 1 and all(exact_issue(row) for row in all_issues) and len(economics) <= 1)
+    rebuilt_cash = _f(result.get("cash", result.get("reconstructed_cash")))
+    rebuilt_equity = _f(result.get("equity", result.get("reconstructed_equity")))
+    rebuilt_positions = _d(result.get("open_positions"))
+    if not rebuilt_positions:
+        rebuilt_symbols = sorted(str(value).upper() for value in _l(result.get("reconstructed_open_positions")))
+    else:
+        rebuilt_symbols = sorted(str(value).upper() for value in rebuilt_positions)
+    projected_positions = _d(projection.get("positions"))
+    qty_match = True
+    if rebuilt_positions and set(rebuilt_positions) == set(projected_positions):
+        for symbol, expected in projected_positions.items():
+            observed = _d(rebuilt_positions.get(symbol))
+            if not _close(observed.get("qty", observed.get("shares")), float(expected.get("shares") or 0.0), QTY_TOLERANCE):
+                qty_match = False
+    elif rebuilt_symbols != sorted(projected_positions):
+        qty_match = False
+    ready = bool(
+        issue_shape
+        and rebuilt_cash is not None and abs(rebuilt_cash - float(projection.get("cash") or 0.0)) <= MONEY_TOLERANCE
+        and rebuilt_equity is not None and abs(rebuilt_equity - float(projection.get("equity") or 0.0)) <= EQUITY_TOLERANCE
+        and rebuilt_symbols == sorted(projected_positions)
+        and qty_match
+    )
+    return result, ready
+
+
+def _preconditions(core: Any) -> Dict[str, Any]:
+    pf = _portfolio(core)
+    snapshot, baseline_issues = _baseline_snapshot(pf)
+    canonical, canonical_ready = _canonical_evidence(core)
+    state_trades, state_trades_ready = _state_trade_evidence(pf)
+    projection = _project(core, snapshot, canonical) if canonical_ready and not baseline_issues else {"status": "fail", "issues": ["projection_preconditions_missing"]}
+    cross, cross_ready = _accounting_cross_check(core, projection) if projection.get("status") == "ok" else ({}, False)
+    risk = _d(pf.get("risk_controls"))
+    risk_exact = bool(risk.get("halted") and str(risk.get("halt_reason") or "") == "canonical execution lifecycle integrity halt")
+    projected_symbols = sorted(_d(projection.get("positions")))
+    projected_shape = projection.get("status") == "ok" and projected_symbols == ["DHR"] and projection.get("excluded_execution_ids") == [INVALID_EXECUTION_ID]
+    current_cash = _f(pf.get("cash"))
+    projected_cash = _f(projection.get("cash"))
+    invalid_notional = float(EXPECTED_V3_ROWS[2]["shares"]) * float(EXPECTED_V3_ROWS[2]["price"])
+    invalid_cash_effect_exact = bool(
+        current_cash is not None and projected_cash is not None
+        and abs((current_cash - projected_cash) - invalid_notional) <= MONEY_TOLERANCE
+    )
+    checks = {
+        "paper_runtime": _paper_only(),
+        "baseline_exact": not baseline_issues,
+        "canonical_chain_and_exact_three_v3_rows": canonical_ready,
+        "state_trade_mirror_exact_three_v3_rows": state_trades_ready,
+        "existing_lifecycle_halt_preserved": risk_exact,
+        "deterministic_projection_clean": bool(projected_shape),
+        "invalid_partial_cash_effect_exact": invalid_cash_effect_exact,
+        "legacy_accounting_cross_check_exact": cross_ready,
+    }
+    failed = [name for name, ok in checks.items() if not ok]
+    return {
+        "checks": checks,
+        "failed": failed,
+        "baseline_issues": baseline_issues,
+        "canonical": canonical,
+        "state_trades": state_trades,
+        "projection": projection,
+        "accounting_cross_check": cross,
+        "invalid_partial_cash_effect_dollars": invalid_notional,
+    }
+
+
+def _archive_state(core: Any, pre: Dict[str, Any], ledger_path: str, ledger_digest: str | None) -> Dict[str, Any]:
+    os.makedirs(ARCHIVE_ROOT, exist_ok=True)
+    stamp = dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    archive_dir = os.path.join(ARCHIVE_ROOT, f"{stamp}_{DECISION_ID}")
+    os.makedirs(archive_dir, exist_ok=False)
+    root_abs = os.path.abspath(ARCHIVE_ROOT)
+    copied: List[Dict[str, Any]] = []
+    for name in sorted(os.listdir(STATE_DIR)):
+        src = os.path.join(STATE_DIR, name)
+        src_abs = os.path.abspath(src)
+        if src_abs == root_abs or src_abs.startswith(root_abs + os.sep):
+            continue
+        dst = os.path.join(archive_dir, name)
+        try:
+            if os.path.isdir(src):
+                shutil.copytree(src, dst)
+                copied.append({"name": name, "type": "directory"})
+            elif os.path.isfile(src):
+                shutil.copy2(src, dst)
+                copied.append({"name": name, "type": "file", "size_bytes": os.path.getsize(dst), "sha256": _sha256(dst)})
+        except Exception as exc:
+            copied.append({"name": name, "type": "copy_error", "error": f"{type(exc).__name__}: {exc}"})
+    projection = _d(pre.get("projection"))
+    manifest = {
+        "status": "ok",
+        "type": "issue126_v3_successor_archive",
+        "version": VERSION,
+        "decision_id": DECISION_ID,
+        "prior_epoch_id": OLD_EPOCH_ID,
+        "target_epoch_id": TARGET_EPOCH_ID,
+        "created_local": _now(core),
+        "archive_dir": archive_dir,
+        "evidence": {
+            "authoritative_snapshot_workflow_run": 33001743744,
+            "authoritative_snapshot_artifact_id": 9619045572,
+            "prospective_fix_main_sha": "71c3e0777f82f3b1521b3ab17df53a25fb1d91d1",
+            "canonical_row_count": _d(pre.get("canonical")).get("row_count"),
+            "canonical_v3_rows": _d(pre.get("canonical")).get("rows"),
+            "invalid_execution_id": INVALID_EXECUTION_ID,
+            "invalid_event_hash": INVALID_EVENT_HASH,
+            "invalid_row_retained_immutably": True,
+            "invalid_row_economic_effect_excluded_only_in_successor_projection": True,
+        },
+        "canonical_ledger": {
+            "path": ledger_path,
+            "sha256_before_cutover": ledger_digest,
+            "immutable_history_retained_in_place": True,
+            "rotated_or_truncated": False,
+            "chain_valid": _d(pre.get("canonical")).get("chain_valid"),
+        },
+        "projection": {
+            "cash": projection.get("cash"),
+            "equity": projection.get("equity"),
+            "open_symbols": projection.get("open_symbols"),
+            "valid_execution_ids": projection.get("valid_execution_ids"),
+            "excluded_execution_ids": projection.get("excluded_execution_ids"),
+        },
+        "pre_cutover_account": copy.deepcopy(_portfolio(core)),
+        "copied_entries": copied,
+    }
+    _atomic_json(os.path.join(archive_dir, "issue126_v3_successor_archive_manifest.json"), manifest)
+    return manifest
+
+
+def build_successor_state(pf: Dict[str, Any], projection: Dict[str, Any], archive_dir: str, started_local: str) -> Dict[str, Any]:
+    state = copy.deepcopy(pf)
+    risk_before = copy.deepcopy(_d(state.get("risk_controls")))
+    positions = copy.deepcopy(_d(projection.get("positions")))
+    cash = float(projection.get("cash") or 0.0)
+    equity = float(projection.get("equity") or 0.0)
+    if cash <= 0 or equity <= 0 or sorted(positions) != ["DHR"]:
+        raise RuntimeError("deterministic successor projection is not sane")
+    if not bool(risk_before.get("halted")) or str(risk_before.get("halt_reason") or "") != "canonical execution lifecycle integrity halt":
+        raise RuntimeError("expected lifecycle halt is not active")
+
+    state["cash"] = cash
+    state["equity"] = equity
+    state["positions"] = positions
+    state["trades"] = []
+    realized = _d(state.setdefault("realized_pnl", {}))
+    realized["today"] = float(projection.get("realized_today") or 0.0)
+    realized["total"] = float(projection.get("realized_total") or 0.0)
+    state["realized_pnl"] = realized
+    perf = _d(state.setdefault("performance", {}))
+    perf["open_positions"] = copy.deepcopy(positions)
+    perf["unrealized_pnl"] = float(projection.get("unrealized_pnl") or 0.0)
+    perf["realized_pnl_today"] = float(projection.get("realized_today") or 0.0)
+    perf["realized_pnl_total"] = float(projection.get("realized_total") or 0.0)
+    state["performance"] = perf
+    state["risk_controls"] = risk_before
+
+    snapshot_positions: Dict[str, Dict[str, Any]] = {}
+    for symbol, raw in positions.items():
+        pos = _d(raw)
+        snapshot_positions[symbol] = {
+            "side": str(pos.get("side") or "long"),
+            "qty": float(pos.get("shares", pos.get("qty")) or 0.0),
+            "entry_price": float(pos.get("entry", pos.get("entry_price")) or 0.0),
+            "mark": float(pos.get("last_price") or 0.0),
+        }
+    snapshot = {
+        "verified": True,
+        "version": VERSION,
+        "started_local": started_local,
+        "cash": cash,
+        "equity": equity,
+        "realized_today": float(projection.get("realized_today") or 0.0),
+        "realized_total": float(projection.get("realized_total") or 0.0),
+        "positions": snapshot_positions,
+        "source": "deterministic_v3_verified_snapshot_plus_exact_valid_canonical_replay",
+        "invalid_execution_retained_but_excluded_from_successor_economics": INVALID_EXECUTION_ID,
+    }
+    state["accounting_epoch_id"] = TARGET_EPOCH_ID
+    state["paper_accounting_epoch"] = {
+        "version": VERSION,
+        "id": TARGET_EPOCH_ID,
+        "decision_id": DECISION_ID,
+        "started_local": started_local,
+        "starting_cash": cash,
+        "starting_equity": equity,
+        "clean_start": False,
+        "zero_trade_baseline": False,
+        "baseline_type": "verified_snapshot_with_open_position",
+        "verified_snapshot_baseline": snapshot,
+        "historical_recovery_decision": HISTORICAL_DECISION,
+        "prior_epoch_id": OLD_EPOCH_ID,
+        "prior_epoch_disposition": "archived_with_exact_issue126_sls_reentrant_artifact_disposition_and_immutable_canonical_ledger_retained",
+        "historical_evidence_archived": True,
+        "forensic_archive_dir": archive_dir,
+        "validation_hold": True,
+        "validation_hold_reason": "issue 126 v4 clean-active-accounting validation hold",
+        "validation_release_status": "blocked",
+        "validation_released": False,
+        "validation_released_local": None,
+        "forward_validation_required": True,
+        "valid_path_rows_baseline": 0,
+        "invalid_execution_id": INVALID_EXECUTION_ID,
+        "invalid_event_hash": INVALID_EVENT_HASH,
+        "canonical_history_retained_immutably": True,
+    }
+    return state
+
+
+def _rotate_journal_for_successor() -> None:
+    try:
+        import trade_journal as tj
+        factory = getattr(tj, "_empty_journal", None)
+        journal = factory() if callable(factory) else {"trades": [], "recent_trades": [], "snapshots": [], "event_hook_events": []}
+        if not isinstance(journal, dict):
+            journal = {"trades": [], "recent_trades": [], "snapshots": [], "event_hook_events": []}
+        journal["accounting_epoch_id"] = TARGET_EPOCH_ID
+        journal["issue126_successor_epoch_started_local"] = _now()
+        journal["issue126_successor_version"] = VERSION
+        for attr in ("TRADE_JOURNAL_FILE", "TRADE_JOURNAL_BACKUP_FILE"):
+            path = str(getattr(tj, attr, "") or "")
+            if path:
+                _atomic_json(path, journal)
+    except Exception:
+        return
+
+
+def _complete_marker(started: Dict[str, Any], core: Any, state_file: str, successor: Dict[str, Any], digest_after: str | None, *, retried: bool) -> Dict[str, Any]:
+    completed = dict(started)
+    completed.update({
+        "status": "completed",
+        "overall": "pass",
+        "completed_local": _now(core),
+        "state_file": state_file,
+        "validation_hold": True,
+        "canonical_ledger_sha256_after": digest_after,
+        "canonical_ledger_unchanged": digest_after == started.get("canonical_ledger_sha256_before"),
+        "successor_cash": successor.get("cash"),
+        "successor_equity": successor.get("equity"),
+        "successor_positions": sorted(_d(successor.get("positions"))),
+        "successor_trade_rows": len(_l(successor.get("trades"))),
+        "lifecycle_halt_preserved": bool(_d(successor.get("risk_controls")).get("halted")),
+        "lifecycle_halt_reason": _d(successor.get("risk_controls")).get("halt_reason"),
+        "interrupted_completion_retry_performed": retried,
+    })
+    _atomic_json(MARKER_FILE, completed)
+    return completed
+
+
+def _cutover(core: Any, pre: Dict[str, Any], *, retried: bool = False) -> Dict[str, Any]:
+    global _LAST
+    import canonical_execution_ledger as ledger
+    import clean_accounting_epoch as clean
+    ledger_path = str(getattr(ledger, "LEDGER_FILE", "") or "")
+    digest_before = _sha256(ledger_path)
+    archive = _archive_state(core, pre, ledger_path, digest_before)
+    started_local = _now(core)
+    started = {
+        "status": "cutover_started",
+        "version": VERSION,
+        "decision_id": DECISION_ID,
+        "prior_epoch_id": OLD_EPOCH_ID,
+        "target_epoch_id": TARGET_EPOCH_ID,
+        "archive_dir": archive.get("archive_dir"),
+        "started_local": started_local,
+        "canonical_ledger_sha256_before": digest_before,
+        "invalid_execution_id": INVALID_EXECUTION_ID,
+        "invalid_event_hash": INVALID_EVENT_HASH,
+    }
+    _atomic_json(MARKER_FILE, started)
+    successor = build_successor_state(_portfolio(core), _d(pre.get("projection")), str(archive.get("archive_dir") or ""), started_local)
+    risk_before = copy.deepcopy(_d(_portfolio(core).get("risk_controls")))
+    history_before = copy.deepcopy(_portfolio(core).get("history"))
+    with clean._runtime_locks():
+        state_file = clean._write_clean_state_and_backups(core, successor)
+        _rotate_journal_for_successor()
+        clean._reset_snapshot_archive(successor, state_file)
+        pf = _portfolio(core)
+        pf.clear()
+        pf.update(successor)
+    digest_after = _sha256(ledger_path)
+    if digest_before != digest_after:
+        raise RuntimeError("canonical ledger changed during Issue #126 successor cutover")
+    if _d(successor.get("risk_controls")) != risk_before:
+        raise RuntimeError("risk controls changed during Issue #126 successor cutover")
+    if successor.get("history") != history_before:
+        raise RuntimeError("historical equity series changed during Issue #126 successor cutover")
+    completed = _complete_marker(started, core, state_file, successor, digest_after, retried=retried)
+    _LAST = completed
+    return completed
+
+
+def _active_status(core: Any) -> Dict[str, Any]:
+    pf = _portfolio(core)
+    epoch = _d(pf.get("paper_accounting_epoch"))
+    marker = _marker()
+    risk = _d(pf.get("risk_controls"))
+    return {
+        "status": "validation_hold",
+        "overall": "pass",
+        "version": VERSION,
+        "epoch_id": TARGET_EPOCH_ID,
+        "prior_epoch_id": OLD_EPOCH_ID,
+        "historical_evidence_archived": bool(epoch.get("historical_evidence_archived", False)),
+        "forensic_archive_dir": epoch.get("forensic_archive_dir") or marker.get("archive_dir"),
+        "validation_hold": bool(epoch.get("validation_hold", False)),
+        "canonical_ledger_unchanged": bool(marker.get("canonical_ledger_unchanged", False)),
+        "invalid_execution_retained_immutably": str(epoch.get("invalid_execution_id") or "") == INVALID_EXECUTION_ID,
+        "state_trade_rows": len(_l(pf.get("trades"))),
+        "positions": sorted(_d(pf.get("positions"))),
+        "cash": pf.get("cash"),
+        "equity": pf.get("equity"),
+        "lifecycle_halt_preserved": bool(risk.get("halted")),
+        "lifecycle_halt_reason": risk.get("halt_reason"),
+        "interrupted_completion_retry_performed": bool(marker.get("interrupted_completion_retry_performed", False)),
+    }
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _LAST
+    if core is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+    if not _paper_only():
+        return {"status": "blocked", "overall": "fail", "version": VERSION, "reason": "paper_runtime_only"}
+    with _LOCK:
+        pf = _portfolio(core)
+        active_epoch = _epoch_id(pf)
+        marker = _marker()
+        if active_epoch == TARGET_EPOCH_ID:
+            result = _active_status(core)
+            if marker.get("status") != "completed":
+                result.update({"status": "error", "overall": "fail", "reason": "v4_active_without_completed_issue126_marker"})
+            _LAST = result
+            return result
+        if active_epoch != OLD_EPOCH_ID:
+            result = {
+                "status": "not_applicable",
+                "overall": "pass",
+                "version": VERSION,
+                "reason": "issue126_v3_epoch_not_active",
+                "active_epoch_id": active_epoch,
+            }
+            _LAST = result
+            return result
+        retry = marker.get("status") in {"cutover_started", "completed"}
+        if retry and not (
+            str(marker.get("prior_epoch_id") or "") == OLD_EPOCH_ID
+            and str(marker.get("target_epoch_id") or "") == TARGET_EPOCH_ID
+            and str(marker.get("invalid_execution_id") or "") == INVALID_EXECUTION_ID
+            and str(marker.get("invalid_event_hash") or "") == INVALID_EVENT_HASH
+        ):
+            result = {"status": "blocked", "overall": "fail", "version": VERSION, "reason": "issue126_successor_marker_mismatch"}
+            _LAST = result
+            return result
+
+        pre = _preconditions(core)
+        if pre["failed"]:
+            result = {
+                "status": "blocked",
+                "overall": "fail",
+                "version": VERSION,
+                "reason": "issue126_successor_preconditions_not_met",
+                "failed_checks": pre["failed"],
+                "checks": pre["checks"],
+                "baseline_issues": pre.get("baseline_issues"),
+                "canonical": {key: value for key, value in _d(pre.get("canonical")).items() if key != "raw_rows"},
+                "projection": {key: value for key, value in _d(pre.get("projection")).items() if key != "positions"},
+            }
+            _LAST = result
+            return result
+        try:
+            return _cutover(core, pre, retried=bool(retry))
+        except Exception as exc:
+            result = {"status": "error", "overall": "fail", "version": VERSION, "reason": "issue126_successor_cutover_failed", "error": f"{type(exc).__name__}: {exc}"}
+            _LAST = result
+            return result
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    if core is None:
+        result = dict(_LAST) if _LAST else {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+    elif _epoch_id(_portfolio(core)) == TARGET_EPOCH_ID:
+        result = _active_status(core)
+    else:
+        result = dict(_LAST) if _LAST else {
+            "status": "pending",
+            "overall": "warn",
+            "version": VERSION,
+            "active_epoch_id": _epoch_id(_portfolio(core)),
+        }
+    return {
+        **result,
+        "type": "verified_v3_successor_epoch_migration_status",
+        "status_reads_are_observational": True,
+        "authority": {
+            "paper_only": True,
+            "one_time_accounting_epoch_rollforward": True,
+            "deterministic_verified_snapshot_plus_canonical_replay": True,
+            "archives_prior_v3_evidence": True,
+            "clears_active_state_trade_window": True,
+            "retains_invalid_canonical_row_immutably": True,
+            "excludes_only_exact_invalid_row_from_successor_economics": True,
+            "edits_or_deletes_canonical_rows": False,
+            "rotates_or_truncates_canonical_ledger": False,
+            "rewrites_current_day_peak": False,
+            "rewrites_history": False,
+            "clears_hard_halt": False,
+            "places_orders": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    result = apply(core)
+    if flask_app is None:
+        return result
+    app_id = id(flask_app)
+    if app_id not in _REGISTERED_APP_IDS:
+        from flask import jsonify
+        path = "/paper/verified-v3-successor-epoch-status"
+        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+        if path not in existing:
+            flask_app.add_url_rule(path, "verified_v3_successor_epoch_status", lambda: jsonify(status_payload(core)))
+        _REGISTERED_APP_IDS.add(app_id)
+    return status_payload(core)

--- a/verified_v3_successor_epoch_migration.py
+++ b/verified_v3_successor_epoch_migration.py
@@ -112,7 +112,9 @@ def _f(value: Any) -> float | None:
 
 def _close(value: Any, expected: float, tolerance: float) -> bool:
     number = _f(value)
-    return number is not None and abs(number - expected) <= tolerance
+    if number is None:
+        return False
+    return abs(number - expected) <= tolerance
 
 
 def _now(core: Any = None) -> str:


### PR DESCRIPTION
Implements the bounded accounting recovery for Issue #126 after PR #127 prospectively removed the re-entrant SLS resurrection defect.

Fresh post-merge Splendid evidence on main `71c3e0777f82f3b1521b3ab17df53a25fb1d91d1` proves the canonical ledger is still hash-valid at exactly 45 rows, with exactly three v3 rows: valid SLS full exit `9ab93335faff4e3293d24ebe0bad4e87`, valid DHR partial `26702f252870490c8f1ddab86ce794f5`, and the sole invalid re-entrant SLS partial `90b22aad76074031906e0c6459dfa0bc`. No new lifecycle artifact appeared after the prospective fix deployed.

This migration requires that exact immutable canonical shape and exact v3 verified baseline, archives the complete v3 persistence, replays only the two valid v3 executions from the verified snapshot baseline, retains the invalid SLS row immutably while excluding only its economic effect from the successor projection, and starts `stable-paper-v4-20260826-successor01` under validation hold. It preserves the current risk controls/history exactly, including the canonical lifecycle halt and current-day peak, and verifies canonical ledger bytes are unchanged across cutover. Exact startup-marker retry handling makes the v4 cutover sticky if legacy startup registration restores v3 after the bounded write.

The older v1/v2/v3 compatibility owners are updated only to recognize the exact v4 lineage as a legitimate successor; they gain no v3->v4 write authority. Focused regression tests are imported into the mandatory Stage-F suite.

Paper-only. No canonical row edit/delete/relabel/truncate, no manual halt clear, no day-peak/history rewrite, no `/paper/run`, no strategy/signals/sizing/risk-threshold/live/ML authority change. Issue #126 remains open after this PR until authoritative post-deploy v4 evidence proves a clean active accounting audit; lifecycle-halt release will be a separate exact-evidence boundary if warranted.