### PR TITLE
Fix DELL serialized micro-share accounting residue

### DIFF
--- a/paper_bidirectional_accounting_guard.py
+++ b/paper_bidirectional_accounting_guard.py
@@ -21,7 +21,7 @@ import copy
 import datetime as dt
 from typing import Any, Dict, List, Tuple
 
-VERSION = "paper-bidirectional-accounting-2026-08-25-v2-state-trade-qty-tolerance"
+VERSION = "paper-bidirectional-accounting-2026-09-02-v3-open-residue-tolerance"
 # state.trades serializes execution quantities to six decimals. Accept only the
 # bounded sub-five-micro-share residue already proven safe by canonical replay;
 # material quantity gaps remain coverage failures and cannot create cash.
@@ -192,8 +192,6 @@ def analyze_ledger(pf: Dict[str, Any], core: Any = None) -> Dict[str, Any]:
                     "overspend": round(notional - cash, 6),
                 })
             cash -= notional
-            # [remaining qty, entry price].  For shorts, entry notional is also
-            # the reserved margin released pro-rata on exits.
             book.append([qty, price])
             if cash < -max(2.0, initial * 0.0025):
                 economic_issues.append({
@@ -252,7 +250,11 @@ def analyze_ledger(pf: Dict[str, Any], core: Any = None) -> Dict[str, Any]:
     position_value_total = 0.0
     unrealized = 0.0
     for symbol, side_books in books.items():
-        open_sides = [side for side in ("long", "short") if sum(row[0] for row in side_books[side]) > 1e-9]
+        open_sides = [
+            side
+            for side in ("long", "short")
+            if sum(row[0] for row in side_books[side]) > STATE_TRADE_QTY_SERIALIZATION_TOLERANCE
+        ]
         if len(open_sides) > 1:
             economic_issues.append({"reason": "opposing_open_books_same_symbol", "symbol": symbol, "open_sides": open_sides})
         for side in open_sides:

--- a/test_bidirectional_accounting_quantity_tolerance.py
+++ b/test_bidirectional_accounting_quantity_tolerance.py
@@ -14,6 +14,17 @@ def _trade(action, shares, price=36.0):
     }
 
 
+def _dell_trade(action, shares, price):
+    return {
+        "action": action,
+        "symbol": "DELL",
+        "side": "short",
+        "shares": shares,
+        "price": price,
+        "timestamp": "2026-09-02 09:30:00 CDT",
+    }
+
+
 def test_six_decimal_state_trade_residue_is_accepted_as_serialization_only():
     portfolio = {
         "initial_cash": 10000.0,
@@ -51,3 +62,40 @@ def test_material_state_trade_quantity_gap_still_fails_closed():
     issue = rebuilt["coverage_issues"][0]
     assert issue["reason"] == "exit_exceeds_reconstructed_position"
     assert issue["unmatched_qty"] > accounting.STATE_TRADE_QTY_SERIALIZATION_TOLERANCE
+
+
+def test_dell_exact_serialized_terminal_exit_micro_residue_reconstructs_flat():
+    portfolio = {
+        "initial_cash": 13475.004711,
+        "trades": [
+            _dell_trade("entry", 2.323047, 436.96),
+            _dell_trade("partial_exit", 0.766605, 426.25),
+            _dell_trade("exit", 1.556441, 466.10),
+        ],
+        "positions": {},
+    }
+
+    rebuilt = accounting.analyze_ledger(portfolio)
+
+    assert rebuilt["coverage_complete"] is True
+    assert rebuilt["coverage_issue_count"] == 0
+    assert rebuilt["economic_issue_count"] == 0
+    assert rebuilt["open_positions"] == {}
+
+
+def test_dell_residue_above_serialization_tolerance_remains_open():
+    portfolio = {
+        "initial_cash": 13475.004711,
+        "trades": [
+            _dell_trade("entry", 2.323047, 436.96),
+            _dell_trade("partial_exit", 0.766605, 426.25),
+            _dell_trade("exit", 1.556436, 466.10),
+        ],
+        "positions": {},
+    }
+
+    rebuilt = accounting.analyze_ledger(portfolio)
+
+    assert rebuilt["coverage_complete"] is True
+    assert "DELL" in rebuilt["open_positions"]
+    assert rebuilt["open_positions"]["DELL"]["qty"] > accounting.STATE_TRADE_QTY_SERIALIZATION_TOLERANCE


### PR DESCRIPTION
Fixes #150.

Bounded paper-only accounting reconstruction repair. Applies the existing `STATE_TRADE_QTY_SERIALIZATION_TOLERANCE` only when deciding whether reconstructed lot residue constitutes an open position. Exit-overrun detection, cash/economic checks, strategy/signals/sizing/hard-risk thresholds, live/ML authority, and runtime state are unchanged.

Adds focused regressions for the exact DELL lifecycle observed on authoritative Splendid and proves residue above the existing 5e-6 tolerance remains an open reconstructed position.

Do not merge until exact-head Change Safety, Repository Safety and Performance Audit Validation, Architecture Debt Regression Gate, full Refactor/Ownership/Configuration/State/Decision/Runtime/Startup/Research Audit including exact Gunicorn smoke, and focused accounting regressions are green. After merge, require fresh authoritative Splendid read-only evidence before closing #150 or changing any halt/hold.