### PR TITLE
Governed v4 validation-hold release

### DIFF
--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-08-26-v39-issue126-v4-successor"
+VERSION = "data-integrity-startup-bridge-2026-09-02-v40-v4-validation-release"
 MODULES = (
     "final_daily_audit_compactor",
     "daily_audit_entry_count_bridge",
@@ -91,6 +91,10 @@ MODULES = (
     # both apply/register passes also makes the v4 cutover sticky against any
     # earlier legacy startup registration that restores a stale v3 snapshot.
     "verified_v3_successor_epoch_migration",
+    # Governed v4 release runs only after every integrity/research wrapper and
+    # the final v3->v4 state owner. It can change only v4 validation metadata
+    # after the configured forward evidence and accounting gates pass.
+    "verified_v4_validation_release",
 )
 
 

--- a/final_daily_audit_compactor.py
+++ b/final_daily_audit_compactor.py
@@ -80,8 +80,12 @@ def _active_epoch_status(core: Any = None) -> Dict[str, Any]:
 
 def _release_status(core: Any = None) -> Dict[str, Any]:
     try:
-        import clean_epoch_validation_release as module
-        return module.status_payload(core)
+        import verified_v4_validation_release as v4_module
+        v4 = v4_module.status_payload(core)
+        if v4.get("validation_hold") is not None:
+            return v4
+        import clean_epoch_validation_release as legacy_module
+        return legacy_module.status_payload(core)
     except Exception as exc:
         return {"status": "warn", "error": f"{type(exc).__name__}: {exc}"}
 

--- a/test_verified_v4_validation_release.py
+++ b/test_verified_v4_validation_release.py
@@ -1,0 +1,123 @@
+import copy
+import types
+
+import verified_v4_validation_release as release
+
+
+def _core(state):
+    saved = []
+    return types.SimpleNamespace(
+        portfolio=state,
+        local_ts_text=lambda: "2026-09-02 13:15:00 CDT",
+        save_state=lambda *args: saved.append(copy.deepcopy(state)),
+        saved=saved,
+    )
+
+
+def _state():
+    return {
+        "cash": 13475.004711,
+        "equity": 13475.0,
+        "accounting_epoch_id": release.TARGET_EPOCH_ID,
+        "paper_accounting_epoch": {
+            "id": release.TARGET_EPOCH_ID,
+            "historical_evidence_archived": True,
+            "validation_hold": True,
+            "validation_hold_reason": "issue 126 v4 clean-active-accounting validation hold",
+            "validation_release_status": "blocked",
+            "validation_released": False,
+            "forward_validation_required": True,
+        },
+        "risk_controls": {"halted": False, "halt_reason": "", "self_defense_active": False},
+    }
+
+
+def _evidence(rows=19):
+    return {
+        "ledger": {
+            "chain_valid": True,
+            "authoritative_for_new_executions": True,
+            "current_epoch_id": release.TARGET_EPOCH_ID,
+            "current_epoch_rows": 9,
+        },
+        "accounting": {
+            "coverage_complete": True,
+            "coverage_issue_count": 0,
+            "economic_issue_count": 0,
+            "reconstructed": {
+                "cash": 13475.004291,
+                "equity": 13475.004291,
+                "open_positions": {},
+            },
+        },
+        "integrity": {
+            "status": "pass",
+            "forward_validation": {
+                "promotion_evidence_eligible": True,
+                "post_epoch_valid_exact_lifecycle_rows": rows,
+            },
+        },
+    }
+
+
+def test_releases_only_v4_validation_metadata(monkeypatch):
+    state = _state()
+    risk_before = copy.deepcopy(state["risk_controls"])
+    core = _core(state)
+    monkeypatch.setattr(release, "_evidence", lambda _core: _evidence())
+
+    out = release.apply(core)
+
+    assert out["status"] == "released"
+    assert out["post_epoch_valid_exact_lifecycle_rows"] == 19
+    assert state["paper_accounting_epoch"]["validation_hold"] is False
+    assert state["paper_accounting_epoch"]["validation_release_status"] == "released"
+    assert state["paper_accounting_epoch"]["validation_released"] is True
+    assert state["paper_accounting_epoch"]["forward_validation_required"] is False
+    assert state["risk_controls"] == risk_before
+    assert len(core.saved) == 1
+
+
+def test_blocks_when_forward_rows_are_missing(monkeypatch):
+    state = _state()
+    core = _core(state)
+    monkeypatch.setattr(release, "_evidence", lambda _core: _evidence(rows=0))
+
+    out = release.apply(core)
+
+    assert out["status"] == "blocked"
+    assert "post_epoch_rows_sufficient" in out["failed_checks"]
+    assert state["paper_accounting_epoch"]["validation_hold"] is True
+    assert not core.saved
+
+
+def test_never_clears_an_active_risk_halt(monkeypatch):
+    state = _state()
+    state["risk_controls"].update({"halted": True, "halt_reason": "performance risk hard halt"})
+    core = _core(state)
+    monkeypatch.setattr(release, "_evidence", lambda _core: _evidence())
+
+    out = release.apply(core)
+
+    assert out["status"] == "blocked"
+    assert "risk_not_halted" in out["failed_checks"]
+    assert state["risk_controls"]["halted"] is True
+    assert state["paper_accounting_epoch"]["validation_hold"] is True
+    assert not core.saved
+
+
+def test_fails_closed_on_canonical_or_accounting_defect(monkeypatch):
+    for section, key, value in (
+        ("ledger", "chain_valid", False),
+        ("accounting", "coverage_issue_count", 1),
+        ("accounting", "economic_issue_count", 1),
+    ):
+        state = _state()
+        core = _core(state)
+        evidence = _evidence()
+        evidence[section][key] = value
+        monkeypatch.setattr(release, "_evidence", lambda _core, evidence=evidence: evidence)
+        out = release.apply(core)
+        assert out["status"] == "blocked"
+        assert state["paper_accounting_epoch"]["validation_hold"] is True
+        assert not core.saved

--- a/verified_v4_validation_release.py
+++ b/verified_v4_validation_release.py
@@ -1,0 +1,259 @@
+"""Governed release of the Issue #126 v4 successor validation hold.
+
+The v4 successor was deliberately created with a validation hold after exact-
+evidence accounting recovery.  This module releases only that epoch metadata
+hold after the existing forward-validation and integrity surfaces independently
+prove the configured criteria.  It never clears a risk halt, edits canonical
+history, or changes strategy, sizing, risk limits, live authority, ML authority,
+or order authority.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import os
+from typing import Any, Dict
+
+VERSION = "verified-v4-validation-release-2026-09-02-v1"
+TARGET_EPOCH_ID = "stable-paper-v4-20260826-successor01"
+MINIMUM_POST_EPOCH_VALID_ROWS = 1
+_LAST: Dict[str, Any] = {}
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _i(value: Any) -> int:
+    try:
+        if value is None or isinstance(value, bool):
+            return 0
+        return max(0, int(value))
+    except Exception:
+        return 0
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or isinstance(value, bool):
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def _now(core: Any = None) -> str:
+    try:
+        return str(core.local_ts_text())
+    except Exception:
+        return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _paper_only() -> bool:
+    live = os.environ.get("LIVE_TRADING_ENABLED", "false").lower() in {"1", "true", "yes", "on"}
+    broker_live = os.environ.get("BROKER_MODE", "").lower() in {"live", "real", "production"}
+    return not live and not broker_live
+
+
+def _portfolio(core: Any) -> Dict[str, Any]:
+    pf = getattr(core, "portfolio", None) if core is not None else None
+    return pf if isinstance(pf, dict) else {}
+
+
+def _evidence(core: Any) -> Dict[str, Any]:
+    try:
+        import canonical_execution_ledger as ledger_module
+        ledger = ledger_module.status_payload(core)
+    except Exception as exc:
+        ledger = {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
+    try:
+        import paper_bidirectional_accounting_guard as accounting_module
+        accounting = accounting_module.status_payload(core)
+        rebuilt = accounting_module.analyze_ledger(_portfolio(core), core)
+        accounting = {**accounting, "reconstructed": rebuilt}
+    except Exception as exc:
+        accounting = {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
+    try:
+        import daily_data_integrity_audit_overlay as audit_module
+        integrity = audit_module.build_integrity_section(core)
+    except Exception as exc:
+        integrity = {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
+    return {"ledger": ledger, "accounting": accounting, "integrity": integrity}
+
+
+def _preconditions(core: Any) -> Dict[str, Any]:
+    state = _portfolio(core)
+    epoch = _d(state.get("paper_accounting_epoch"))
+    risk = _d(state.get("risk_controls"))
+    evidence = _evidence(core)
+    ledger = _d(evidence.get("ledger"))
+    accounting = _d(evidence.get("accounting"))
+    rebuilt = _d(accounting.get("reconstructed"))
+    integrity = _d(evidence.get("integrity"))
+    forward = _d(integrity.get("forward_validation"))
+    epoch_evidence = _d(integrity.get("post_recovery_evidence_epoch"))
+    post_epoch_rows = _i(
+        forward.get(
+            "post_epoch_valid_exact_lifecycle_rows",
+            epoch_evidence.get("post_epoch_valid_exact_lifecycle_rows"),
+        )
+    )
+    stored_cash = _f(state.get("cash"))
+    stored_equity = _f(state.get("equity"))
+    reconstructed_cash = _f(rebuilt.get("cash"), float("inf"))
+    reconstructed_equity = _f(rebuilt.get("equity"), float("inf"))
+    money_tolerance = max(0.01, abs(stored_equity) * 1e-8)
+    checks = {
+        "paper_runtime": _paper_only(),
+        "target_epoch": str(epoch.get("id") or state.get("accounting_epoch_id") or "") == TARGET_EPOCH_ID,
+        "historical_evidence_archived": bool(epoch.get("historical_evidence_archived")),
+        "validation_hold_active": bool(epoch.get("validation_hold")),
+        "validation_release_blocked": str(epoch.get("validation_release_status") or "") == "blocked",
+        "forward_validation_required": bool(epoch.get("forward_validation_required")),
+        "risk_not_halted": not bool(risk.get("halted")),
+        "self_defense_inactive": not bool(risk.get("self_defense_active")),
+        "canonical_chain_valid": bool(ledger.get("chain_valid")),
+        "canonical_ledger_authoritative": bool(ledger.get("authoritative_for_new_executions")),
+        "canonical_epoch_matches": str(ledger.get("current_epoch_id") or "") == TARGET_EPOCH_ID,
+        "canonical_epoch_has_rows": _i(ledger.get("current_epoch_rows")) > 0,
+        "accounting_coverage_complete": bool(accounting.get("coverage_complete")),
+        "accounting_no_coverage_issues": _i(accounting.get("coverage_issue_count")) == 0,
+        "accounting_no_economic_issues": _i(accounting.get("economic_issue_count")) == 0,
+        "accounting_reconstructed_flat": not _d(rebuilt.get("open_positions")),
+        "cash_matches_reconstruction": abs(stored_cash - reconstructed_cash) <= money_tolerance,
+        "equity_matches_reconstruction": abs(stored_equity - reconstructed_equity) <= money_tolerance,
+        "integrity_not_failed": str(integrity.get("status") or "").lower() != "fail",
+        "forward_promotion_evidence_eligible": forward.get("promotion_evidence_eligible") is True,
+        "post_epoch_rows_sufficient": post_epoch_rows >= MINIMUM_POST_EPOCH_VALID_ROWS,
+    }
+    return {
+        "checks": checks,
+        "failed": [name for name, ok in checks.items() if not ok],
+        "post_epoch_valid_exact_lifecycle_rows": post_epoch_rows,
+        "evidence": evidence,
+    }
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _LAST
+    if core is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+    if not _paper_only():
+        return {"status": "blocked", "overall": "fail", "version": VERSION, "reason": "paper_runtime_only"}
+
+    state = _portfolio(core)
+    epoch = _d(state.get("paper_accounting_epoch"))
+    active = str(epoch.get("id") or state.get("accounting_epoch_id") or "") == TARGET_EPOCH_ID
+    if active and not bool(epoch.get("validation_hold")):
+        result = {
+            "status": "released",
+            "overall": "pass",
+            "version": VERSION,
+            "epoch_id": TARGET_EPOCH_ID,
+            "already_released": True,
+            "released_local": epoch.get("validation_released_local"),
+        }
+        _LAST = result
+        return result
+
+    pre = _preconditions(core)
+    if pre["failed"]:
+        result = {
+            "status": "blocked",
+            "overall": "warn",
+            "version": VERSION,
+            "epoch_id": TARGET_EPOCH_ID,
+            "reason": "v4_validation_release_preconditions_not_met",
+            "failed_checks": pre["failed"],
+            "checks": pre["checks"],
+            "post_epoch_valid_exact_lifecycle_rows": pre["post_epoch_valid_exact_lifecycle_rows"],
+        }
+        _LAST = result
+        return result
+
+    # Change only the v4 epoch's validation metadata. Risk state and all trading
+    # authority remain byte-for-byte unchanged.
+    epoch_before = dict(epoch)
+    epoch["validation_hold"] = False
+    epoch["validation_hold_reason"] = ""
+    epoch["validation_release_status"] = "released"
+    epoch["validation_released"] = True
+    epoch["validation_released_local"] = _now(core)
+    epoch["validation_release_version"] = VERSION
+    epoch["forward_validation_required"] = False
+    epoch["forward_validation_completed_rows"] = pre["post_epoch_valid_exact_lifecycle_rows"]
+    state["paper_accounting_epoch"] = epoch
+
+    save = getattr(core, "save_state", None)
+    if not callable(save):
+        epoch.clear()
+        epoch.update(epoch_before)
+        return {"status": "error", "overall": "fail", "version": VERSION, "reason": "save_state_missing"}
+    try:
+        save(state)
+    except TypeError:
+        try:
+            save()
+        except Exception as exc:
+            epoch.clear()
+            epoch.update(epoch_before)
+            return {"status": "error", "overall": "fail", "version": VERSION, "reason": "save_state_failed", "error": f"{type(exc).__name__}: {exc}"}
+    except Exception as exc:
+        epoch.clear()
+        epoch.update(epoch_before)
+        return {"status": "error", "overall": "fail", "version": VERSION, "reason": "save_state_failed", "error": f"{type(exc).__name__}: {exc}"}
+
+    result = {
+        "status": "released",
+        "overall": "pass",
+        "version": VERSION,
+        "epoch_id": TARGET_EPOCH_ID,
+        "already_released": False,
+        "released_local": epoch.get("validation_released_local"),
+        "post_epoch_valid_exact_lifecycle_rows": pre["post_epoch_valid_exact_lifecycle_rows"],
+        "checks": pre["checks"],
+    }
+    _LAST = result
+    return result
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    state = _portfolio(core) if core is not None else {}
+    epoch = _d(state.get("paper_accounting_epoch"))
+    active = str(epoch.get("id") or state.get("accounting_epoch_id") or "") == TARGET_EPOCH_ID
+    released = bool(active and not epoch.get("validation_hold") and epoch.get("validation_released"))
+    return {
+        "status": "released" if released else _LAST.get("status", "pending"),
+        "overall": "pass" if released else _LAST.get("overall", "warn"),
+        "type": "verified_v4_validation_release_status",
+        "version": VERSION,
+        "epoch_id": TARGET_EPOCH_ID,
+        "released": released,
+        "validation_hold": bool(epoch.get("validation_hold")) if active else None,
+        "released_local": epoch.get("validation_released_local") if active else None,
+        "last_result": dict(_LAST),
+        "authority": {
+            "paper_only": True,
+            "changes_only_v4_validation_metadata": True,
+            "clears_risk_halts": False,
+            "edits_or_deletes_canonical_rows": False,
+            "rewrites_current_day_peak": False,
+            "rewrites_history": False,
+            "places_orders": False,
+            "changes_strategy": False,
+            "changes_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    result = apply(core)
+    if flask_app is None:
+        return result
+    from flask import jsonify
+    path = "/paper/verified-v4-validation-release-status"
+    existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+    if path not in existing:
+        flask_app.add_url_rule(path, "verified_v4_validation_release_status", lambda: jsonify(status_payload(core)))
+    return status_payload(core)


### PR DESCRIPTION
Closes #154.

Adds a separate fail-closed release gate for the exact `stable-paper-v4-20260826-successor01` epoch. It runs last in integrity startup composition and releases only v4 validation metadata after independently proving paper mode, canonical chain/authority/current epoch, accounting coverage/economics/reconstruction parity, configured post-epoch forward evidence, and no active risk halt or self-defense.

Safety boundaries:
- preserves `risk_controls` byte-for-byte;
- does not edit canonical rows, historical state, day peaks, or equity history;
- does not change strategy, thresholds, sizing, hard-risk limits, live authority, ML authority, or order authority;
- does not place orders or call `/paper/run`;
- fails closed on missing or contradictory evidence;
- provides `/paper/verified-v4-validation-release-status` and makes compact daily audit select the active v4 release status rather than the legacy v1-only status.

Local verification:
- `python -m pytest -q test_verified_v4_validation_release.py test_verified_v3_successor_epoch_migration.py test_daily_data_integrity_overlay_v2.py` → 20 passed
- `python -m py_compile ...` → pass
- `git diff --check` → pass

The existing unrelated legacy test `test_release_module_never_clears_unrelated_risk_halt` fails when run against the pre-existing v1 module because that module reports `already_released` whenever the v1 hold flag is absent, even if another risk halt exists. This PR does not modify that v1 behavior; its new v4 regressions explicitly prove an active risk halt blocks release.