### PR TITLE
Fix Issue #126 terminal DHR canonical-only successor recovery

### DIFF
--- a/PROJECT_HANDOFF_CURRENT.md
+++ b/PROJECT_HANDOFF_CURRENT.md
@@ -1,11 +1,13 @@
 # Project Handoff — Authoritative Current Trading Runtime
 
-Last updated: 2026-08-28 12:05 CDT  
+Last updated: 2026-08-28 14:38 CDT  
 Repository: `sterlingfancher-cmyk/Trading-bot`  
 Authoritative paper runtime: Splendid / `https://web-production-e1796.up.railway.app`  
 Non-authoritative legacy state lineage: `https://trading-bot-clean.up.railway.app`  
-Current runtime code baseline: `54df8c9edf43af645b5abac4f6d93c262aeeff37` (squash merge of PR #134)  
-Current `main` before this handoff refresh: `1600dd0e5cdc4e162a587c0e6478dd1f9f95eb72`  
+Current deployed runtime code baseline: `54df8c9edf43af645b5abac4f6d93c262aeeff37` (squash merge of PR #134)  
+Current `main`: `90e7e8da74022fcd6994cd9474044ef5c30ddcc4`  
+Active repair branch: `fix/issue126-row46-canonical-only-20260828`  
+Active repair branch head before this handoff update: `dcf97474192244560b3dc7ac77e4f4381bcc818d`  
 Active stability/accounting issue: Issue #126
 
 ## Communication and Continuity
@@ -79,21 +81,49 @@ The current persisted state proves the row-46 economic effect was never mirrored
 
 `canonical_execution_ledger.py` deliberately appends the immutable canonical row before invoking the prior `record_trade()` state mirror. The evidence therefore classifies row 46 as a **valid canonical-only DHR full exit whose state/cash mirror did not complete**, rather than as a second invalid execution artifact.
 
-Successor-recovery rule is now exact:
+Successor-recovery rule is exact:
 - retain all 46 canonical rows immutably;
 - replay the valid SLS full exit, valid DHR partial, and valid DHR full exit;
 - exclude only invalid SLS partial execution `90b22aad76074031906e0c6459dfa0bc` from successor economics;
 - require the pre-cutover state to prove row 46 is absent from `state.trades`, DHR remains exactly at the reconstructable remainder, and row-46 cash proceeds are absent;
-- the deterministic v4 successor projection should therefore have **no open positions**;
+- deterministic v4 successor projection is flat with **no open positions**;
 - preserve validation hold and the lifecycle halt through cutover until clean active-v4 evidence independently proves any release is safe.
 
-A new guarded repo-agent repair was triggered from Issue #126 at midday with those exact requirements. Repo-agent workflow run `33192730802` is the active bounded repair. It must abort if it produces a truncated/replaced migration file or unrelated changes. Any resulting PR must be exact-diff reviewed and pass the complete mandatory exact-head gate suite before automatic merge.
+## 2026-08-28 Pre-Close Direct Repair
 
-## Current Authoritative Splendid Runtime — 2026-08-28 Midday Evidence
+The guarded repo-agent has now failed twice before any repository write while attempting this bounded row-46 repair:
+- midday run `33192730802` failed because the generated response was malformed JSON;
+- retry run `33204222733` / job `98961037342` failed with `JSONDecodeError: Unterminated string` after the generated full-file JSON response was truncated inside `verified_v3_successor_epoch_migration.py`.
 
-Latest automated read-only runtime snapshot:
+Both failures were contained before branch/PR/runtime mutation. They are repo-agent transport/generation failures, not trading-runtime mutations.
+
+To avoid repeatedly delegating a proven bounded repair through the failing large-JSON path, the repair is now being performed directly on `fix/issue126-row46-canonical-only-20260828` from exact main `90e7e8da74022fcd6994cd9474044ef5c30ddcc4`.
+
+Direct production commit `a71c599c1502de66f08e17a3a86035a0f25297fc` updates only the exact-evidence successor migration logic so it:
+- requires 46 total canonical rows and four exact ordered v3 signatures;
+- keeps the original three mirrored state trades as the only permitted pre-cutover `state.trades` rows;
+- requires canonical row 46 to be absent from the state-trade mirror;
+- requires DHR to remain in state at the exact reconstructed post-partial remainder within existing quantity tolerance;
+- requires current cash to prove the invalid SLS partial effect is still present while row-46 DHR proceeds are still absent;
+- replays the valid SLS full exit, valid DHR partial, and valid canonical-only DHR full exit;
+- excludes only the exact invalid SLS partial from successor economics;
+- projects a flat v4 successor with no open positions;
+- preserves immutable canonical history, current lifecycle halt, current risk state/history, validation hold, paper-only authority, strategy, sizing, hard-risk thresholds, live authority, and ML authority.
+
+Focused regression commit `dcf97474192244560b3dc7ac77e4f4381bcc818d` adds `tests/test_verified_v3_terminal_dhr_recovery.py` covering:
+- exact fourth-row DHR signature and event-hash fail-closed behavior;
+- requirement that row 46 remain canonical-only pre-cutover;
+- deterministic replay to a flat successor while excluding only the invalid SLS row;
+- successor state preserving halt/history/validation hold;
+- fail-closed preconditions for wrong cash or wrong DHR remainder.
+
+This branch is **not merged** yet. The next boundary is exact diff review plus the complete exact-head validation suite. If any unexpected deletion, unrelated mutation, compilation/test failure, architecture/ownership regression, or startup failure appears, do not merge.
+
+## Current Authoritative Splendid Runtime — 2026-08-28 Pre-Close Baseline
+
+Until the direct repair is safely merged and deployed, the latest authoritative read-only Splendid evidence remains the midday proof boundary:
 - application bootstrap: ready/delegating; no bootstrap error;
-- runner: PASS, no active error; latest successful run `2026-08-28 09:34:57 CDT`;
+- runner: PASS, no active error; latest recorded successful run in the evidence `2026-08-28 09:34:57 CDT`;
 - canonical ledger: PASS, append-only/hash-valid, 46 rows, 4 current-v3 rows;
 - account cash: `13483.47647864577`;
 - account equity: approximately `13602.08`;
@@ -108,13 +138,15 @@ Latest automated read-only runtime snapshot:
 - validation hold remains active;
 - no strategy/sizing/risk-threshold/live/ML authority was changed.
 
-The overall audit remains FAIL because the successor accounting repair has not yet been applied, not because runner, market data, canonical hash chain, bootstrap, or fresh-day initialization are unhealthy.
+The overall audit remains FAIL until successor accounting recovery is proven and applied. This is a fail-closed accounting/lifecycle condition, not a runner, market-data, bootstrap, canonical-chain, or genuine daily-loss failure.
 
 ## Immediate Next Action
 
-Inspect the repo-agent output for run `33192730802`. Accept only a bounded migration/test repair that encodes the exact 46-row/four-v3-row evidence, requires row 46 to be canonical-only and economically unapplied in pre-cutover state, replays DHR row 46 into the successor, excludes only the exact invalid SLS partial, and projects no open positions. Reject any destructive or overbroad diff.
+Create and exact-diff review the direct repair PR. Accept only the migration file, focused terminal-DHR regression file, and this handoff update. Require the mandatory exact-head Change Safety Audit, Repository Safety and Performance Audit Validation, Architecture Debt Regression Gate, full Refactor/Ownership/Configuration/State/Decision/Runtime/Startup/Research Audit including exact Gunicorn smoke, plus affected focused Stable Paper/invariant regressions.
 
-If a safe PR is produced, require the full exact-head safety suite before automatic squash merge, then validate authoritative Splendid deployment/bootstrap/daily-audit evidence. No user action is currently required.
+If and only if every required exact-head gate is green and the diff remains inside the declared paper-only accounting-recovery boundary, squash-merge automatically. Then wait for deployment and use fresh automated Splendid evidence to prove the v4 cutover completed with canonical ledger unchanged/hash-valid, zero unexplained active-v4 accounting issues, deterministic cash/equity, no open positions, zero successor state-trade rows, validation hold retained, lifecycle halt retained unless independently and prospectively proven safe to release, and healthy bootstrap/runner/market-data/state persistence.
+
+No user action is currently required.
 
 ## Completion Criteria for Issue #126
 

--- a/test_verified_v3_successor_epoch_migration.py
+++ b/test_verified_v3_successor_epoch_migration.py
@@ -19,7 +19,7 @@ class Issue126V3V4SuccessorMigrationTests(unittest.TestCase):
             "realized_today": 0.0,
             "realized_total": 42.0,
             "positions": {
-                "DHR": {"side": "long", "qty": 0.540748758, "entry_price": 216.960007, "mark": 215.79},
+                "DHR": {"side": "long", "qty": migration.EXPECTED_BASELINE_DHR_QTY, "entry_price": 216.960007, "mark": 215.79},
                 "SLS": {"side": "long", "qty": migration.EXPECTED_BASELINE_SLS_QTY, "entry_price": 14.335, "mark": 14.45},
             },
         }
@@ -38,36 +38,27 @@ class Issue126V3V4SuccessorMigrationTests(unittest.TestCase):
             }
             for index in range(migration.EXPECTED_V3_START_INDEX)
         ]
-        rows.extend([
-            {
-                **migration.EXPECTED_V3_ROWS[0],
-                "shares": migration.EXPECTED_BASELINE_SLS_QTY,
-            },
-            {
-                **migration.EXPECTED_V3_ROWS[1],
-                "shares": 0.178447,
-            },
-            dict(migration.EXPECTED_V3_ROWS[2]),
-        ])
+        rows.extend(dict(expected) for expected in migration.EXPECTED_V3_ROWS)
         for row in rows:
             row.pop("ledger_index", None)
             row.pop("economic_disposition", None)
         return rows
 
     def _projection_numbers(self):
-        cash = migration.EXPECTED_BASELINE_CASH
-        cash += migration.EXPECTED_BASELINE_SLS_QTY * 13.62
-        cash += 0.178447 * 242.4872
-        dhr_qty = 0.540748758 - 0.178447
-        equity = cash + dhr_qty * 215.79
-        return cash, dhr_qty, equity
+        cash_after_mirrored_valid = migration.EXPECTED_BASELINE_CASH
+        cash_after_mirrored_valid += migration.EXPECTED_BASELINE_SLS_QTY * float(migration.EXPECTED_V3_ROWS[0]["price"])
+        cash_after_mirrored_valid += float(migration.EXPECTED_V3_ROWS[1]["shares"]) * float(migration.EXPECTED_V3_ROWS[1]["price"])
+        dhr_remainder = migration.EXPECTED_DHR_REMAINDER
+        final_clean_cash = cash_after_mirrored_valid + dhr_remainder * float(migration.EXPECTED_V3_ROWS[3]["price"])
+        pre_terminal_equity = cash_after_mirrored_valid + dhr_remainder * 215.79
+        return final_clean_cash, dhr_remainder, cash_after_mirrored_valid, pre_terminal_equity
 
     def _portfolio(self, *, halt_reason="canonical execution lifecycle integrity halt"):
-        projected_cash, dhr_qty, _ = self._projection_numbers()
-        invalid_notional = float(migration.EXPECTED_V3_ROWS[2]["shares"]) * 16.04
-        rows = self._rows()[-3:]
+        _, dhr_qty, pre_terminal_cash, _ = self._projection_numbers()
+        invalid_notional = float(migration.EXPECTED_V3_ROWS[2]["shares"]) * float(migration.EXPECTED_V3_ROWS[2]["price"])
+        mirrored_rows = self._rows()[migration.EXPECTED_V3_START_INDEX:migration.EXPECTED_V3_START_INDEX + 3]
         trades = []
-        for row in rows:
+        for row in mirrored_rows:
             trades.append({
                 "execution_id": row["execution_id"],
                 "accounting_epoch_id": migration.OLD_EPOCH_ID,
@@ -79,7 +70,7 @@ class Issue126V3V4SuccessorMigrationTests(unittest.TestCase):
                 "canonical_ledger_event_hash": row["event_hash"],
             })
         return {
-            "cash": projected_cash + invalid_notional,
+            "cash": pre_terminal_cash + invalid_notional,
             "equity": 13601.69,
             "positions": {
                 "DHR": {"side": "long", "shares": dhr_qty, "qty": dhr_qty, "entry": 216.960007, "last_price": 215.79},
@@ -129,22 +120,24 @@ class Issue126V3V4SuccessorMigrationTests(unittest.TestCase):
             "raw_rows": rows,
         }
 
-    def test_exact_production_rows_project_only_dhr_and_exclude_invalid_sls_partial(self):
+    def test_exact_production_rows_project_flat_and_exclude_only_invalid_sls_partial(self):
         core = types.SimpleNamespace(portfolio=self._portfolio())
         projection = migration._project(core, self._baseline_snapshot(), self._canonical())
-        expected_cash, expected_qty, expected_equity = self._projection_numbers()
+        expected_cash, _, _, _ = self._projection_numbers()
 
         self.assertEqual(projection["status"], "ok")
-        self.assertEqual(projection["open_symbols"], ["DHR"])
+        self.assertEqual(projection["open_symbols"], [])
+        self.assertEqual(projection["positions"], {})
         self.assertEqual(projection["excluded_execution_ids"], [migration.INVALID_EXECUTION_ID])
         self.assertEqual(projection["valid_execution_ids"], [
             migration.EXPECTED_V3_ROWS[0]["execution_id"],
             migration.EXPECTED_V3_ROWS[1]["execution_id"],
+            migration.EXPECTED_V3_ROWS[3]["execution_id"],
         ])
         self.assertAlmostEqual(projection["cash"], expected_cash, places=6)
-        self.assertAlmostEqual(projection["positions"]["DHR"]["shares"], expected_qty, places=9)
-        self.assertAlmostEqual(projection["equity"], expected_equity, places=6)
+        self.assertAlmostEqual(projection["equity"], expected_cash, places=6)
         self.assertNotIn("SLS", projection["positions"])
+        self.assertNotIn("DHR", projection["positions"])
 
     def test_exact_canonical_signature_fails_closed_on_hash_mismatch_or_extra_v3_row(self):
         import canonical_execution_ledger as ledger
@@ -153,6 +146,8 @@ class Issue126V3V4SuccessorMigrationTests(unittest.TestCase):
             observed, ready = migration._canonical_evidence(types.SimpleNamespace())
         self.assertTrue(ready)
         self.assertTrue(observed["v3_rows_exact"])
+        self.assertEqual(observed["row_count"], 46)
+        self.assertEqual(observed["v3_row_count"], 4)
 
         bad = copy.deepcopy(rows)
         bad[-1]["event_hash"] = "wrong"
@@ -185,20 +180,22 @@ class Issue126V3V4SuccessorMigrationTests(unittest.TestCase):
         self.assertEqual(before["accounting_epoch_id"], migration.OLD_EPOCH_ID)
         self.assertEqual(after["accounting_epoch_id"], migration.TARGET_EPOCH_ID)
         self.assertEqual(after["trades"], [])
-        self.assertEqual(sorted(after["positions"]), ["DHR"])
+        self.assertEqual(after["positions"], {})
+        self.assertAlmostEqual(after["cash"], after["equity"], places=6)
         self.assertEqual(after["risk_controls"], original_risk)
         self.assertEqual(after["history"], original_history)
         epoch = after["paper_accounting_epoch"]
         self.assertTrue(epoch["validation_hold"])
         self.assertFalse(epoch["validation_released"])
         self.assertEqual(epoch["invalid_execution_id"], migration.INVALID_EXECUTION_ID)
+        self.assertEqual(epoch["terminal_valid_dhr_execution_id"], migration.TERMINAL_DHR_EXECUTION_ID)
         self.assertTrue(epoch["canonical_history_retained_immutably"])
 
     def test_exact_authoritative_contamination_shape_satisfies_preconditions(self):
         import canonical_execution_ledger as ledger
         import paper_bidirectional_accounting_guard as accounting
         core = types.SimpleNamespace(portfolio=self._portfolio())
-        expected_cash, expected_qty, expected_equity = self._projection_numbers()
+        _, expected_qty, pre_terminal_cash, pre_terminal_equity = self._projection_numbers()
         accounting_result = {
             "status": "partial",
             "coverage_complete": False,
@@ -215,8 +212,8 @@ class Issue126V3V4SuccessorMigrationTests(unittest.TestCase):
             "coverage_issue_count": 1,
             "economic_issues": [],
             "economic_issue_count": 0,
-            "cash": expected_cash,
-            "equity": expected_equity,
+            "cash": pre_terminal_cash,
+            "equity": pre_terminal_equity,
             "open_positions": {
                 "DHR": {"side": "long", "qty": expected_qty, "entry_price": 216.960007, "last_price": 215.79}
             },
@@ -226,17 +223,18 @@ class Issue126V3V4SuccessorMigrationTests(unittest.TestCase):
             pre = migration._preconditions(core)
         self.assertEqual(pre["failed"], [])
         self.assertTrue(all(pre["checks"].values()))
+        self.assertEqual(pre["projection"]["open_symbols"], [])
 
     def test_preconditions_do_not_accept_a_different_halt(self):
         import canonical_execution_ledger as ledger
         import paper_bidirectional_accounting_guard as accounting
         core = types.SimpleNamespace(portfolio=self._portfolio(halt_reason="different halt"))
-        expected_cash, expected_qty, expected_equity = self._projection_numbers()
+        _, expected_qty, pre_terminal_cash, pre_terminal_equity = self._projection_numbers()
         accounting_result = {
             "coverage_issues": [{"action": "partial_exit", "symbol": "SLS", "side": "long", "reason": "exit_exceeds_reconstructed_position", "requested_qty": 1.436519, "price": 16.04}],
             "economic_issues": [],
-            "cash": expected_cash,
-            "equity": expected_equity,
+            "cash": pre_terminal_cash,
+            "equity": pre_terminal_equity,
             "open_positions": {"DHR": {"qty": expected_qty}},
         }
         rows = self._rows()
@@ -257,7 +255,7 @@ class Issue126V3V4SuccessorMigrationTests(unittest.TestCase):
             marker = Path(folder) / "marker.json"
             core = types.SimpleNamespace(portfolio=self._portfolio(), local_ts_text=lambda: "2026-08-26 14:00:00 CDT")
             projection = migration._project(core, self._baseline_snapshot(), self._canonical())
-            pre = {"projection": projection, "canonical": {"row_count": 45, "chain_valid": True}}
+            pre = {"projection": projection, "canonical": {"row_count": 46, "chain_valid": True}}
             risk_before = copy.deepcopy(core.portfolio["risk_controls"])
             history_before = copy.deepcopy(core.portfolio["history"])
             saved = {}
@@ -280,7 +278,9 @@ class Issue126V3V4SuccessorMigrationTests(unittest.TestCase):
             self.assertEqual(core.portfolio["risk_controls"], risk_before)
             self.assertEqual(core.portfolio["history"], history_before)
             self.assertEqual(core.portfolio["accounting_epoch_id"], migration.TARGET_EPOCH_ID)
+            self.assertEqual(core.portfolio["positions"], {})
             self.assertEqual(saved["state"]["trades"], [])
+            self.assertEqual(saved["state"]["positions"], {})
 
     def test_authority_never_clears_halt_or_edits_ledger(self):
         authority = migration.status_payload(None)["authority"]

--- a/tests/test_verified_v3_terminal_dhr_recovery.py
+++ b/tests/test_verified_v3_terminal_dhr_recovery.py
@@ -18,7 +18,7 @@ def _mirrored_trade(expected):
     return row
 
 
-def _baseline_snapshot():
+def _terminal_dhr_fixture_snapshot():
     return {
         "verified": True,
         "cash": migration.EXPECTED_BASELINE_CASH,
@@ -54,7 +54,7 @@ def _fake_portfolio(current_cash=None, dhr_qty=None):
         invalid = migration.EXPECTED_V3_ROWS[2]
         projection = migration._project(
             SimpleNamespace(portfolio={"positions": {}}),
-            _baseline_snapshot(),
+            _terminal_dhr_fixture_snapshot(),
             _canonical_payload(),
         )
         current_cash = (
@@ -130,7 +130,7 @@ def test_state_trade_evidence_requires_terminal_dhr_row_to_be_canonical_only():
 def test_projection_replays_terminal_dhr_and_excludes_only_invalid_sls():
     core = SimpleNamespace(portfolio={"positions": {}})
 
-    projection = migration._project(core, _baseline_snapshot(), _canonical_payload())
+    projection = migration._project(core, _terminal_dhr_fixture_snapshot(), _canonical_payload())
 
     assert projection["status"] == "ok"
     assert projection["open_symbols"] == []
@@ -149,7 +149,7 @@ def test_successor_state_is_flat_and_preserves_halt_and_history():
     pf["history"] = [13500.0, 13600.0]
     projection = migration._project(
         SimpleNamespace(portfolio=pf),
-        _baseline_snapshot(),
+        _terminal_dhr_fixture_snapshot(),
         _canonical_payload(),
     )
 
@@ -167,10 +167,10 @@ def test_successor_state_is_flat_and_preserves_halt_and_history():
 def test_preconditions_require_exact_canonical_only_terminal_state_and_cash(monkeypatch):
     pf = _fake_portfolio()
     core = SimpleNamespace(portfolio=pf)
-    projection = migration._project(core, _baseline_snapshot(), _canonical_payload())
+    projection = migration._project(core, _terminal_dhr_fixture_snapshot(), _canonical_payload())
 
     monkeypatch.setattr(migration, "_paper_only", lambda: True)
-    monkeypatch.setattr(migration, "_baseline_snapshot", lambda _pf: (_baseline_snapshot(), []))
+    monkeypatch.setattr(migration, "_baseline_snapshot", lambda _pf: (_terminal_dhr_fixture_snapshot(), []))
     monkeypatch.setattr(migration, "_canonical_evidence", lambda _core: (_canonical_payload(), True))
     monkeypatch.setattr(
         migration,

--- a/tests/test_verified_v3_terminal_dhr_recovery.py
+++ b/tests/test_verified_v3_terminal_dhr_recovery.py
@@ -1,0 +1,193 @@
+import copy
+from types import SimpleNamespace
+
+import pytest
+
+import verified_v3_successor_epoch_migration as migration
+
+
+def _canonical_row(expected):
+    row = copy.deepcopy(expected)
+    row.pop("economic_disposition", None)
+    return row
+
+
+def _mirrored_trade(expected):
+    row = _canonical_row(expected)
+    row["canonical_ledger_event_hash"] = row.pop("event_hash")
+    return row
+
+
+def _baseline_snapshot():
+    return {
+        "verified": True,
+        "cash": migration.EXPECTED_BASELINE_CASH,
+        "equity": migration.EXPECTED_BASELINE_EQUITY,
+        "realized_today": 0.0,
+        "realized_total": 0.0,
+        "positions": {
+            "SLS": {
+                "side": "long",
+                "qty": migration.EXPECTED_BASELINE_SLS_QTY,
+                "entry_price": 14.0,
+                "mark": 14.0,
+            },
+            "DHR": {
+                "side": "long",
+                "qty": migration.EXPECTED_BASELINE_DHR_QTY,
+                "entry_price": 216.9600067138672,
+                "mark": 203.0,
+            },
+        },
+    }
+
+
+def _canonical_payload():
+    rows = [{} for _ in range(migration.EXPECTED_V3_START_INDEX)]
+    rows.extend(_canonical_row(expected) for expected in migration.EXPECTED_V3_ROWS)
+    return {"raw_rows": rows}
+
+
+def _fake_portfolio(current_cash=None, dhr_qty=None):
+    if current_cash is None:
+        terminal = migration.EXPECTED_V3_ROWS[3]
+        invalid = migration.EXPECTED_V3_ROWS[2]
+        projection = migration._project(
+            SimpleNamespace(portfolio={"positions": {}}),
+            _baseline_snapshot(),
+            _canonical_payload(),
+        )
+        current_cash = (
+            float(projection["cash"])
+            + float(invalid["shares"]) * float(invalid["price"])
+            - float(terminal["shares"]) * float(terminal["price"])
+        )
+    if dhr_qty is None:
+        dhr_qty = migration.EXPECTED_DHR_REMAINDER
+    return {
+        "cash": current_cash,
+        "positions": {
+            "DHR": {
+                "side": "long",
+                "qty": dhr_qty,
+                "entry": 216.9600067138672,
+                "last_price": 203.0,
+            },
+            "SLS": {
+                "side": "long",
+                "qty": 1.43651871,
+                "entry": 14.0,
+                "last_price": 16.04,
+            },
+        },
+        "trades": [_mirrored_trade(expected) for expected in migration.MIRRORED_V3_ROWS],
+        "risk_controls": {
+            "halted": True,
+            "halt_reason": "canonical execution lifecycle integrity halt",
+        },
+    }
+
+
+def test_fourth_v3_row_is_exact_terminal_dhr_exit():
+    expected = migration.EXPECTED_V3_ROWS[3]
+    row = _canonical_row(expected)
+
+    checks = migration._signature_checks(row, expected, int(expected["ledger_index"]))
+
+    assert migration.EXPECTED_LEDGER_ROW_COUNT == 46
+    assert len(migration.EXPECTED_V3_ROWS) == 4
+    assert expected["execution_id"] == migration.TERMINAL_DHR_EXECUTION_ID
+    assert all(checks.values())
+
+
+def test_terminal_dhr_signature_fails_closed_on_event_hash_mismatch():
+    expected = migration.EXPECTED_V3_ROWS[3]
+    row = _canonical_row(expected)
+    row["event_hash"] = "0" * 64
+
+    checks = migration._signature_checks(row, expected, int(expected["ledger_index"]))
+
+    assert checks["event_hash"] is False
+    assert all(value for name, value in checks.items() if name != "event_hash")
+
+
+def test_state_trade_evidence_requires_terminal_dhr_row_to_be_canonical_only():
+    pf = {"trades": [_mirrored_trade(expected) for expected in migration.MIRRORED_V3_ROWS]}
+
+    evidence, ready = migration._state_trade_evidence(pf)
+
+    assert ready is True
+    assert evidence["state_trade_count"] == 3
+    assert evidence["terminal_dhr_execution_absent"] is True
+
+    pf["trades"].append(_mirrored_trade(migration.EXPECTED_V3_ROWS[3]))
+    evidence, ready = migration._state_trade_evidence(pf)
+
+    assert ready is False
+    assert evidence["terminal_dhr_execution_absent"] is False
+
+
+def test_projection_replays_terminal_dhr_and_excludes_only_invalid_sls():
+    core = SimpleNamespace(portfolio={"positions": {}})
+
+    projection = migration._project(core, _baseline_snapshot(), _canonical_payload())
+
+    assert projection["status"] == "ok"
+    assert projection["open_symbols"] == []
+    assert projection["positions"] == {}
+    assert projection["excluded_execution_ids"] == [migration.INVALID_EXECUTION_ID]
+    assert projection["valid_execution_ids"] == [
+        migration.EXPECTED_V3_ROWS[0]["execution_id"],
+        migration.EXPECTED_V3_ROWS[1]["execution_id"],
+        migration.TERMINAL_DHR_EXECUTION_ID,
+    ]
+    assert projection["equity"] == pytest.approx(projection["cash"])
+
+
+def test_successor_state_is_flat_and_preserves_halt_and_history():
+    pf = _fake_portfolio()
+    pf["history"] = [13500.0, 13600.0]
+    projection = migration._project(
+        SimpleNamespace(portfolio=pf),
+        _baseline_snapshot(),
+        _canonical_payload(),
+    )
+
+    successor = migration.build_successor_state(pf, projection, "/tmp/archive", "2026-08-28 14:00:00 CDT")
+
+    assert successor["positions"] == {}
+    assert successor["trades"] == []
+    assert successor["cash"] == pytest.approx(successor["equity"])
+    assert successor["risk_controls"] == pf["risk_controls"]
+    assert successor["history"] == pf["history"]
+    assert successor["paper_accounting_epoch"]["validation_hold"] is True
+    assert successor["paper_accounting_epoch"]["terminal_valid_dhr_execution_id"] == migration.TERMINAL_DHR_EXECUTION_ID
+
+
+def test_preconditions_require_exact_canonical_only_terminal_state_and_cash(monkeypatch):
+    pf = _fake_portfolio()
+    core = SimpleNamespace(portfolio=pf)
+    projection = migration._project(core, _baseline_snapshot(), _canonical_payload())
+
+    monkeypatch.setattr(migration, "_paper_only", lambda: True)
+    monkeypatch.setattr(migration, "_baseline_snapshot", lambda _pf: (_baseline_snapshot(), []))
+    monkeypatch.setattr(migration, "_canonical_evidence", lambda _core: (_canonical_payload(), True))
+    monkeypatch.setattr(
+        migration,
+        "_state_trade_evidence",
+        lambda _pf: ({"state_trade_count": 3, "state_trade_rows_exact": True, "terminal_dhr_execution_absent": True}, True),
+    )
+    monkeypatch.setattr(migration, "_project", lambda _core, _snapshot, _canonical: copy.deepcopy(projection))
+    monkeypatch.setattr(migration, "_accounting_cross_check", lambda _core, _projection: ({"status": "partial"}, True))
+
+    pre = migration._preconditions(core)
+    assert pre["failed"] == []
+
+    pf["cash"] += 1.0
+    pre = migration._preconditions(core)
+    assert pre["checks"]["canonical_only_terminal_cash_effect_absent"] is False
+
+    pf["cash"] -= 1.0
+    pf["positions"]["DHR"]["qty"] += 0.01
+    pre = migration._preconditions(core)
+    assert pre["checks"]["canonical_only_terminal_dhr_state_shape_exact"] is False

--- a/tests/test_verified_v3_terminal_dhr_recovery.py
+++ b/tests/test_verified_v3_terminal_dhr_recovery.py
@@ -7,9 +7,7 @@ import verified_v3_successor_epoch_migration as migration
 
 
 def _canonical_row(expected):
-    row = copy.deepcopy(expected)
-    row.pop("economic_disposition", None)
-    return row
+    return {key: copy.deepcopy(value) for key, value in expected.items() if key != "economic_disposition"}
 
 
 def _mirrored_trade(expected):

--- a/verified_v3_successor_epoch_migration.py
+++ b/verified_v3_successor_epoch_migration.py
@@ -7,9 +7,9 @@ SLS position, allowing one later SLS partial exit that cannot be matched to any
 remaining canonical quantity.
 
 This module never changes the append-only canonical ledger. It requires the
-exact three-row v3 canonical shape proven by the post-PR-127 Splendid snapshot,
+exact four-row v3 canonical shape proven by the post-PR-127 Splendid snapshots,
 excludes only the exact invalid SLS partial row from successor economics, replays
-the two valid rows from the verified v3 snapshot baseline, archives the complete
+the three valid rows from the verified v3 snapshot baseline, archives the complete
 v3 persistence, and starts a v4 verified-snapshot accounting epoch.
 
 The existing canonical lifecycle halt and current-day risk peak are preserved.
@@ -28,17 +28,18 @@ import shutil
 import threading
 from typing import Any, Dict, List, Tuple
 
-VERSION = "verified-v3-successor-epoch-migration-2026-08-26-v1-issue126-sls-disposition"
+VERSION = "verified-v3-successor-epoch-migration-2026-08-28-v2-issue126-terminal-dhr"
 OLD_EPOCH_ID = "stable-paper-v3-20260825-successor01"
 TARGET_EPOCH_ID = "stable-paper-v4-20260826-successor01"
 PRIOR_EPOCH_ID = "stable-paper-v2-20260812-verified01"
 DECISION_ID = "issue-126-sls-reentrant-accounting-disposition-2026-08-26"
 HISTORICAL_DECISION = "issue126_sls_reentrant_accounting_successor_rollforward"
-EXPECTED_LEDGER_ROW_COUNT = 45
+EXPECTED_LEDGER_ROW_COUNT = 46
 EXPECTED_V3_START_INDEX = 42
 EXPECTED_BASELINE_CASH = 13357.874520862653
 EXPECTED_BASELINE_EQUITY = 13535.962581344369
 EXPECTED_BASELINE_SLS_QTY = 4.353086829
+EXPECTED_BASELINE_DHR_QTY = 0.540748758
 QTY_TOLERANCE = 5e-6
 PRICE_TOLERANCE = 5e-6
 MONEY_TOLERANCE = 0.01
@@ -87,9 +88,25 @@ EXPECTED_V3_ROWS: tuple[dict[str, Any], ...] = (
         "event_hash": "d39e877f34bcf9d5a720a8bfd94a66ebace9d8cfa30987bedce29a1112db8774",
         "economic_disposition": "exclude_exact_invalid_reentrant_artifact",
     },
+    {
+        "ledger_index": 45,
+        "execution_id": "ae9d82d3d25748459f37842679d501cd",
+        "accounting_epoch_id": OLD_EPOCH_ID,
+        "action": "exit",
+        "symbol": "DHR",
+        "side": "long",
+        "price": 203.039993,
+        "shares": 0.36230183,
+        "event_hash": "0a3af37e3f69477acbc49a29454a8cd377d509186e3c60fa53aa3fe0ae3592b8",
+        "economic_disposition": "valid_replay_canonical_only_state_mirror_missing",
+    },
 )
+MIRRORED_V3_ROWS = EXPECTED_V3_ROWS[:3]
 INVALID_EXECUTION_ID = EXPECTED_V3_ROWS[2]["execution_id"]
 INVALID_EVENT_HASH = EXPECTED_V3_ROWS[2]["event_hash"]
+TERMINAL_DHR_EXECUTION_ID = EXPECTED_V3_ROWS[3]["execution_id"]
+TERMINAL_DHR_EVENT_HASH = EXPECTED_V3_ROWS[3]["event_hash"]
+EXPECTED_DHR_REMAINDER = EXPECTED_BASELINE_DHR_QTY - float(EXPECTED_V3_ROWS[1]["shares"])
 
 
 def _d(value: Any) -> Dict[str, Any]:
@@ -202,6 +219,11 @@ def _baseline_snapshot(pf: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
         issues.append("v3_baseline_sls_side_mismatch")
     if not _close(sls.get("qty", sls.get("shares")), EXPECTED_BASELINE_SLS_QTY, QTY_TOLERANCE):
         issues.append("v3_baseline_sls_qty_mismatch")
+    dhr = _d(positions.get("DHR"))
+    if str(dhr.get("side") or "long").lower() != "long":
+        issues.append("v3_baseline_dhr_side_mismatch")
+    if not _close(dhr.get("qty", dhr.get("shares")), EXPECTED_BASELINE_DHR_QTY, QTY_TOLERANCE):
+        issues.append("v3_baseline_dhr_qty_mismatch")
     return snap, issues
 
 
@@ -271,8 +293,8 @@ def _canonical_evidence(core: Any) -> Tuple[Dict[str, Any], bool]:
 def _state_trade_evidence(pf: Dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
     trades = [row for row in _l(pf.get("trades")) if isinstance(row, dict)]
     checks: List[Dict[str, Any]] = []
-    exact = len(trades) == len(EXPECTED_V3_ROWS)
-    for index, expected in enumerate(EXPECTED_V3_ROWS):
+    exact = len(trades) == len(MIRRORED_V3_ROWS)
+    for index, expected in enumerate(MIRRORED_V3_ROWS):
         row = trades[index] if index < len(trades) else {}
         row_checks = {
             "execution_id": str(row.get("execution_id") or "") == str(expected["execution_id"]),
@@ -280,13 +302,20 @@ def _state_trade_evidence(pf: Dict[str, Any]) -> Tuple[Dict[str, Any], bool]:
             "action": str(row.get("action") or "").lower() == str(expected["action"]),
             "symbol": str(row.get("symbol") or "").upper() == str(expected["symbol"]),
             "side": str(row.get("side") or "long").lower() == str(expected["side"]),
-            "price": _close(row.get("price"), float(expected["price"]), 1e-6),
+            "price": _close(row.get("price"), float(expected["price"]), PRICE_TOLERANCE),
             "canonical_ledger_event_hash": str(row.get("canonical_ledger_event_hash") or "") == str(expected["event_hash"]),
         }
         row_exact = bool(row and all(row_checks.values()))
         exact = exact and row_exact
         checks.append({"trade_index": index, "execution_id": row.get("execution_id"), "checks": row_checks, "exact": row_exact})
-    return {"state_trade_count": len(trades), "state_trade_rows_exact": bool(exact), "rows": checks}, bool(exact)
+    terminal_absent = all(str(row.get("execution_id") or "") != TERMINAL_DHR_EXECUTION_ID for row in trades)
+    exact = exact and terminal_absent
+    return {
+        "state_trade_count": len(trades),
+        "state_trade_rows_exact": bool(exact),
+        "terminal_dhr_execution_absent": terminal_absent,
+        "rows": checks,
+    }, bool(exact)
 
 
 def _opening_books(snapshot: Dict[str, Any]) -> Tuple[float, Dict[str, Dict[str, float]], float, float, List[str]]:
@@ -452,7 +481,7 @@ def _accounting_cross_check(core: Any, projection: Dict[str, Any]) -> Tuple[Dict
             and str(row.get("symbol") or "").upper() == "SLS"
             and str(row.get("action") or "").lower() == "partial_exit"
             and _close(row.get("requested_qty", row.get("shares")), 1.436519, QTY_TOLERANCE)
-            and _close(row.get("price"), 16.04, 1e-6)
+            and _close(row.get("price"), 16.04, PRICE_TOLERANCE)
         )
 
     issue_shape = bool(len(coverage) == 1 and all(exact_issue(row) for row in all_issues) and len(economics) <= 1)
@@ -463,22 +492,38 @@ def _accounting_cross_check(core: Any, projection: Dict[str, Any]) -> Tuple[Dict
         rebuilt_symbols = sorted(str(value).upper() for value in _l(result.get("reconstructed_open_positions")))
     else:
         rebuilt_symbols = sorted(str(value).upper() for value in rebuilt_positions)
-    projected_positions = _d(projection.get("positions"))
-    qty_match = True
-    if rebuilt_positions and set(rebuilt_positions) == set(projected_positions):
-        for symbol, expected in projected_positions.items():
-            observed = _d(rebuilt_positions.get(symbol))
-            if not _close(observed.get("qty", observed.get("shares")), float(expected.get("shares") or 0.0), QTY_TOLERANCE):
-                qty_match = False
-    elif rebuilt_symbols != sorted(projected_positions):
-        qty_match = False
+
+    terminal = EXPECTED_V3_ROWS[3]
+    terminal_notional = float(terminal["shares"]) * float(terminal["price"])
+    projected_cash = _f(projection.get("cash"))
+    expected_pre_terminal_cash = (projected_cash - terminal_notional) if projected_cash is not None else None
+    dhr_current = _d(_d(_portfolio(core).get("positions")).get("DHR"))
+    dhr_mark = _f(dhr_current.get("last_price", dhr_current.get("mark")))
+    if dhr_mark is None or dhr_mark <= 0:
+        dhr_mark = _f(_d(_d(_d(_portfolio(core).get("paper_accounting_epoch")).get("verified_snapshot_baseline")).get("positions")).get("DHR", {}).get("mark"))
+    expected_pre_terminal_equity = (
+        expected_pre_terminal_cash + (EXPECTED_DHR_REMAINDER * dhr_mark)
+        if expected_pre_terminal_cash is not None and dhr_mark is not None and dhr_mark > 0
+        else None
+    )
+
+    qty_match = rebuilt_symbols == ["DHR"]
+    if rebuilt_positions:
+        observed = _d(rebuilt_positions.get("DHR"))
+        qty_match = qty_match and _close(observed.get("qty", observed.get("shares")), EXPECTED_DHR_REMAINDER, QTY_TOLERANCE)
+
     ready = bool(
         issue_shape
-        and rebuilt_cash is not None and abs(rebuilt_cash - float(projection.get("cash") or 0.0)) <= MONEY_TOLERANCE
-        and rebuilt_equity is not None and abs(rebuilt_equity - float(projection.get("equity") or 0.0)) <= EQUITY_TOLERANCE
-        and rebuilt_symbols == sorted(projected_positions)
+        and rebuilt_cash is not None and expected_pre_terminal_cash is not None
+        and abs(rebuilt_cash - expected_pre_terminal_cash) <= MONEY_TOLERANCE
+        and rebuilt_equity is not None and expected_pre_terminal_equity is not None
+        and abs(rebuilt_equity - expected_pre_terminal_equity) <= EQUITY_TOLERANCE
         and qty_match
     )
+    result = dict(result)
+    result["issue126_expected_pre_terminal_cash"] = expected_pre_terminal_cash
+    result["issue126_expected_pre_terminal_equity"] = expected_pre_terminal_equity
+    result["issue126_expected_pre_terminal_dhr_qty"] = EXPECTED_DHR_REMAINDER
     return result, ready
 
 
@@ -492,23 +537,49 @@ def _preconditions(core: Any) -> Dict[str, Any]:
     risk = _d(pf.get("risk_controls"))
     risk_exact = bool(risk.get("halted") and str(risk.get("halt_reason") or "") == "canonical execution lifecycle integrity halt")
     projected_symbols = sorted(_d(projection.get("positions")))
-    projected_shape = projection.get("status") == "ok" and projected_symbols == ["DHR"] and projection.get("excluded_execution_ids") == [INVALID_EXECUTION_ID]
+    projected_shape = bool(
+        projection.get("status") == "ok"
+        and projected_symbols == []
+        and projection.get("excluded_execution_ids") == [INVALID_EXECUTION_ID]
+        and projection.get("valid_execution_ids") == [
+            EXPECTED_V3_ROWS[0]["execution_id"],
+            EXPECTED_V3_ROWS[1]["execution_id"],
+            EXPECTED_V3_ROWS[3]["execution_id"],
+        ]
+    )
+
+    current_positions = _d(pf.get("positions"))
+    dhr_current = _d(current_positions.get("DHR"))
+    terminal_state_shape_exact = bool(
+        set(str(symbol).upper() for symbol in current_positions) == {"DHR", "SLS"}
+        and str(dhr_current.get("side") or "long").lower() == "long"
+        and _close(dhr_current.get("qty", dhr_current.get("shares")), EXPECTED_DHR_REMAINDER, QTY_TOLERANCE)
+    )
+
     current_cash = _f(pf.get("cash"))
     projected_cash = _f(projection.get("cash"))
     invalid_notional = float(EXPECTED_V3_ROWS[2]["shares"]) * float(EXPECTED_V3_ROWS[2]["price"])
-    invalid_cash_effect_exact = bool(
-        current_cash is not None and projected_cash is not None
-        and abs((current_cash - projected_cash) - invalid_notional) <= MONEY_TOLERANCE
+    terminal_notional = float(EXPECTED_V3_ROWS[3]["shares"]) * float(EXPECTED_V3_ROWS[3]["price"])
+    expected_pre_cutover_cash = (
+        projected_cash + invalid_notional - terminal_notional
+        if projected_cash is not None
+        else None
     )
+    terminal_cash_effect_absent = bool(
+        current_cash is not None and expected_pre_cutover_cash is not None
+        and abs(current_cash - expected_pre_cutover_cash) <= MONEY_TOLERANCE
+    )
+
     checks = {
         "paper_runtime": _paper_only(),
         "baseline_exact": not baseline_issues,
-        "canonical_chain_and_exact_three_v3_rows": canonical_ready,
-        "state_trade_mirror_exact_three_v3_rows": state_trades_ready,
+        "canonical_chain_and_exact_four_v3_rows": canonical_ready,
+        "state_trade_mirror_exact_original_three_v3_rows": state_trades_ready,
+        "canonical_only_terminal_dhr_state_shape_exact": terminal_state_shape_exact,
+        "canonical_only_terminal_cash_effect_absent": terminal_cash_effect_absent,
         "existing_lifecycle_halt_preserved": risk_exact,
-        "deterministic_projection_clean": bool(projected_shape),
-        "invalid_partial_cash_effect_exact": invalid_cash_effect_exact,
-        "legacy_accounting_cross_check_exact": cross_ready,
+        "deterministic_projection_clean_flat": bool(projected_shape),
+        "legacy_accounting_cross_check_exact_pre_terminal_state": cross_ready,
     }
     failed = [name for name, ok in checks.items() if not ok]
     return {
@@ -520,6 +591,9 @@ def _preconditions(core: Any) -> Dict[str, Any]:
         "projection": projection,
         "accounting_cross_check": cross,
         "invalid_partial_cash_effect_dollars": invalid_notional,
+        "terminal_dhr_cash_effect_dollars": terminal_notional,
+        "expected_pre_cutover_cash": expected_pre_cutover_cash,
+        "expected_dhr_remainder": EXPECTED_DHR_REMAINDER,
     }
 
 
@@ -556,13 +630,16 @@ def _archive_state(core: Any, pre: Dict[str, Any], ledger_path: str, ledger_dige
         "created_local": _now(core),
         "archive_dir": archive_dir,
         "evidence": {
-            "authoritative_snapshot_workflow_run": 33001743744,
-            "authoritative_snapshot_artifact_id": 9619045572,
+            "authoritative_snapshot_workflow_run": 33181093054,
+            "authoritative_snapshot_artifact_id": 9689875237,
             "prospective_fix_main_sha": "71c3e0777f82f3b1521b3ab17df53a25fb1d91d1",
             "canonical_row_count": _d(pre.get("canonical")).get("row_count"),
             "canonical_v3_rows": _d(pre.get("canonical")).get("rows"),
             "invalid_execution_id": INVALID_EXECUTION_ID,
             "invalid_event_hash": INVALID_EVENT_HASH,
+            "terminal_valid_dhr_execution_id": TERMINAL_DHR_EXECUTION_ID,
+            "terminal_valid_dhr_event_hash": TERMINAL_DHR_EVENT_HASH,
+            "terminal_valid_dhr_was_canonical_only_pre_cutover": True,
             "invalid_row_retained_immutably": True,
             "invalid_row_economic_effect_excluded_only_in_successor_projection": True,
         },
@@ -593,8 +670,8 @@ def build_successor_state(pf: Dict[str, Any], projection: Dict[str, Any], archiv
     positions = copy.deepcopy(_d(projection.get("positions")))
     cash = float(projection.get("cash") or 0.0)
     equity = float(projection.get("equity") or 0.0)
-    if cash <= 0 or equity <= 0 or sorted(positions) != ["DHR"]:
-        raise RuntimeError("deterministic successor projection is not sane")
+    if cash <= 0 or equity <= 0 or positions or abs(equity - cash) > EQUITY_TOLERANCE:
+        raise RuntimeError("deterministic successor projection is not sane and flat")
     if not bool(risk_before.get("halted")) or str(risk_before.get("halt_reason") or "") != "canonical execution lifecycle integrity halt":
         raise RuntimeError("expected lifecycle halt is not active")
 
@@ -614,15 +691,6 @@ def build_successor_state(pf: Dict[str, Any], projection: Dict[str, Any], archiv
     state["performance"] = perf
     state["risk_controls"] = risk_before
 
-    snapshot_positions: Dict[str, Dict[str, Any]] = {}
-    for symbol, raw in positions.items():
-        pos = _d(raw)
-        snapshot_positions[symbol] = {
-            "side": str(pos.get("side") or "long"),
-            "qty": float(pos.get("shares", pos.get("qty")) or 0.0),
-            "entry_price": float(pos.get("entry", pos.get("entry_price")) or 0.0),
-            "mark": float(pos.get("last_price") or 0.0),
-        }
     snapshot = {
         "verified": True,
         "version": VERSION,
@@ -631,9 +699,10 @@ def build_successor_state(pf: Dict[str, Any], projection: Dict[str, Any], archiv
         "equity": equity,
         "realized_today": float(projection.get("realized_today") or 0.0),
         "realized_total": float(projection.get("realized_total") or 0.0),
-        "positions": snapshot_positions,
-        "source": "deterministic_v3_verified_snapshot_plus_exact_valid_canonical_replay",
+        "positions": {},
+        "source": "deterministic_v3_verified_snapshot_plus_exact_valid_canonical_replay_including_terminal_dhr",
         "invalid_execution_retained_but_excluded_from_successor_economics": INVALID_EXECUTION_ID,
+        "terminal_valid_dhr_execution_replayed": TERMINAL_DHR_EXECUTION_ID,
     }
     state["accounting_epoch_id"] = TARGET_EPOCH_ID
     state["paper_accounting_epoch"] = {
@@ -649,7 +718,7 @@ def build_successor_state(pf: Dict[str, Any], projection: Dict[str, Any], archiv
         "verified_snapshot_baseline": snapshot,
         "historical_recovery_decision": HISTORICAL_DECISION,
         "prior_epoch_id": OLD_EPOCH_ID,
-        "prior_epoch_disposition": "archived_with_exact_issue126_sls_reentrant_artifact_disposition_and_immutable_canonical_ledger_retained",
+        "prior_epoch_disposition": "archived_with_exact_issue126_sls_reentrant_artifact_disposition_terminal_dhr_replay_and_immutable_canonical_ledger_retained",
         "historical_evidence_archived": True,
         "forensic_archive_dir": archive_dir,
         "validation_hold": True,
@@ -661,6 +730,8 @@ def build_successor_state(pf: Dict[str, Any], projection: Dict[str, Any], archiv
         "valid_path_rows_baseline": 0,
         "invalid_execution_id": INVALID_EXECUTION_ID,
         "invalid_event_hash": INVALID_EVENT_HASH,
+        "terminal_valid_dhr_execution_id": TERMINAL_DHR_EXECUTION_ID,
+        "terminal_valid_dhr_event_hash": TERMINAL_DHR_EVENT_HASH,
         "canonical_history_retained_immutably": True,
     }
     return state
@@ -725,6 +796,8 @@ def _cutover(core: Any, pre: Dict[str, Any], *, retried: bool = False) -> Dict[s
         "canonical_ledger_sha256_before": digest_before,
         "invalid_execution_id": INVALID_EXECUTION_ID,
         "invalid_event_hash": INVALID_EVENT_HASH,
+        "terminal_valid_dhr_execution_id": TERMINAL_DHR_EXECUTION_ID,
+        "terminal_valid_dhr_event_hash": TERMINAL_DHR_EVENT_HASH,
     }
     _atomic_json(MARKER_FILE, started)
     successor = build_successor_state(_portfolio(core), _d(pre.get("projection")), str(archive.get("archive_dir") or ""), started_local)
@@ -765,6 +838,7 @@ def _active_status(core: Any) -> Dict[str, Any]:
         "validation_hold": bool(epoch.get("validation_hold", False)),
         "canonical_ledger_unchanged": bool(marker.get("canonical_ledger_unchanged", False)),
         "invalid_execution_retained_immutably": str(epoch.get("invalid_execution_id") or "") == INVALID_EXECUTION_ID,
+        "terminal_valid_dhr_execution_replayed": str(epoch.get("terminal_valid_dhr_execution_id") or "") == TERMINAL_DHR_EXECUTION_ID,
         "state_trade_rows": len(_l(pf.get("trades"))),
         "positions": sorted(_d(pf.get("positions"))),
         "cash": pf.get("cash"),
@@ -858,6 +932,7 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
             "archives_prior_v3_evidence": True,
             "clears_active_state_trade_window": True,
             "retains_invalid_canonical_row_immutably": True,
+            "replays_terminal_valid_canonical_only_dhr_exit": True,
             "excludes_only_exact_invalid_row_from_successor_economics": True,
             "edits_or_deletes_canonical_rows": False,
             "rotates_or_truncates_canonical_ledger": False,


### PR DESCRIPTION
## Scope
Bounded paper-only Issue #126 successor-accounting repair for the independently proven canonical-only DHR full exit at ledger row 46.

## Exact behavior
- requires exactly 46 canonical rows / four ordered v3 signatures;
- retains every canonical row immutably;
- requires row 46 to be absent from the pre-cutover state-trade mirror and its proceeds absent from persisted cash;
- requires DHR to remain at the reconstructed post-partial remainder;
- replays valid SLS full exit, valid DHR partial, and valid DHR full exit;
- excludes only exact invalid SLS partial `90b22aad76074031906e0c6459dfa0bc` from successor economics;
- projects a flat v4 successor;
- preserves lifecycle halt, validation hold, risk/history, strategy, sizing, hard-risk thresholds, live authority, and ML authority.

## Validation
Includes focused fail-closed regressions for the exact row-46 signature, canonical-only mirror condition, flat replay, successor state, cash mismatch, and DHR-quantity mismatch. Do not merge unless every mandatory exact-head safety/startup/invariant gate is green.