### PR TITLE
Give repo-agent complete context for large bounded files

### DIFF
--- a/scripts/repo_agent.py
+++ b/scripts/repo_agent.py
@@ -21,7 +21,7 @@ from typing import Any
 ROOT = Path.cwd().resolve()
 MODEL = os.getenv("REPO_AGENT_MODEL", "gpt-5-mini")
 MAX_INSTRUCTION = 4000
-MAX_CONTEXT_CHARS = 80000
+MAX_CONTEXT_CHARS = 120000
 MAX_FILES = 8
 MAX_FILE_CHARS = 120000
 
@@ -144,7 +144,7 @@ def build_context(instruction: str) -> str:
         remaining = MAX_CONTEXT_CHARS - total
         if remaining <= 1000:
             break
-        clipped = text[: min(remaining, 15000)]
+        clipped = text[: min(remaining, 60000)]
         pieces.append(f"\n===== {rel} =====\n{clipped}")
         total += len(clipped)
 


### PR DESCRIPTION
Follow-up to PR #137. The output truncation is fixed, but PR #138 proved the agent still receives only the first 15,000 characters of each ranked file, so a large target module is reconstructed destructively even when the response completes. This changes only the grounded-context budget: 80k→120k total and 15k→60k per ranked file. It does not change trading code, protected paths, repo-agent authority, merge authority, risk policy, runtime state, strategy, sizing, live authority, or ML authority. Exact compare is two constant/budget lines only.