### PR TITLE
Fix Issue #146 read-only status persistence latency

### DIFF
--- a/PROJECT_HANDOFF_CURRENT.md
+++ b/PROJECT_HANDOFF_CURRENT.md
@@ -1,11 +1,11 @@
 # Project Handoff — Authoritative Current Trading Runtime
 
-Last updated: 2026-09-01 10:48 CDT  
+Last updated: 2026-09-01 11:31 CDT  
 Repository: `sterlingfancher-cmyk/Trading-bot`  
 Authoritative paper runtime: Splendid / `https://web-production-e1796.up.railway.app`  
 Non-authoritative legacy state lineage: `https://trading-bot-clean.up.railway.app`  
-Current code baseline before this handoff commit: `3421829a68d898bbb413e5638372c95f78fb1177`  
-Active stability/accounting issue: none; active runtime-observability/performance issue: Issue #146
+Current code baseline before this handoff commit: `a490075a6d630dce2c866acd5216d8daeda1a67d`  
+Active stability/accounting issue: none; active runtime-observability/performance issue: Issue #146; active repair PR: #147
 
 ## Communication and Continuity
 
@@ -100,23 +100,21 @@ A fresh post-deploy retry confirmed the intended Issue #143 behavior: active `st
 
 ## Issue #146 — Required Core Status/Root Latency
 
-The same post-PR-145 authoritative retry exposed a distinct runtime-observability/performance defect that must not be hidden by Issue #143 classification logic. `/paper/status` is explicitly a required core endpoint in the self-check contract, yet both `/paper/status` and `/` exceeded the runtime research collector's 20-second read timeout on two attempts.
+The post-PR-145 authoritative retry exposed a distinct runtime-observability/performance defect. `/paper/status` is explicitly a required core endpoint in the self-check contract, yet both `/paper/status` and `/` exceeded the runtime research collector's 20-second read timeout on two attempts.
 
-At the same snapshot, independent required evidence was healthy:
-- `/bootstrap-status` returned HTTP 200 and reported ready/delegating;
-- `/paper/self-check` returned PASS with no base failures and open paper positions `NOW`, `BBAI`, and `DELL`;
-- `/paper/fresh-day-check` returned PASS with reset pending false;
-- `/paper/daily-audit` returned overall PASS;
-- active epoch remained `stable-paper-v4-20260826-successor01` with `validation_hold=true`;
-- accounting coverage was complete with zero coverage issues and zero economic issues;
-- canonical ledger remained hash-valid at 51 rows with five v4 rows;
-- runner had no active error, risk passed, and no risk/lifecycle halt was active.
+At the same snapshot, independent required evidence was healthy: bootstrap, self-check, fresh-day, daily audit, accounting coverage/economics, canonical ledger integrity, runner, and risk all passed; active epoch remained `stable-paper-v4-20260826-successor01` with `validation_hold=true`.
 
-The runtime research snapshot therefore correctly remained WARN after Issue #143 was fixed because `/paper/status` is a required core endpoint and timed out. Issue #146 now owns the bounded diagnosis/repair of `/paper/status` and root read latency. Do not solve it by suppressing the required endpoint or merely increasing the audit timeout without evidence that the timeout itself is invalid. The repair must not alter strategy, signals, sizing, hard-risk limits, canonical/accounting state, validation hold, live authority, ML authority, or order authority.
+### 2026-09-01 Root cause and PR #147
+
+Static trace on current main identified a concrete latency source. `app.py`'s `/paper/status` GET executes `save_state(portfolio)` after building the status snapshot. The active `state_journal_apply_guardrail` is already the existing owner wrapping `core.save_state`; before delegating a save it rebuilds state/journal reconciliation for the candidate state, loads persisted state, rebuilds reconciliation for disk state, then calls the original persistence path. Therefore a required read-only GET can perform journal scans, disk reads, JSON persistence/fsync work, and stale-write reconciliation. That violates the intended observability boundary and can occupy the web worker long enough for the immediately following optional root request to time out too.
+
+PR #147 (`fix/issue-146-readonly-status-persistence`) is the bounded repair. It changes the existing save-state owner rather than adding another mutation owner. Only request-scoped GET/HEAD `/paper/status` skips the redundant save and expensive stale-write reconciliation. Automatic trading cycles, repair routes, POSTs, and every non-status save continue through the unchanged stale-write guard and original persistence path. Focused regressions prove GET/HEAD status performs neither persistence nor guard scans, while non-status saves and a hypothetical status POST still delegate and execute the guard.
+
+PR #147 current head after code/tests is `07b48a718192da2cce40dcf314822feb2e962a85`; this handoff update advances that branch once more. No merge is authorized until exact-head Change Safety, Repository Safety/Performance, Architecture Debt, full ownership/config/state/runtime/startup/research audit, exact Gunicorn smoke, and focused regressions are all green. Post-deploy acceptance still requires fresh Splendid evidence that `/paper/status` is responsive and the overall runtime-research snapshot no longer WARNs for the required core endpoint.
 
 ## Current Validation Boundary
 
-There is no active canonical/accounting correctness defect. Issue #146 is an active required-core runtime observability/performance defect. Continue normal autonomous paper operation and read-only audits while the endpoint latency is diagnosed; the healthy accounting/risk evidence does not authorize weakening `/paper/status`'s required-core contract.
+There is no active canonical/accounting correctness defect. Issue #146 remains an active required-core runtime observability/performance defect with bounded repair PR #147. Continue normal autonomous paper operation and read-only audits while CI validates the repair; healthy accounting/risk evidence does not authorize weakening `/paper/status`'s required-core contract.
 
 The next governed trading-state decision remains validation-hold release for the clean v4 successor. Do not release it merely because Issue #126 is closed. Require a bounded release gate proving the configured forward-validation criteria are satisfied while preserving canonical history, risk/day-peak history, strategy, sizing, hard-risk thresholds, live authority, and ML authority.
 
@@ -124,7 +122,7 @@ No `/paper/run`, manual halt/hold release, canonical mutation, day-peak rewrite,
 
 ## Immediate Next Action
 
-Diagnose Issue #146 as a bounded read-only/status-path performance repair. Preserve `/paper/status` as a required fail-closed core endpoint. Add focused latency/regression coverage and require every standard exact-head safety/audit gate before automatic merge. After deployment, require a fresh authoritative runtime snapshot with `/paper/status` responsive and the overall research snapshot no longer WARN before closing Issue #146.
+Wait for PR #147 exact-head CI/audit evidence. If every required gate passes, squash-merge automatically; otherwise repair only the demonstrated failure without weakening required-core observability. After deployment, run fresh authoritative read-only Splendid validation and close Issue #146 only when `/paper/status` responds within the normal collector boundary and no genuine required endpoint/runtime/accounting/risk failure remains.
 
 Separately evaluate validation-hold release only from explicit clean forward-validation evidence; do not manually clear the hold.
 

--- a/state_journal_apply_guardrail.py
+++ b/state_journal_apply_guardrail.py
@@ -12,6 +12,14 @@ app state can immediately save the old open-position view back over the repaired
 file. This module now also wraps core.save_state. If an outgoing save would
 reintroduce a state/journal full-exit mismatch while the persisted file is already
 clean, the stale write is blocked and the core module is resynced from disk.
+
+2026-09-01 follow-up:
+/paper/status is a required read-only observability route, but app.py calls
+save_state() while building that GET response. The stale-write wrapper previously
+performed journal/disk reconciliation before delegating every such save, turning a
+status read into potentially expensive persistence work. The wrapper now skips only
+the redundant save initiated by GET/HEAD /paper/status while preserving all normal
+runtime persistence and stale-write protection.
 """
 from __future__ import annotations
 
@@ -22,7 +30,7 @@ import os
 import tempfile
 from typing import Any, Dict
 
-VERSION = "state-journal-apply-direct-persist-2026-05-13-memory-sync"
+VERSION = "state-journal-apply-direct-persist-2026-09-01-readonly-status"
 _PATCHED: set[int] = set()
 _CORE_SAVE_PATCHED: set[int] = set()
 _LAST_STALE_WRITE_BLOCK: Dict[str, Any] = {}
@@ -128,9 +136,6 @@ def _sync_core_state(core: Any | None, state: Dict[str, Any]) -> Dict[str, Any]:
                 synced_attrs.append(attr)
         except Exception:
             continue
-    # Some code paths may not expose a single named global. Keep a canonical
-    # repaired copy available for diagnostics and future patches without forcing
-    # app.py itself to know this module exists.
     try:
         setattr(core, "STATE_JOURNAL_REPAIRED_STATE", copy.deepcopy(state))
         setattr(core, "STATE_JOURNAL_REPAIRED_STATE_LOCAL", _now_text())
@@ -146,6 +151,20 @@ def _guard_for_state(guard_module: Any, state: Dict[str, Any]) -> Dict[str, Any]
         return guard_module.build_guard(state=state, journal=journal, core=None)
     except Exception as exc:
         return {"status": "error", "active": None, "error": repr(exc)}
+
+
+def _is_readonly_status_request() -> bool:
+    """Return True only for the required read-only /paper/status GET/HEAD route."""
+    try:
+        from flask import has_request_context, request
+
+        return bool(
+            has_request_context()
+            and request.path == "/paper/status"
+            and request.method in {"GET", "HEAD"}
+        )
+    except Exception:
+        return False
 
 
 def _install_core_stale_write_guard(core: Any | None, guard_module: Any, state_file: str) -> Dict[str, Any]:
@@ -166,6 +185,16 @@ def _install_core_stale_write_guard(core: Any | None, guard_module: Any, state_f
 
     def protected_save_state(state: Dict[str, Any], *args: Any, **kwargs: Any) -> Any:
         global _LAST_STALE_WRITE_BLOCK
+
+        # /paper/status is a GET/HEAD observability surface. app.py already builds
+        # its response from the current in-memory state and then redundantly calls
+        # save_state(). Skipping only that request-scoped persistence prevents the
+        # read path from paying journal/disk reconciliation and fsync costs. All
+        # automatic cycles, repair paths, POSTs, and non-status saves still flow
+        # through the exact stale-write guard below.
+        if _is_readonly_status_request():
+            return None
+
         if isinstance(state, dict):
             candidate_guard = _guard_for_state(guard_module, state)
             disk_state = _load_json_direct(str(state_file))
@@ -217,8 +246,6 @@ def apply(guard_module: Any, core: Any | None = None) -> Dict[str, Any]:
 
     stale_write_guard_status = _install_core_stale_write_guard(core, guard_module, str(state_file))
 
-    # Force the repair module to persist directly to /data/state.json instead of
-    # going through app/core wrappers that may hold a stale in-memory state object.
     def direct_load_state(active_core: Any | None = None) -> Dict[str, Any]:
         return _load_json_direct(str(state_file))
 
@@ -237,8 +264,6 @@ def apply(guard_module: Any, core: Any | None = None) -> Dict[str, Any]:
         pass
 
     def call_original_repair(apply_flag: bool) -> Any:
-        # Always pass core=None so repair/post-repair verification reloads the
-        # persisted file, not a potentially stale app module state.
         try:
             return original_repair(apply=apply_flag, core=None)
         except TypeError as exc:

--- a/test_issue146_readonly_status_persistence.py
+++ b/test_issue146_readonly_status_persistence.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import types
+import unittest
+
+from flask import Flask
+
+import state_journal_apply_guardrail as guardrail
+
+
+class Issue146ReadonlyStatusPersistenceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        guardrail._CORE_SAVE_PATCHED.clear()
+        guardrail._LAST_STALE_WRITE_BLOCK.clear()
+        self.app = Flask(__name__)
+        self.tmp = tempfile.TemporaryDirectory()
+        self.state_file = os.path.join(self.tmp.name, "state.json")
+        self.journal_file = os.path.join(self.tmp.name, "trade_journal.json")
+        with open(self.state_file, "w", encoding="utf-8") as handle:
+            json.dump({"cash": 10000.0, "positions": {}}, handle)
+        with open(self.journal_file, "w", encoding="utf-8") as handle:
+            json.dump([], handle)
+
+        self.save_calls = []
+        self.guard_calls = []
+
+        def original_save(state, *args, **kwargs):
+            self.save_calls.append(state)
+            return "saved"
+
+        def build_guard(*, state, journal, core=None):
+            self.guard_calls.append((state, journal, core))
+            return {"status": "ok", "active": False}
+
+        self.core = types.SimpleNamespace(save_state=original_save)
+        self.guard_module = types.SimpleNamespace(
+            TRADE_JOURNAL_FILE=self.journal_file,
+            build_guard=build_guard,
+        )
+        result = guardrail._install_core_stale_write_guard(
+            self.core, self.guard_module, self.state_file
+        )
+        self.assertEqual(result["status"], "ok")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_get_paper_status_skips_persistence_and_reconciliation(self) -> None:
+        with self.app.test_request_context("/paper/status", method="GET"):
+            result = self.core.save_state({"cash": 10000.0, "positions": {}})
+        self.assertIsNone(result)
+        self.assertEqual(self.save_calls, [])
+        self.assertEqual(self.guard_calls, [])
+
+    def test_head_paper_status_skips_persistence_and_reconciliation(self) -> None:
+        with self.app.test_request_context("/paper/status", method="HEAD"):
+            self.core.save_state({"cash": 10000.0, "positions": {}})
+        self.assertEqual(self.save_calls, [])
+        self.assertEqual(self.guard_calls, [])
+
+    def test_non_status_save_preserves_stale_write_guard_and_persistence(self) -> None:
+        state = {"cash": 10000.0, "positions": {}}
+        with self.app.test_request_context("/paper/run", method="POST"):
+            result = self.core.save_state(state)
+        self.assertEqual(result, "saved")
+        self.assertEqual(self.save_calls, [state])
+        self.assertEqual(len(self.guard_calls), 2)
+
+    def test_status_post_is_not_suppressed(self) -> None:
+        state = {"cash": 10000.0, "positions": {}}
+        with self.app.test_request_context("/paper/status", method="POST"):
+            result = self.core.save_state(state)
+        self.assertEqual(result, "saved")
+        self.assertEqual(self.save_calls, [state])
+        self.assertEqual(len(self.guard_calls), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the demonstrated `/paper/status` read-path persistence defect without changing trading/accounting authority.

Root cause: `app.py` builds `/paper/status` and then calls `save_state(portfolio)`. The active `state_journal_apply_guardrail` wraps every save with journal/disk reconciliation before delegating, so a required read-only status GET can perform expensive persistence/reconciliation work and occupy the worker long enough for the subsequent root request to time out as well.

This repair keeps the existing save-state owner and stale-write guard intact. It adds one request-scoped fast path inside that existing owner: only GET/HEAD `/paper/status` skips the redundant persistence/reconciliation. All automatic cycles, repair paths, POSTs, and non-status saves continue through the existing fail-closed stale-write guard and normal persistence.

Focused regressions prove GET/HEAD status performs no save or guard scan, while non-status saves and a hypothetical status POST still delegate and execute the guard.

No canonical ledger/state rewrite, no halt/validation-hold change, no `/paper/run`, and no strategy/signals/sizing/hard-risk/live/ML/order authority change.