### PR TITLE
Fix Issue #143 runtime snapshot false WARN classification

### DIFF
--- a/runtime_research_snapshot.py
+++ b/runtime_research_snapshot.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_BASE_URL = "https://web-production-e1796.up.railway.app"
-VERSION = "runtime-research-snapshot-2026-08-24-v5-market-open-stabilization"
+VERSION = "runtime-research-snapshot-2026-09-01-v6-lineage-aware-classification"
 
 ENDPOINTS = {
     "bootstrap_status": "/bootstrap-status",
@@ -41,6 +41,18 @@ def _dict(value: Any) -> dict[str, Any]:
 
 def _list(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
+
+
+def _stable_paper_epoch_generation(epoch_id: Any) -> int | None:
+    text = str(epoch_id or "")
+    prefix = "stable-paper-v"
+    if not text.startswith(prefix):
+        return None
+    generation_text = text[len(prefix) :].split("-", 1)[0]
+    try:
+        return int(generation_text)
+    except (TypeError, ValueError):
+        return None
 
 
 def _fetch_json(url: str, retries: int, timeout: float) -> dict[str, Any]:
@@ -254,6 +266,34 @@ def _summarize(raw: dict[str, dict[str, Any]]) -> dict[str, Any]:
     audit_overall = audit_payload.get("overall")
     v2_run_status = v2_payload.get("run_status") or latest.get("status") or "unknown"
 
+    active_epoch_id = _dict(audit_payload.get("accounting_epoch")).get("epoch_id")
+    active_epoch_generation = _stable_paper_epoch_generation(active_epoch_id)
+    recovery_gate_superseded = bool(
+        active_epoch_generation is not None and active_epoch_generation >= 4
+    )
+    root_optional_nonblocking = bool(
+        "root" in failures
+        and "bootstrap_status" in reachable
+        and "paper_status" in reachable
+        and "self_check" in reachable
+        and application_ready
+        and self_overall == "pass"
+        and paper_payload.get("status") in {None, "ok", "pass"}
+    )
+    nonblocking_failures = set()
+    if root_optional_nonblocking:
+        nonblocking_failures.add("root")
+    if recovery_gate_superseded:
+        nonblocking_failures.add("verified_v2_recovery_gate")
+    classification_failures = sorted(set(failures) - nonblocking_failures)
+    recovery_gate["classification_applicable"] = not recovery_gate_superseded
+    recovery_gate["classification_reason"] = (
+        "superseded_by_active_v4_plus_lineage"
+        if recovery_gate_superseded
+        else "active_verified_v2_recovery_gate"
+    )
+    recovery_gate["active_epoch_id"] = active_epoch_id
+
     if not listener_reachable:
         overall = "error"
     elif not application_ready:
@@ -264,9 +304,9 @@ def _summarize(raw: dict[str, dict[str, Any]]) -> dict[str, Any]:
         overall = "warn"
     elif audit_overall not in {None, "pass"}:
         overall = "warn"
-    elif recovery_overall not in {None, "pass"}:
+    elif not recovery_gate_superseded and recovery_overall not in {None, "pass"}:
         overall = "warn"
-    elif str(v2_run_status).lower() == "error" or failures:
+    elif str(v2_run_status).lower() == "error" or classification_failures:
         overall = "warn"
     else:
         overall = "pass"
@@ -278,6 +318,8 @@ def _summarize(raw: dict[str, dict[str, Any]]) -> dict[str, Any]:
             "total_count": len(raw),
             "reachable_endpoints": reachable,
             "failed_endpoints": failures,
+            "classification_failed_endpoints": classification_failures,
+            "nonblocking_failed_endpoints": sorted(nonblocking_failures),
             "listener_reachable": listener_reachable,
             "application_ready": application_ready,
             "delegate_ready": delegate_ready,
@@ -287,6 +329,7 @@ def _summarize(raw: dict[str, dict[str, Any]]) -> dict[str, Any]:
             "bootstrap_elapsed_seconds": bootstrap_payload.get("elapsed_seconds"),
             "loader_thread_alive": bootstrap_payload.get("loader_thread_alive"),
             "root_status": root_payload.get("status"),
+            "root_optional_nonblocking": root_optional_nonblocking,
             "paper_status": paper_payload.get("status"),
         },
         "self_check": {
@@ -377,6 +420,8 @@ def _markdown(report: dict[str, Any]) -> str:
         f"- Bootstrap phase: `{connectivity.get('bootstrap_phase')}`",
         f"- Bootstrap error: `{connectivity.get('bootstrap_error')}`",
         f"- Failed endpoints: `{connectivity.get('failed_endpoints')}`",
+        f"- Classification failures: `{connectivity.get('classification_failed_endpoints')}`",
+        f"- Nonblocking failures: `{connectivity.get('nonblocking_failed_endpoints')}`",
         "",
         "## Paper Runtime",
         "",
@@ -412,6 +457,9 @@ def _markdown(report: dict[str, Any]) -> str:
         "## Verified-v2 Recovery Gate",
         "",
         f"- Overall: `{recovery_gate.get('overall')}`",
+        f"- Classification applicable: `{recovery_gate.get('classification_applicable')}`",
+        f"- Classification reason: `{recovery_gate.get('classification_reason')}`",
+        f"- Active epoch: `{recovery_gate.get('active_epoch_id')}`",
         f"- Diagnosis: `{recovery_gate.get('diagnosis')}`",
         f"- Version: `{recovery_gate.get('version')}`",
         f"- Ledger rows / chain: `{recovery_gate.get('ledger_row_count')}` / `{recovery_gate.get('chain_valid')}`",

--- a/test_runtime_research_snapshot.py
+++ b/test_runtime_research_snapshot.py
@@ -11,6 +11,7 @@ class RuntimeResearchSnapshotTests(unittest.TestCase):
         recovery_overall="pass",
         fresh_baseline_status="pass",
         audit_overall="pass",
+        epoch_id="stable-paper-v2-20260812-verified01",
     ):
         raw = {
             name: {"status": "ok", "payload": {}}
@@ -45,7 +46,7 @@ class RuntimeResearchSnapshotTests(unittest.TestCase):
             "overall": audit_overall,
             "generated_local": "2026-08-24 10:30:00 CDT",
             "accounting_epoch": {
-                "epoch_id": "stable-paper-v2-20260812-verified01",
+                "epoch_id": epoch_id,
                 "validation_hold": True,
             },
             "accounting_integrity": {
@@ -56,7 +57,7 @@ class RuntimeResearchSnapshotTests(unittest.TestCase):
             "execution_ledger": {
                 "chain_valid": True,
                 "row_count": 39,
-                "current_epoch_id": "stable-paper-v2-20260812-verified01",
+                "current_epoch_id": epoch_id,
             },
             "market_data": {"status": "pass"},
             "runner": {
@@ -126,6 +127,7 @@ class RuntimeResearchSnapshotTests(unittest.TestCase):
         self.assertEqual(summary["overall"], "pass")
         gate = summary["recovery_gate"]
         self.assertEqual(gate["overall"], "pass")
+        self.assertTrue(gate["classification_applicable"])
         self.assertEqual(gate["ledger_row_count"], 39)
         self.assertEqual(gate["known_invalid_execution_count"], 7)
         self.assertTrue(gate["all_known_invalid_signatures_exact"])
@@ -176,14 +178,79 @@ class RuntimeResearchSnapshotTests(unittest.TestCase):
         self.assertEqual(summary["daily_audit"]["coverage_issue_count"], 1)
         self.assertEqual(summary["daily_audit"]["economic_issue_count"], 1)
 
-    def test_failed_recovery_gate_warns_snapshot_without_manual_probe_regression(self):
+    def test_failed_recovery_gate_warns_on_active_verified_v2_lineage(self):
         summary = snapshot._summarize(self._raw(recovery_overall="fail"))
 
         self.assertEqual(summary["overall"], "warn")
         gate = summary["recovery_gate"]
         self.assertEqual(gate["overall"], "fail")
+        self.assertTrue(gate["classification_applicable"])
+        self.assertEqual(
+            gate["classification_reason"], "active_verified_v2_recovery_gate"
+        )
         self.assertFalse(gate["mechanically_complete_for_successor_migration_design"])
         self.assertFalse(gate["manual_per_event_probe_required"])
+
+    def test_failed_verified_v2_gate_is_superseded_on_active_v4_lineage(self):
+        raw = self._raw(
+            recovery_overall="fail",
+            epoch_id="stable-paper-v4-20260826-successor01",
+        )
+        raw["verified_v2_recovery_gate"]["payload"]["diagnosis"] = (
+            "canonical_ledger_epoch_lineage_not_exactly_verified_v2"
+        )
+
+        summary = snapshot._summarize(raw)
+
+        self.assertEqual(summary["overall"], "pass")
+        gate = summary["recovery_gate"]
+        self.assertEqual(gate["overall"], "fail")
+        self.assertFalse(gate["classification_applicable"])
+        self.assertEqual(
+            gate["classification_reason"],
+            "superseded_by_active_v4_plus_lineage",
+        )
+        self.assertEqual(
+            gate["active_epoch_id"], "stable-paper-v4-20260826-successor01"
+        )
+
+    def test_optional_root_failure_does_not_warn_when_required_runtime_is_healthy(self):
+        raw = self._raw(
+            recovery_overall="fail",
+            epoch_id="stable-paper-v4-20260826-successor01",
+        )
+        raw["root"] = {"status": "error", "error": "HTTPError: 404"}
+
+        summary = snapshot._summarize(raw)
+
+        self.assertEqual(summary["overall"], "pass")
+        connectivity = summary["connectivity"]
+        self.assertIn("root", connectivity["failed_endpoints"])
+        self.assertNotIn("root", connectivity["classification_failed_endpoints"])
+        self.assertIn("root", connectivity["nonblocking_failed_endpoints"])
+        self.assertTrue(connectivity["root_optional_nonblocking"])
+
+    def test_root_failure_stays_blocking_when_required_self_check_is_unhealthy(self):
+        raw = self._raw(epoch_id="stable-paper-v4-20260826-successor01")
+        raw["root"] = {"status": "error", "error": "HTTPError: 404"}
+        raw["self_check"]["payload"]["overall"] = "fail"
+
+        summary = snapshot._summarize(raw)
+
+        self.assertEqual(summary["overall"], "warn")
+        self.assertIn("root", summary["connectivity"]["classification_failed_endpoints"])
+        self.assertFalse(summary["connectivity"]["root_optional_nonblocking"])
+
+    def test_required_endpoint_failure_still_warns_on_v4(self):
+        raw = self._raw(epoch_id="stable-paper-v4-20260826-successor01")
+        raw["paper_status"] = {"status": "error", "error": "timeout"}
+
+        summary = snapshot._summarize(raw)
+
+        self.assertEqual(summary["overall"], "warn")
+        self.assertIn(
+            "paper_status", summary["connectivity"]["classification_failed_endpoints"]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #143 with a diagnostics-only, read-only classification repair.

Scope:
- preserve collection/reporting of the legacy verified-v2 recovery probe;
- when the active daily-audit lineage is stable-paper-v4 or later, mark that legacy probe superseded for overall classification while retaining its raw evidence;
- preserve active verified-v2 failure behavior;
- treat only the root `/` fetch as nonblocking, and only when bootstrap, paper status, application readiness, and self-check are healthy;
- preserve fail-closed behavior for required endpoint, self-check, fresh-day, daily-audit, and active-v2 recovery failures;
- add focused regressions for the exact v4 lineage and optional-root failure.

No strategy, signals, sizing, hard-risk limits, canonical ledger/accounting state, halt/validation hold, live authority, ML authority, or order authority changes.