### PR TITLE
Finish Issue #146 root JSON negotiation

### DIFF
--- a/readonly_core_status_override.py
+++ b/readonly_core_status_override.py
@@ -16,7 +16,7 @@ from typing import Any, Dict
 
 from flask import Response, jsonify, request
 
-VERSION = "readonly-core-status-override-2026-09-01-v2-before-request"
+VERSION = "readonly-core-status-override-2026-09-01-v3-root-json-negotiation"
 _INSTALLED_APP_IDS: set[int] = set()
 
 
@@ -215,6 +215,8 @@ def _paper_status(core: Any):
 
 def _home(core: Any):
     row = _snapshot(core)
+    if request.accept_mimetypes.best == "application/json":
+        return jsonify(row)
     positions = ", ".join(row.get("position_symbols", [])) or "none"
     body = f"""<!doctype html>
 <html><head><meta charset=\"utf-8\"><title>Trading Bot Status</title></head>

--- a/test_issue146_readonly_core_status.py
+++ b/test_issue146_readonly_core_status.py
@@ -121,6 +121,19 @@ class Issue146ReadonlyCoreStatusTests(unittest.TestCase):
         self.assertIn(override.VERSION, text)
         self.assertEqual(self.forbidden_calls, [])
 
+    def test_root_returns_json_for_collector_accept_header(self) -> None:
+        override.install(self.core)
+        with self.app.test_request_context(
+            "/", method="GET", headers={"Accept": "application/json"}
+        ):
+            response = self._handler()()
+            payload = response.get_json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["runtime_status"], "running")
+        self.assertEqual(payload["position_symbols"], ["BBAI", "DELL"])
+        self.assertTrue(payload["authority"]["read_only"])
+        self.assertEqual(self.forbidden_calls, [])
+
     def test_full_query_does_not_reenable_expensive_legacy_status(self) -> None:
         override.install(self.core)
         with self.app.test_request_context("/paper/status?full=1", method="GET"):


### PR DESCRIPTION
Fresh authoritative Splendid post-PR-148 evidence proves `/paper/status` is fixed and responds in ~0.2s, while root `/` now returns the intended lightweight HTML. `runtime_research_snapshot.py` requests root with `Accept: application/json` and therefore raises JSONDecodeError on the HTML response, producing a false required-root failure during the late-day self-defense window.

This PR is intentionally surgical:
- preserve lightweight HTML root for normal browser requests;
- return the same bounded in-memory JSON snapshot when the client explicitly prefers `application/json`;
- add a focused regression for the collector Accept header;
- no persistence, accounting, canonical-ledger, risk, strategy, sizing, live, ML, order, or state-authority changes.

Do not merge unless exact-head Change Safety Audit, Repository Safety and Performance Audit Validation, Architecture Debt Regression Gate, full Refactor/Ownership/Configuration/State/Decision/Runtime/Startup/Research Audit including exact Gunicorn smoke, and the focused Issue #146 regression are all green.