### PR TITLE
Preserve released v4 successor through startup compatibility

### DIFF
--- a/clean_epoch_successor_compatibility.py
+++ b/clean_epoch_successor_compatibility.py
@@ -51,7 +51,13 @@ def _successor_epoch(core: Any) -> str | None:
         and str(epoch.get("prior_epoch_id") or "") == ISSUE82_V3_EPOCH_ID
         and str(epoch.get("historical_recovery_decision") or "") == ISSUE126_V4_DECISION
         and bool(epoch.get("historical_evidence_archived", False))
-        and bool(epoch.get("validation_hold", False))
+        and (
+            bool(epoch.get("validation_hold", False))
+            or (
+                epoch.get("validation_released") is True
+                and str(epoch.get("validation_release_status") or "") == "released"
+            )
+        )
     ):
         return ISSUE126_V4_EPOCH_ID
     return None

--- a/test_issue126_successor_compatibility.py
+++ b/test_issue126_successor_compatibility.py
@@ -12,7 +12,7 @@ import verified_v2_successor_epoch_migration_precondition_compatibility as v2_co
 
 class Issue126SuccessorCompatibilityTests(unittest.TestCase):
     @staticmethod
-    def _v4_core(*, canonical_history_retained_immutably=True):
+    def _v4_core(*, canonical_history_retained_immutably=True, released=False):
         return types.SimpleNamespace(portfolio={
             "accounting_epoch_id": clean_compat.ISSUE126_V4_EPOCH_ID,
             "paper_accounting_epoch": {
@@ -20,7 +20,9 @@ class Issue126SuccessorCompatibilityTests(unittest.TestCase):
                 "prior_epoch_id": clean_compat.ISSUE82_V3_EPOCH_ID,
                 "historical_recovery_decision": clean_compat.ISSUE126_V4_DECISION,
                 "historical_evidence_archived": True,
-                "validation_hold": True,
+                "validation_hold": not released,
+                "validation_released": released,
+                "validation_release_status": "released" if released else "blocked",
                 "canonical_history_retained_immutably": canonical_history_retained_immutably,
             },
         })
@@ -38,6 +40,9 @@ class Issue126SuccessorCompatibilityTests(unittest.TestCase):
         ):
             changed = copy.deepcopy(core.portfolio)
             changed["paper_accounting_epoch"][field] = bad
+            if field == "validation_hold":
+                changed["paper_accounting_epoch"]["validation_released"] = False
+                changed["paper_accounting_epoch"]["validation_release_status"] = "blocked"
             self.assertFalse(clean_compat._is_verified_successor(types.SimpleNamespace(portfolio=changed)))
 
     def test_v2_migration_compatibility_treats_exact_v4_as_superseded_without_write(self):
@@ -59,6 +64,11 @@ class Issue126SuccessorCompatibilityTests(unittest.TestCase):
         self.assertEqual(calls["original"], 0)
         self.assertEqual(core.portfolio, before)
         self.assertFalse(result["writes_state"])
+
+    def test_released_v4_remains_exact_successor_for_legacy_compatibility(self):
+        core = self._v4_core(released=True)
+        self.assertEqual(clean_compat._successor_epoch(core), clean_compat.ISSUE126_V4_EPOCH_ID)
+        self.assertTrue(v2_compat._exact_issue126_v4_successor(v2_migration, core))
 
     def test_v2_migration_compatibility_fails_closed_on_v4_lineage_mismatch(self):
         core = self._v4_core(canonical_history_retained_immutably=False)

--- a/test_verified_v4_validation_release.py
+++ b/test_verified_v4_validation_release.py
@@ -121,3 +121,16 @@ def test_fails_closed_on_canonical_or_accounting_defect(monkeypatch):
         assert out["status"] == "blocked"
         assert state["paper_accounting_epoch"]["validation_hold"] is True
         assert not core.saved
+
+
+def test_status_fails_closed_if_release_attempt_is_not_authoritative(monkeypatch):
+    state = _state()
+    core = _core(state)
+    monkeypatch.setattr(release, "_LAST", {"status": "released", "already_released": False})
+
+    out = release.status_payload(core)
+
+    assert out["status"] == "blocked"
+    assert out["overall"] == "fail"
+    assert out["released"] is False
+    assert out["reason"] == "release_attempt_not_reflected_in_authoritative_state"

--- a/verified_v2_successor_epoch_migration_precondition_compatibility.py
+++ b/verified_v2_successor_epoch_migration_precondition_compatibility.py
@@ -119,7 +119,13 @@ def _exact_issue126_v4_successor(migration: Any, core: Any) -> bool:
         and str(epoch.get("prior_epoch_id") or "") == migration.TARGET_EPOCH_ID
         and str(epoch.get("historical_recovery_decision") or "") == ISSUE126_V4_DECISION
         and bool(epoch.get("historical_evidence_archived", False))
-        and bool(epoch.get("validation_hold", False))
+        and (
+            bool(epoch.get("validation_hold", False))
+            or (
+                epoch.get("validation_released") is True
+                and str(epoch.get("validation_release_status") or "") == "released"
+            )
+        )
         and bool(epoch.get("canonical_history_retained_immutably", False))
     )
 

--- a/verified_v4_validation_release.py
+++ b/verified_v4_validation_release.py
@@ -221,15 +221,22 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
     epoch = _d(state.get("paper_accounting_epoch"))
     active = str(epoch.get("id") or state.get("accounting_epoch_id") or "") == TARGET_EPOCH_ID
     released = bool(active and not epoch.get("validation_hold") and epoch.get("validation_released"))
+    attempted_but_not_persisted = bool(
+        active
+        and not released
+        and _LAST.get("status") == "released"
+        and _LAST.get("already_released") is False
+    )
     return {
-        "status": "released" if released else _LAST.get("status", "pending"),
-        "overall": "pass" if released else _LAST.get("overall", "warn"),
+        "status": "released" if released else "blocked" if attempted_but_not_persisted else _LAST.get("status", "pending"),
+        "overall": "pass" if released else "fail" if attempted_but_not_persisted else _LAST.get("overall", "warn"),
         "type": "verified_v4_validation_release_status",
         "version": VERSION,
         "epoch_id": TARGET_EPOCH_ID,
         "released": released,
         "validation_hold": bool(epoch.get("validation_hold")) if active else None,
         "released_local": epoch.get("validation_released_local") if active else None,
+        "reason": "release_attempt_not_reflected_in_authoritative_state" if attempted_but_not_persisted else None,
         "last_result": dict(_LAST),
         "authority": {
             "paper_only": True,


### PR DESCRIPTION
Follow-up for #154 after settled Splendid evidence showed the first release mutation was not retained: the v4 gate reported a successful attempt, but legacy successor compatibility still required `validation_hold=true`, so later startup composition did not recognize the released v4 shape as the exact authorized successor.

This PR:
- treats either the original held v4 shape or the exact governed released shape (`validation_released=true`, `validation_release_status=released`) as the same verified v4 successor in both legacy compatibility layers;
- does not broaden lineage acceptance: prior epoch, recovery decision, archived evidence, and canonical-history requirements remain exact;
- makes v4 release status fail closed if a release attempt is not reflected in authoritative state;
- adds regressions for released-v4 compatibility and non-persisted release reporting.

No canonical/history/day-peak/risk/strategy/sizing/live/ML/order authority changes. No `/paper/run`.

Focused verification: 26 passed.