### PR TITLE
Increase repo-agent output budget for bounded large-file repairs

### DIFF
--- a/scripts/repo_agent.py
+++ b/scripts/repo_agent.py
@@ -182,7 +182,7 @@ def call_openai(instruction: str, context: str) -> dict[str, Any]:
                 "content": f"Instruction:\n{instruction}\n\nRepository context:\n{context}",
             },
         ],
-        "max_output_tokens": 12000,
+        "max_output_tokens": 24000,
     }
     request = urllib.request.Request(
         "https://api.openai.com/v1/responses",


### PR DESCRIPTION
Issue #126 repair attempts are repeatedly failing before any write because the guarded repo-agent response is truncated while returning complete replacement content for the existing migration module. This changes only `max_output_tokens` from 12000 to 24000; no repository safety policy, protected path, trading code, runtime state, strategy, risk, live authority, ML authority, or merge authority changes. Exact compare: one line changed. Purpose is to let the existing guarded PR-only agent finish a bounded large-file response instead of producing invalid JSON.