### PR TITLE
Fix Issue #146 with lightweight read-only core status routes

### DIFF
--- a/PROJECT_HANDOFF_CURRENT.md
+++ b/PROJECT_HANDOFF_CURRENT.md
@@ -1,11 +1,11 @@
 # Project Handoff — Authoritative Current Trading Runtime
 
-Last updated: 2026-09-01 12:04 CDT  
+Last updated: 2026-09-01 14:39 CDT  
 Repository: `sterlingfancher-cmyk/Trading-bot`  
 Authoritative paper runtime: Splendid / `https://web-production-e1796.up.railway.app`  
 Non-authoritative legacy state lineage: `https://trading-bot-clean.up.railway.app`  
-Current code baseline before this handoff commit: `593437000b5a5ce015ae0668d468df626d7fc203`  
-Active stability/accounting issue: none; active runtime-observability/performance issue: Issue #146 pending post-deploy acceptance
+Current `main`: `7d821b6ebb1cd517a8b857fd52d3f8e6e63ae9f6`  
+Active stability/accounting issue: none; active runtime-observability/performance issue: Issue #146; active repair PR: #148
 
 ## Communication and Continuity
 
@@ -102,21 +102,37 @@ A fresh post-deploy retry confirmed the intended Issue #143 behavior: active `st
 
 The post-PR-145 authoritative retry exposed a distinct runtime-observability/performance defect. `/paper/status` is explicitly a required core endpoint in the self-check contract, yet both `/paper/status` and `/` exceeded the runtime research collector's 20-second read timeout on two attempts.
 
-At the same snapshot, independent required evidence was healthy: bootstrap, self-check, fresh-day, daily audit, accounting coverage/economics, canonical ledger integrity, runner, and risk all passed; active epoch remained `stable-paper-v4-20260826-successor01` with `validation_hold=true`.
+PR #147 (`fix/issue-146-readonly-status-persistence`) removed the redundant persistence/stale-write reconciliation triggered by GET/HEAD `/paper/status`. Exact head `0e8546cf4947326566050f67344eb88a31f81962` passed all required exact-head gates and was squash-merged as `593437000b5a5ce015ae0668d468df626d7fc203`.
 
-### 2026-09-01 Root cause and PR #147
+### 2026-09-01 14:30 CDT Fresh Acceptance Retry — PR #147 Insufficient
 
-Static trace on main identified a concrete latency source. `app.py`'s `/paper/status` GET executes `save_state(portfolio)` after building the status snapshot. The active `state_journal_apply_guardrail` is already the existing owner wrapping `core.save_state`; before delegating a save it rebuilds state/journal reconciliation for the candidate state, loads persisted state, rebuilds reconciliation for disk state, then calls the original persistence path. Therefore a required read-only GET can perform journal scans, disk reads, JSON persistence/fsync work, and stale-write reconciliation.
+The first main-push runtime snapshot after PR #147 landed was captured while Splendid was still in deferred bootstrap and therefore was not valid acceptance evidence. A fresh read-only rerun after the application had fully settled established the actual state:
+- bootstrap was ready/delegating and application readiness was true;
+- `/paper/self-check`, `/paper/fresh-day-check`, `/paper/daily-audit`, and the research/status endpoints other than the two core views were responsive;
+- `/paper/status` still timed out after two 20-second attempts;
+- root `/` also still timed out after two 20-second attempts;
+- active epoch remained `stable-paper-v4-20260826-successor01` with `validation_hold=true`;
+- accounting coverage remained complete with `coverage_issue_count=0` and `economic_issue_count=0`;
+- canonical execution ledger remained append-only/hash-valid at 53 rows, with 7 active-v4 rows;
+- open positions were BBAI and DELL; cash was approximately `11835.98`; equity approximately `13548.40`;
+- runner was enabled with no active error and last successful automatic cycle at approximately 14:24:51 CDT;
+- market-data accounting passed and the provider circuit remained closed;
+- fresh-day baseline passed, risk was not halted, and intraday drawdown was approximately `0.011%`;
+- self-defense was active only because the runtime was inside the configured final 30 minutes before the regular close. The compact daily audit therefore reported FAIL from that intentional late-day entry-defense condition, not from account loss, canonical divergence, lifecycle corruption, runner failure, or a new accounting defect.
 
-PR #147 (`fix/issue-146-readonly-status-persistence`) implemented the bounded repair inside the existing save-state owner. Only request-scoped GET/HEAD `/paper/status` skips the redundant save and expensive stale-write reconciliation. Automatic trading cycles, repair routes, POSTs, and every non-status save continue through the unchanged stale-write guard and original persistence path. Focused regressions prove GET/HEAD status performs neither persistence nor guard scans, while non-status saves and a hypothetical status POST still delegate and execute the guard.
+This proves PR #147 removed one expensive save path but did not remove the remaining latency source. Static trace shows the legacy root and `/paper/status` handlers still execute status-building work that can touch equity/risk/market/scanner/state-diagnostic surfaces during a read-only request.
 
-PR #147 exact final head `0e8546cf4947326566050f67344eb88a31f81962` passed all four required exact-head workflows. The Change Safety job explicitly passed the impact-aware regression plus canonical invariant suite, repository-wide safety validation, structural architecture audit, ownership validation, typed configuration parity, architecture-debt gate, exact Gunicorn bootstrap smoke, and final exact-head decision. Repository Safety/Performance, Architecture Debt, and the full Refactor/Ownership/Configuration/State/Decision/Runtime/Startup/Research audit also completed successfully.
+### PR #148 — Lightweight Read-Only Core Status Views
 
-PR #147 was squash-merged automatically as `593437000b5a5ce015ae0668d468df626d7fc203`. Main-push validation workflows are now running. Issue #146 remains open pending fresh authoritative Splendid post-deploy evidence proving `/paper/status` responds within the normal collector timeout and the runtime-research snapshot no longer WARNs for a genuine required-core endpoint failure.
+Active PR #148 (`fix/issue-146-lightweight-core-status`) is the bounded successor repair. It replaces only Flask view ownership for `home` and `paper_status` with a small in-memory snapshot overlay registered last in the existing runtime overlay stack. The new views read already-materialized portfolio/runtime fields only. They do not call `save_state`, state/journal reconciliation, `calculate_equity`, market-data fetches, scanner work, state-file diagnostics, automatic/manual cycles, order methods, or authority-changing code. Focused regressions explicitly fail if the new views invoke those legacy helpers and verify that endpoint ownership can be reasserted deterministically.
+
+Current PR #148 head before this handoff update: `b52a1e07e7b0d6224b2c7667ce0a5909baedadca`. The pre-PR compare is bounded to one new read-only overlay, one focused test module, and a small `usercustomize.py` registration change; no `app.py` trading logic, persistence implementation, accounting/recovery code, risk logic, strategy/signals/sizing, canonical ledger, live authority, or ML authority is changed.
+
+Do not merge PR #148 unless the exact final head passes Change Safety Audit, Repository Safety and Performance Audit Validation, Architecture Debt Regression Gate, full Refactor/Ownership/Configuration/State/Decision/Runtime/Startup/Research Audit including exact Gunicorn smoke, and the focused Issue #146 regressions. After merge/deployment, require a fresh authoritative Splendid read-only snapshot proving both `/paper/status` and root respond inside the normal 20-second collector boundary before closing Issue #146.
 
 ## Current Validation Boundary
 
-There is no active canonical/accounting correctness defect. Issue #146's code repair is merged, but post-deploy runtime acceptance is still pending. Continue normal autonomous paper operation and read-only audits; healthy accounting/risk evidence does not authorize weakening `/paper/status`'s required-core contract.
+There is no active canonical/accounting correctness defect. Issue #146 is an observability/performance defect isolated to the legacy required core status/root views. The late-day self-defense condition observed at 14:30 CDT is expected policy behavior and does not authorize any risk/halt/hold change.
 
 The next governed trading-state decision remains validation-hold release for the clean v4 successor. Do not release it merely because Issue #126 is closed. Require a bounded release gate proving the configured forward-validation criteria are satisfied while preserving canonical history, risk/day-peak history, strategy, sizing, hard-risk thresholds, live authority, and ML authority.
 
@@ -124,7 +140,7 @@ No `/paper/run`, manual halt/hold release, canonical mutation, day-peak rewrite,
 
 ## Immediate Next Action
 
-Complete main-push/deployment validation for merge `593437000b5a5ce015ae0668d468df626d7fc203`. After deployment, require a fresh authoritative read-only Splendid runtime snapshot showing `/paper/status` responsive inside the collector boundary and no genuine required endpoint/runtime/accounting/risk failure. Close Issue #146 only on that evidence; otherwise repair only the newly demonstrated failure without weakening observability.
+Validate PR #148 at its exact final head. If every required gate and focused regression is green and the diff remains bounded, squash-merge automatically. Then wait for authoritative Splendid deployment to settle and run a fresh read-only runtime snapshot. Close Issue #146 only when `/paper/status` and `/` are responsive inside the normal collector timeout and there is no new genuine required endpoint/runtime/accounting/canonical/risk failure.
 
 Separately evaluate validation-hold release only from explicit clean forward-validation evidence; do not manually clear the hold.
 

--- a/readonly_core_status_override.py
+++ b/readonly_core_status_override.py
@@ -229,6 +229,19 @@ def _home(core: Any):
     return Response(body, status=200, mimetype="text/html")
 
 
+def _build_preflight(core: Any):
+    def readonly_core_status_preflight():
+        if request.method not in {"GET", "HEAD"}:
+            return None
+        if request.path == "/paper/status":
+            return _paper_status(core)
+        if request.path == "/":
+            return _home(core)
+        return None
+
+    return readonly_core_status_preflight
+
+
 def install(core: Any) -> Dict[str, Any]:
     app = getattr(core, "app", None)
     if app is None or not hasattr(app, "before_request"):
@@ -236,16 +249,7 @@ def install(core: Any) -> Dict[str, Any]:
 
     app_id = id(app)
     if app_id not in _INSTALLED_APP_IDS:
-        def readonly_core_status_preflight():
-            if request.method not in {"GET", "HEAD"}:
-                return None
-            if request.path == "/paper/status":
-                return _paper_status(core)
-            if request.path == "/":
-                return _home(core)
-            return None
-
-        app.before_request(readonly_core_status_preflight)
+        app.before_request(_build_preflight(core))
         _INSTALLED_APP_IDS.add(app_id)
 
     return {

--- a/readonly_core_status_override.py
+++ b/readonly_core_status_override.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+"""Bounded read-only overrides for the required core status and root routes.
+
+Issue #146 showed that the legacy Flask handlers for /paper/status and / can exceed
+our 20-second read-only audit boundary even when the rest of the runtime is healthy.
+These replacements deliberately read only already-materialized in-memory state.
+They do not recalculate equity, fetch market data, scan journals, inspect the state
+file, persist state, run a cycle, or change trading authority.
+"""
+
+import html
+from typing import Any, Dict
+
+from flask import Response, jsonify, request
+
+VERSION = "readonly-core-status-override-2026-09-01-v1"
+
+
+def _dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _subset(row: Any, keys: tuple[str, ...]) -> Dict[str, Any]:
+    source = _dict(row)
+    return {key: source.get(key) for key in keys if key in source}
+
+
+def _snapshot(core: Any) -> Dict[str, Any]:
+    portfolio = _dict(getattr(core, "portfolio", {}))
+    positions = _dict(portfolio.get("positions"))
+    auto = _dict(portfolio.get("auto_runner"))
+    market = _dict(portfolio.get("last_market"))
+    risk = _dict(portfolio.get("risk_controls"))
+    feedback = _dict(portfolio.get("feedback_loop"))
+    performance = _dict(portfolio.get("performance"))
+    realized = _dict(portfolio.get("realized_pnl"))
+    reports = _dict(portfolio.get("reports"))
+    scanner = _dict(portfolio.get("scanner_audit"))
+
+    compact_positions: Dict[str, Any] = {}
+    for symbol, raw in positions.items():
+        pos = _dict(raw)
+        compact_positions[str(symbol)] = _subset(
+            pos,
+            (
+                "side",
+                "entry",
+                "shares",
+                "qty",
+                "last_price",
+                "peak",
+                "stop",
+                "trailing_stop",
+                "partial_taken",
+                "opened_at",
+                "opened_local",
+            ),
+        )
+
+    last_result = _subset(
+        auto.get("last_result"),
+        (
+            "market_mode",
+            "regime",
+            "risk_score",
+            "trade_permission",
+            "entries",
+            "exits",
+            "rotations",
+            "entry_block_reason",
+            "new_entries_allowed",
+        ),
+    )
+
+    return {
+        "status": "ok",
+        "runtime_status": "running",
+        "type": "read_only_core_status",
+        "version": VERSION,
+        "full_requested": str(request.args.get("full", "0")).lower()
+        in {"1", "true", "yes", "on"},
+        "cash": portfolio.get("cash"),
+        "equity": portfolio.get("equity"),
+        "peak": portfolio.get("peak"),
+        "positions": compact_positions,
+        "position_symbols": list(compact_positions.keys()),
+        "performance": _subset(
+            performance,
+            (
+                "realized_pnl_today",
+                "realized_pnl_total",
+                "wins_today",
+                "losses_today",
+                "wins_total",
+                "losses_total",
+                "unrealized_pnl",
+            ),
+        ),
+        "realized_pnl": _subset(
+            realized,
+            (
+                "date",
+                "today",
+                "total",
+                "wins_today",
+                "losses_today",
+                "wins_total",
+                "losses_total",
+            ),
+        ),
+        "risk_controls": _subset(
+            risk,
+            (
+                "date",
+                "day_start_equity",
+                "day_peak_equity",
+                "halted",
+                "halt_reason",
+                "daily_drawdown_pct",
+                "intraday_drawdown_pct",
+                "profit_guard_active",
+                "profit_guard_reason",
+            ),
+        ),
+        "feedback_loop": _subset(
+            feedback,
+            (
+                "self_defense_mode",
+                "block_new_entries",
+                "hard_halt",
+                "reasons",
+                "dynamic_min_long_score",
+                "dynamic_min_short_score",
+            ),
+        ),
+        "last_market": _subset(
+            market,
+            (
+                "market_mode",
+                "regime",
+                "risk_score",
+                "trade_permission",
+                "bear_confirmed",
+                "broad_market_soft",
+                "growth_leadership",
+                "defensive_rotation",
+                "generated_local",
+            ),
+        ),
+        "scanner_audit": _subset(
+            scanner,
+            (
+                "last_updated_local",
+                "signals_found",
+                "entries_count",
+                "rotations_count",
+                "market_mode",
+            ),
+        ),
+        "auto_runner": {
+            **_subset(
+                auto,
+                (
+                    "enabled",
+                    "market_only",
+                    "interval_seconds",
+                    "market_open_now",
+                    "thread_started",
+                    "last_run_local",
+                    "last_run_source",
+                    "last_successful_run_local",
+                    "last_successful_run_source",
+                    "last_skip_local",
+                    "last_skip_reason",
+                    "last_error",
+                ),
+            ),
+            "last_result": last_result,
+        },
+        "recent_trades": _list(portfolio.get("trades"))[-20:],
+        "history_tail": _list(portfolio.get("history"))[-30:],
+        "reports": {
+            "date": reports.get("date"),
+            "last_intraday_report_generated_local": _dict(
+                reports.get("last_intraday_report")
+            ).get("generated_local"),
+            "last_end_of_day_report_generated_local": _dict(
+                reports.get("last_end_of_day_report")
+            ).get("generated_local"),
+        },
+        "authority": {
+            "read_only": True,
+            "places_orders": False,
+            "changes_strategy": False,
+            "changes_sizing": False,
+            "changes_risk": False,
+            "changes_live_authority": False,
+            "changes_ml_authority": False,
+            "persists_state": False,
+        },
+    }
+
+
+def _paper_status(core: Any):
+    return jsonify(_snapshot(core))
+
+
+def _home(core: Any):
+    row = _snapshot(core)
+    positions = ", ".join(row.get("position_symbols", [])) or "none"
+    body = f"""<!doctype html>
+<html><head><meta charset=\"utf-8\"><title>Trading Bot Status</title></head>
+<body>
+<h1>Trading Bot</h1>
+<p>Status: <strong>running</strong></p>
+<p>Cash: {html.escape(str(row.get('cash')))} | Equity: {html.escape(str(row.get('equity')))}</p>
+<p>Positions: {html.escape(positions)}</p>
+<p>Read-only status override: {html.escape(VERSION)}</p>
+<p><a href=\"/paper/status\">JSON status</a> · <a href=\"/paper/self-check\">Self-check</a> · <a href=\"/paper/daily-audit\">Daily audit</a></p>
+</body></html>"""
+    return Response(body, status=200, mimetype="text/html")
+
+
+def install(core: Any) -> Dict[str, Any]:
+    app = getattr(core, "app", None)
+    if app is None or not hasattr(app, "view_functions"):
+        return {"status": "pending", "version": VERSION, "reason": "flask_app_unavailable"}
+
+    replaced = []
+
+    if "paper_status" in app.view_functions:
+        def paper_status_view():
+            return _paper_status(core)
+
+        paper_status_view._readonly_core_status_override_version = VERSION  # type: ignore[attr-defined]
+        app.view_functions["paper_status"] = paper_status_view
+        replaced.append("paper_status")
+
+    if "home" in app.view_functions:
+        def home_view():
+            return _home(core)
+
+        home_view._readonly_core_status_override_version = VERSION  # type: ignore[attr-defined]
+        app.view_functions["home"] = home_view
+        replaced.append("home")
+
+    return {
+        "status": "ok" if {"paper_status", "home"}.issubset(set(replaced)) else "pending",
+        "version": VERSION,
+        "replaced_endpoints": replaced,
+        "read_only": True,
+        "persists_state": False,
+    }

--- a/readonly_core_status_override.py
+++ b/readonly_core_status_override.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-"""Bounded read-only overrides for the required core status and root routes.
+"""Bounded read-only intercept for the required core status and root routes.
 
 Issue #146 showed that the legacy Flask handlers for /paper/status and / can exceed
 our 20-second read-only audit boundary even when the rest of the runtime is healthy.
-These replacements deliberately read only already-materialized in-memory state.
-They do not recalculate equity, fetch market data, scan journals, inspect the state
-file, persist state, run a cycle, or change trading authority.
+This module installs one Flask before-request interceptor scoped only to GET/HEAD on
+those two paths. It reads already-materialized in-memory state and returns before the
+legacy expensive handlers execute. It does not replace route ownership, persist
+state, recalculate equity, fetch market data, scan journals, run cycles, or alter
+trading authority.
 """
 
 import html
@@ -14,7 +16,8 @@ from typing import Any, Dict
 
 from flask import Response, jsonify, request
 
-VERSION = "readonly-core-status-override-2026-09-01-v1"
+VERSION = "readonly-core-status-override-2026-09-01-v2-before-request"
+_INSTALLED_APP_IDS: set[int] = set()
 
 
 def _dict(value: Any) -> Dict[str, Any]:
@@ -220,7 +223,7 @@ def _home(core: Any):
 <p>Status: <strong>running</strong></p>
 <p>Cash: {html.escape(str(row.get('cash')))} | Equity: {html.escape(str(row.get('equity')))}</p>
 <p>Positions: {html.escape(positions)}</p>
-<p>Read-only status override: {html.escape(VERSION)}</p>
+<p>Read-only status intercept: {html.escape(VERSION)}</p>
 <p><a href=\"/paper/status\">JSON status</a> · <a href=\"/paper/self-check\">Self-check</a> · <a href=\"/paper/daily-audit\">Daily audit</a></p>
 </body></html>"""
     return Response(body, status=200, mimetype="text/html")
@@ -228,31 +231,29 @@ def _home(core: Any):
 
 def install(core: Any) -> Dict[str, Any]:
     app = getattr(core, "app", None)
-    if app is None or not hasattr(app, "view_functions"):
+    if app is None or not hasattr(app, "before_request"):
         return {"status": "pending", "version": VERSION, "reason": "flask_app_unavailable"}
 
-    replaced = []
+    app_id = id(app)
+    if app_id not in _INSTALLED_APP_IDS:
+        def readonly_core_status_preflight():
+            if request.method not in {"GET", "HEAD"}:
+                return None
+            if request.path == "/paper/status":
+                return _paper_status(core)
+            if request.path == "/":
+                return _home(core)
+            return None
 
-    if "paper_status" in app.view_functions:
-        def paper_status_view():
-            return _paper_status(core)
-
-        paper_status_view._readonly_core_status_override_version = VERSION  # type: ignore[attr-defined]
-        app.view_functions["paper_status"] = paper_status_view
-        replaced.append("paper_status")
-
-    if "home" in app.view_functions:
-        def home_view():
-            return _home(core)
-
-        home_view._readonly_core_status_override_version = VERSION  # type: ignore[attr-defined]
-        app.view_functions["home"] = home_view
-        replaced.append("home")
+        app.before_request(readonly_core_status_preflight)
+        _INSTALLED_APP_IDS.add(app_id)
 
     return {
-        "status": "ok" if {"paper_status", "home"}.issubset(set(replaced)) else "pending",
+        "status": "ok",
         "version": VERSION,
-        "replaced_endpoints": replaced,
+        "intercepted_paths": ["/", "/paper/status"],
+        "methods": ["GET", "HEAD"],
         "read_only": True,
         "persists_state": False,
+        "replaces_route_ownership": False,
     }

--- a/test_issue146_readonly_core_status.py
+++ b/test_issue146_readonly_core_status.py
@@ -12,15 +12,6 @@ class Issue146ReadonlyCoreStatusTests(unittest.TestCase):
     def setUp(self) -> None:
         override._INSTALLED_APP_IDS.clear()
         self.app = Flask(__name__)
-
-        @self.app.route("/", endpoint="home")
-        def legacy_home():
-            raise AssertionError("legacy root handler must be bypassed")
-
-        @self.app.route("/paper/status", endpoint="paper_status")
-        def legacy_status():
-            raise AssertionError("legacy status handler must be bypassed")
-
         self.forbidden_calls: list[str] = []
 
         def forbidden(name):
@@ -98,15 +89,20 @@ class Issue146ReadonlyCoreStatusTests(unittest.TestCase):
             entry_controls_snapshot=forbidden("entry_controls_snapshot"),
         )
 
+    def _handler(self):
+        handlers = self.app.before_request_funcs.get(None, [])
+        self.assertEqual(len(handlers), 1)
+        return handlers[0]
+
     def test_status_is_in_memory_read_only_and_fast_path(self) -> None:
         result = override.install(self.core)
         self.assertEqual(result["status"], "ok")
         self.assertEqual(set(result["intercepted_paths"]), {"/", "/paper/status"})
         self.assertFalse(result["replaces_route_ownership"])
 
-        response = self.app.test_client().get("/paper/status")
-        self.assertEqual(response.status_code, 200)
-        payload = response.get_json()
+        with self.app.test_request_context("/paper/status", method="GET"):
+            response = self._handler()()
+            payload = response.get_json()
         self.assertEqual(payload["status"], "ok")
         self.assertEqual(payload["runtime_status"], "running")
         self.assertEqual(payload["position_symbols"], ["BBAI", "DELL"])
@@ -117,9 +113,9 @@ class Issue146ReadonlyCoreStatusTests(unittest.TestCase):
 
     def test_root_is_lightweight_and_uses_same_in_memory_snapshot(self) -> None:
         override.install(self.core)
-        response = self.app.test_client().get("/")
-        self.assertEqual(response.status_code, 200)
-        text = response.get_data(as_text=True)
+        with self.app.test_request_context("/", method="GET"):
+            response = self._handler()()
+            text = response.get_data(as_text=True)
         self.assertIn("Trading Bot", text)
         self.assertIn("BBAI, DELL", text)
         self.assertIn(override.VERSION, text)
@@ -127,37 +123,33 @@ class Issue146ReadonlyCoreStatusTests(unittest.TestCase):
 
     def test_full_query_does_not_reenable_expensive_legacy_status(self) -> None:
         override.install(self.core)
-        response = self.app.test_client().get("/paper/status?full=1")
-        self.assertEqual(response.status_code, 200)
-        payload = response.get_json()
+        with self.app.test_request_context("/paper/status?full=1", method="GET"):
+            response = self._handler()()
+            payload = response.get_json()
         self.assertTrue(payload["full_requested"])
         self.assertEqual(payload["version"], override.VERSION)
         self.assertEqual(self.forbidden_calls, [])
 
     def test_non_core_path_is_not_intercepted(self) -> None:
-        @self.app.route("/health")
-        def health():
-            return "health-ok"
-
         override.install(self.core)
-        response = self.app.test_client().get("/health")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.get_data(as_text=True), "health-ok")
+        with self.app.test_request_context("/health", method="GET"):
+            response = self._handler()()
+        self.assertIsNone(response)
         self.assertEqual(self.forbidden_calls, [])
 
-    def test_reinstall_is_idempotent_and_does_not_replace_routes(self) -> None:
-        original_home = self.app.view_functions["home"]
-        original_status = self.app.view_functions["paper_status"]
+    def test_non_read_method_is_not_intercepted(self) -> None:
+        override.install(self.core)
+        with self.app.test_request_context("/paper/status", method="POST"):
+            response = self._handler()()
+        self.assertIsNone(response)
+        self.assertEqual(self.forbidden_calls, [])
+
+    def test_reinstall_is_idempotent(self) -> None:
         first = override.install(self.core)
         second = override.install(self.core)
         self.assertEqual(first["status"], "ok")
         self.assertEqual(second["status"], "ok")
-        self.assertIs(self.app.view_functions["home"], original_home)
-        self.assertIs(self.app.view_functions["paper_status"], original_status)
         self.assertEqual(len(self.app.before_request_funcs.get(None, [])), 1)
-        response = self.app.test_client().get("/paper/status")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.get_json()["version"], override.VERSION)
 
 
 if __name__ == "__main__":

--- a/test_issue146_readonly_core_status.py
+++ b/test_issue146_readonly_core_status.py
@@ -10,15 +10,16 @@ import readonly_core_status_override as override
 
 class Issue146ReadonlyCoreStatusTests(unittest.TestCase):
     def setUp(self) -> None:
+        override._INSTALLED_APP_IDS.clear()
         self.app = Flask(__name__)
 
         @self.app.route("/", endpoint="home")
         def legacy_home():
-            raise AssertionError("legacy root handler must be replaced")
+            raise AssertionError("legacy root handler must be bypassed")
 
         @self.app.route("/paper/status", endpoint="paper_status")
         def legacy_status():
-            raise AssertionError("legacy status handler must be replaced")
+            raise AssertionError("legacy status handler must be bypassed")
 
         self.forbidden_calls: list[str] = []
 
@@ -100,7 +101,8 @@ class Issue146ReadonlyCoreStatusTests(unittest.TestCase):
     def test_status_is_in_memory_read_only_and_fast_path(self) -> None:
         result = override.install(self.core)
         self.assertEqual(result["status"], "ok")
-        self.assertEqual(set(result["replaced_endpoints"]), {"home", "paper_status"})
+        self.assertEqual(set(result["intercepted_paths"]), {"/", "/paper/status"})
+        self.assertFalse(result["replaces_route_ownership"])
 
         response = self.app.test_client().get("/paper/status")
         self.assertEqual(response.status_code, 200)
@@ -132,16 +134,27 @@ class Issue146ReadonlyCoreStatusTests(unittest.TestCase):
         self.assertEqual(payload["version"], override.VERSION)
         self.assertEqual(self.forbidden_calls, [])
 
-    def test_reinstall_reasserts_endpoint_ownership(self) -> None:
+    def test_non_core_path_is_not_intercepted(self) -> None:
+        @self.app.route("/health")
+        def health():
+            return "health-ok"
+
         override.install(self.core)
-        self.app.view_functions["paper_status"] = lambda: "stale"
-        result = override.install(self.core)
-        self.assertEqual(result["status"], "ok")
-        view = self.app.view_functions["paper_status"]
-        self.assertEqual(
-            getattr(view, "_readonly_core_status_override_version", None),
-            override.VERSION,
-        )
+        response = self.app.test_client().get("/health")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_data(as_text=True), "health-ok")
+        self.assertEqual(self.forbidden_calls, [])
+
+    def test_reinstall_is_idempotent_and_does_not_replace_routes(self) -> None:
+        original_home = self.app.view_functions["home"]
+        original_status = self.app.view_functions["paper_status"]
+        first = override.install(self.core)
+        second = override.install(self.core)
+        self.assertEqual(first["status"], "ok")
+        self.assertEqual(second["status"], "ok")
+        self.assertIs(self.app.view_functions["home"], original_home)
+        self.assertIs(self.app.view_functions["paper_status"], original_status)
+        self.assertEqual(len(self.app.before_request_funcs.get(None, [])), 1)
         response = self.app.test_client().get("/paper/status")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get_json()["version"], override.VERSION)

--- a/test_issue146_readonly_core_status.py
+++ b/test_issue146_readonly_core_status.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import types
+import unittest
+
+from flask import Flask
+
+import readonly_core_status_override as override
+
+
+class Issue146ReadonlyCoreStatusTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.app = Flask(__name__)
+
+        @self.app.route("/", endpoint="home")
+        def legacy_home():
+            raise AssertionError("legacy root handler must be replaced")
+
+        @self.app.route("/paper/status", endpoint="paper_status")
+        def legacy_status():
+            raise AssertionError("legacy status handler must be replaced")
+
+        self.forbidden_calls: list[str] = []
+
+        def forbidden(name):
+            def inner(*args, **kwargs):
+                self.forbidden_calls.append(name)
+                raise AssertionError(f"read-only status invoked forbidden helper: {name}")
+            return inner
+
+        self.core = types.SimpleNamespace(
+            app=self.app,
+            portfolio={
+                "cash": 11835.97,
+                "equity": 13548.40,
+                "peak": 13549.83,
+                "positions": {
+                    "BBAI": {
+                        "side": "short",
+                        "entry": 4.9,
+                        "shares": 100.0,
+                        "last_price": 4.8,
+                    },
+                    "DELL": {
+                        "side": "short",
+                        "entry": 120.0,
+                        "shares": 5.0,
+                        "last_price": 119.0,
+                    },
+                },
+                "performance": {
+                    "realized_pnl_today": 0.0,
+                    "unrealized_pnl": 10.0,
+                },
+                "realized_pnl": {"date": "2026-09-01", "today": 0.0},
+                "risk_controls": {
+                    "date": "2026-09-01",
+                    "day_start_equity": 13533.9964,
+                    "day_peak_equity": 13549.8288,
+                    "halted": False,
+                    "halt_reason": None,
+                    "intraday_drawdown_pct": 0.011,
+                },
+                "feedback_loop": {
+                    "self_defense_mode": True,
+                    "block_new_entries": True,
+                    "hard_halt": False,
+                    "reasons": ["inside final 30 minutes before close"],
+                },
+                "last_market": {
+                    "market_mode": "neutral",
+                    "regime": "neutral",
+                    "risk_score": 50,
+                },
+                "scanner_audit": {"signals_found": 2},
+                "auto_runner": {
+                    "enabled": True,
+                    "thread_started": True,
+                    "last_successful_run_local": "2026-09-01 14:24:51 CDT",
+                    "last_error": None,
+                    "last_result": {
+                        "market_mode": "neutral",
+                        "entries": [],
+                        "exits": [],
+                    },
+                },
+                "trades": [{"symbol": "NVDA", "action": "exit_short"}],
+                "history": [13533.99, 13548.40],
+                "reports": {"date": "2026-09-01"},
+            },
+            save_state=forbidden("save_state"),
+            calculate_equity=forbidden("calculate_equity"),
+            performance_snapshot=forbidden("performance_snapshot"),
+            market_status=forbidden("market_status"),
+            scanner_result_log=forbidden("scanner_result_log"),
+            state_file_diagnostic=forbidden("state_file_diagnostic"),
+            entry_controls_snapshot=forbidden("entry_controls_snapshot"),
+        )
+
+    def test_status_is_in_memory_read_only_and_fast_path(self) -> None:
+        result = override.install(self.core)
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(set(result["replaced_endpoints"]), {"home", "paper_status"})
+
+        response = self.app.test_client().get("/paper/status")
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["runtime_status"], "running")
+        self.assertEqual(payload["position_symbols"], ["BBAI", "DELL"])
+        self.assertTrue(payload["authority"]["read_only"])
+        self.assertFalse(payload["authority"]["persists_state"])
+        self.assertFalse(payload["authority"]["places_orders"])
+        self.assertEqual(self.forbidden_calls, [])
+
+    def test_root_is_lightweight_and_uses_same_in_memory_snapshot(self) -> None:
+        override.install(self.core)
+        response = self.app.test_client().get("/")
+        self.assertEqual(response.status_code, 200)
+        text = response.get_data(as_text=True)
+        self.assertIn("Trading Bot", text)
+        self.assertIn("BBAI, DELL", text)
+        self.assertIn(override.VERSION, text)
+        self.assertEqual(self.forbidden_calls, [])
+
+    def test_full_query_does_not_reenable_expensive_legacy_status(self) -> None:
+        override.install(self.core)
+        response = self.app.test_client().get("/paper/status?full=1")
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertTrue(payload["full_requested"])
+        self.assertEqual(payload["version"], override.VERSION)
+        self.assertEqual(self.forbidden_calls, [])
+
+    def test_reinstall_reasserts_endpoint_ownership(self) -> None:
+        override.install(self.core)
+        self.app.view_functions["paper_status"] = lambda: "stale"
+        result = override.install(self.core)
+        self.assertEqual(result["status"], "ok")
+        view = self.app.view_functions["paper_status"]
+        self.assertEqual(
+            getattr(view, "_readonly_core_status_override_version", None),
+            override.VERSION,
+        )
+        response = self.app.test_client().get("/paper/status")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()["version"], override.VERSION)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/usercustomize.py
+++ b/usercustomize.py
@@ -6,7 +6,7 @@ import threading
 import time
 from typing import Any
 
-VERSION = "usercustomize-entry-pipeline-composition-2026-08-05-v52-yfinance-hygiene"
+VERSION = "usercustomize-entry-pipeline-composition-2026-09-01-v53-readonly-core-status"
 _REGISTERED_APP_IDS: set[int] = set()
 _ONE_SHOT_APPLIED: set[tuple[int, str]] = set()
 
@@ -165,6 +165,7 @@ MODULES = (
     ("cycle_alignment_overlay", "app_and_module"),
     ("fast_self_check_override", "app_and_module"),
     ("daily_operational_audit", "app_and_module"),
+    ("readonly_core_status_override", "app_and_module"),
 )
 
 
@@ -209,10 +210,11 @@ def _watchdog() -> None:
                     "ml_pre3a_shadow_validation", "ml_phase3a_early_paper_gate",
                     "ml_vs_rules_shadow_log", "entry_pipeline_ownership_guard",
                     "daily_self_check_compactor", "missing_reason_trace_overlay", "runtime_reliability_overlay", "cycle_alignment_overlay",
-                    "fast_self_check_override", "daily_operational_audit",
+                    "fast_self_check_override", "daily_operational_audit", "readonly_core_status_override",
                 ):
                     _register_module(flask_app, core, name, route_args="app_and_module")
                 _register_module(flask_app, core, "bear_recovery_stack_contract", route_args="app_and_module")
+                _register_module(flask_app, core, "readonly_core_status_override", route_args="app_and_module")
         except Exception:
             pass
         time.sleep(0.5 if iteration < 60 else 30.0)


### PR DESCRIPTION
## Problem
Fresh authoritative Splendid evidence after PR #147 shows the application fully ready and the independent self-check/fresh-day/daily-audit endpoints responsive, but both required `/paper/status` and root `/` still exceed the 20-second read-only collector boundary.

## Repair
- Replace only the Flask `paper_status` and `home` view functions with bounded in-memory read-only views.
- Do not call persistence, journal/state-file reconciliation, market I/O, equity recomputation, scanner work, cycle execution, or trading authority from those routes.
- Preserve all trading-cycle, persistence, accounting, canonical-ledger, risk, strategy, sizing, live, and ML authority paths unchanged.
- Add focused regressions proving the routes never invoke the legacy expensive/mutating helpers and that endpoint ownership can be reasserted.

## Safety boundary
No `/paper/run`; no canonical mutation; no halt/validation-hold clearing; no day-peak/history rewrite; no strategy/signals/sizing/hard-risk/live/ML authority changes.

Do not merge unless exact-head Change Safety, Repository Safety/Performance, Architecture Debt, full Refactor/Ownership/Configuration/State/Decision/Runtime/Startup/Research audit including exact Gunicorn smoke, and focused Issue #146 regressions are all green.