### PR TITLE
Issue #157 Stage 4: canonical outcome memory and scorecards

### DIFF
--- a/POST_VALIDATION_SHADOW_AI_DESIGN.md
+++ b/POST_VALIDATION_SHADOW_AI_DESIGN.md
@@ -1,6 +1,6 @@
 # Post-Validation Shadow-AI Research Design
 
-Status: Stage 3 asynchronous adversarial reviewer implemented; disabled by default
+Status: Stage 4 canonical outcome memory and scorecards implemented; runtime-disconnected
 Issue: #157  
 Runtime authority: unchanged; rules remain the sole execution authority
 
@@ -239,6 +239,23 @@ invalid telemetry only and are not eligible for canonical outcome joins.
 
 Read-only canonical joins, comparable-outcome retrieval, AI-vs-rules lifecycle
 labels, MFE/MAE/return evidence, and net-of-cost counterfactual scorecards.
+
+Implemented in `shadow_ai_outcome_memory.py` as a pure library with no route,
+worker, runtime hook, state save, or provider access. It consumes copies of
+already-derived, integrity-qualified outcome rows. Every accepted row must carry
+an immutable primary canonical execution ID, canonical source IDs including that
+primary ID, valid path provenance, exact MFE/MAE/return evidence, entry notional,
+and the declared comparison dimensions. Duplicate identical rows deduplicate;
+contradictory rows sharing a canonical ID are entirely excluded.
+
+AI results join to outcomes only through an explicit binding that matches
+`cycle_id`, `candidate_id`, and `input_fingerprint` and names exactly one
+canonical execution ID. Symbol/time inference is forbidden. Scorecards compare
+the rule outcome with the shadow `agree`/`reject` counterfactual, subtract exact
+inference cost when present, and segment the evidence without promotion. Missing
+cost makes net metrics null; small, concentrated, incomplete, or contradictory
+samples remain inconclusive. Even sufficient diverse evidence is labeled
+`observational_only` and cannot change trading behavior.
 
 ### Stage 5 — observability and forward evidence
 

--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -45,6 +45,12 @@ SUCCESSOR_REPLAY_TESTS = ("test_verified_v2_successor_replay_status.py",)
 SUCCESSOR_EPOCH_MIGRATION_TESTS = ("test_verified_v2_successor_epoch_migration.py",)
 RUNTIME_RESEARCH_SNAPSHOT_TESTS = ("test_runtime_research_snapshot.py",)
 LEGACY_EXTERNAL_PAPER_RUNNER_TESTS = ("test_legacy_external_paper_runner_retired.py",)
+SHADOW_AI_TESTS = (
+    "test_shadow_ai_research_contract.py",
+    "test_shadow_ai_research_client.py",
+    "test_shadow_ai_adversarial_reviewer.py",
+    "test_shadow_ai_outcome_memory.py",
+)
 
 
 @dataclass(frozen=True)
@@ -103,6 +109,10 @@ def _is_runtime_research_snapshot_path(path: str) -> bool:
 
 def _is_legacy_external_paper_runner_path(path: str) -> bool:
     return path.lower() == ".github/workflows/paper-run.yml"
+
+
+def _is_shadow_ai_path(path: str) -> bool:
+    return Path(path.lower()).name.startswith(("shadow_ai_", "test_shadow_ai_"))
 
 
 def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ...]]:
@@ -191,6 +201,8 @@ def planned_regressions(paths: Iterable[str]) -> tuple[str, ...]:
         tests.extend(RUNTIME_RESEARCH_SNAPSHOT_TESTS)
     if any(_is_legacy_external_paper_runner_path(path) for path in path_tuple):
         tests.extend(LEGACY_EXTERNAL_PAPER_RUNNER_TESTS)
+    if any(_is_shadow_ai_path(path) for path in path_tuple):
+        tests.extend(SHADOW_AI_TESTS)
     existing: list[str] = []
     seen: set[str] = set()
     for test in tests:

--- a/shadow_ai_outcome_memory.py
+++ b/shadow_ai_outcome_memory.py
@@ -1,0 +1,434 @@
+"""Read-only canonical outcome memory and shadow-AI scorecards.
+
+This module accepts already-derived, integrity-qualified outcome rows.  It never
+reads or writes the canonical ledger itself and never infers lifecycle identity
+from symbol or time.  A caller must provide an explicit immutable execution ID
+and an exact AI-review-to-execution binding.  Missing or contradictory evidence
+is excluded with diagnostics.
+
+The output is rebuildable research evidence only.  It cannot promote a model,
+change a rule decision, mutate state, or participate in execution.
+"""
+from __future__ import annotations
+
+import json
+import math
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+
+VERSION = "shadow-ai-outcome-memory-2026-09-02-v1"
+DERIVATION_VERSION = "canonical-outcome-derived-v1"
+
+
+@dataclass(frozen=True, slots=True)
+class OutcomeMemoryConfig:
+    max_records: int = 5_000
+    min_scorecard_samples: int = 20
+    max_symbol_concentration: float = 0.35
+
+    def __post_init__(self) -> None:
+        if not 1 <= int(self.max_records) <= 50_000:
+            raise ValueError("max_records must be in [1, 50000]")
+        if not 2 <= int(self.min_scorecard_samples) <= 10_000:
+            raise ValueError("min_scorecard_samples must be in [2, 10000]")
+        if not 0.05 <= float(self.max_symbol_concentration) <= 1.0:
+            raise ValueError("max_symbol_concentration must be in [0.05, 1.0]")
+
+
+def _number(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _text(value: Any, *, upper: bool = False) -> str:
+    result = str(value or "").strip()
+    return result.upper() if upper else result.lower()
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple, set)):
+        return ()
+    return tuple(sorted({str(item).strip() for item in value if str(item).strip()}))
+
+
+def _signal_tuple(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        value = [value]
+    return _string_tuple(value)
+
+
+def _normalized_outcome(row: Mapping[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    execution_id = str(row.get("canonical_execution_id") or "").strip()
+    source_ids = _string_tuple(row.get("canonical_source_ids"))
+    symbol = _text(row.get("symbol"), upper=True)
+    side = _text(row.get("side"))
+    realized = _number(row.get("realized_return_pct"))
+    mfe = _number(row.get("mfe_pct"))
+    mae = _number(row.get("mae_pct"))
+    notional = _number(row.get("entry_notional_usd"))
+    holding_seconds = _number(row.get("holding_period_seconds"))
+
+    required_text = {
+        "canonical_execution_id": execution_id,
+        "symbol": symbol,
+        "strategy": _text(row.get("strategy")),
+        "setup_family": _text(row.get("setup_family")),
+        "side": side,
+        "regime": _text(row.get("regime")),
+        "sector": _text(row.get("sector"), upper=True),
+        "bucket": _text(row.get("bucket")),
+        "volatility_state": _text(row.get("volatility_state")),
+        "session_phase": _text(row.get("session_phase")),
+        "exit_reason": _text(row.get("exit_reason")),
+        "calendar_segment": str(row.get("calendar_segment") or "").strip(),
+        "path_source_id": str(row.get("path_source_id") or "").strip(),
+    }
+    missing = [key for key, value in required_text.items() if not value]
+    if missing:
+        return None, "missing_required_fields:" + ",".join(sorted(missing))
+    if side not in {"long", "short"}:
+        return None, "invalid_side"
+    if not source_ids or execution_id not in source_ids:
+        return None, "canonical_source_ids_do_not_include_primary"
+    if row.get("canonical_evidence_status") != "valid":
+        return None, "canonical_evidence_not_valid"
+    if row.get("path_integrity_status") != "valid" or row.get("path_training_eligible") is not True:
+        return None, "path_evidence_not_eligible"
+    if realized is None or not -100.0 < realized < 500.0:
+        return None, "invalid_realized_return_pct"
+    if mfe is None or not 0.0 <= mfe < 500.0:
+        return None, "invalid_mfe_pct"
+    if mae is None or not -100.0 < mae <= 0.0:
+        return None, "invalid_mae_pct"
+    if notional is None or notional <= 0.0:
+        return None, "invalid_entry_notional_usd"
+    if holding_seconds is None or holding_seconds < 0.0:
+        return None, "invalid_holding_period_seconds"
+
+    normalized = {
+        **required_text,
+        "canonical_source_ids": list(source_ids),
+        "canonical_evidence_status": "valid",
+        "path_integrity_status": "valid",
+        "path_training_eligible": True,
+        "signal_characteristics": list(_signal_tuple(row.get("signal_characteristics"))),
+        "realized_return_pct": realized,
+        "mfe_pct": mfe,
+        "mae_pct": mae,
+        "entry_notional_usd": notional,
+        "holding_period_seconds": int(holding_seconds),
+        "derivation_version": DERIVATION_VERSION,
+    }
+    return normalized, None
+
+
+def build_outcome_memory(
+    outcome_rows: Iterable[Mapping[str, Any]],
+    config: OutcomeMemoryConfig | None = None,
+) -> dict[str, Any]:
+    """Build a bounded index without mutating or retaining source mappings."""
+    settings = config or OutcomeMemoryConfig()
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    exclusions: list[dict[str, Any]] = []
+    observed = 0
+    for raw in outcome_rows:
+        observed += 1
+        if not isinstance(raw, Mapping):
+            exclusions.append({"reason": "row_not_mapping"})
+            continue
+        normalized, error = _normalized_outcome(raw)
+        if error or normalized is None:
+            exclusions.append({
+                "canonical_execution_id": str(raw.get("canonical_execution_id") or ""),
+                "reason": error or "normalization_failed",
+            })
+            continue
+        grouped[normalized["canonical_execution_id"]].append(normalized)
+
+    accepted: list[dict[str, Any]] = []
+    for execution_id in sorted(grouped):
+        variants = {
+            json.dumps(item, sort_keys=True, separators=(",", ":"))
+            for item in grouped[execution_id]
+        }
+        if len(variants) != 1:
+            exclusions.append({
+                "canonical_execution_id": execution_id,
+                "reason": "contradictory_rows_for_canonical_execution_id",
+            })
+            continue
+        accepted.append(json.loads(next(iter(variants))))
+
+    retained = accepted[-settings.max_records :]
+    return {
+        "status": "ok",
+        "overall": "pass" if not exclusions else "warn",
+        "type": "shadow_ai_canonical_outcome_memory",
+        "version": VERSION,
+        "derivation_version": DERIVATION_VERSION,
+        "primary_key": "canonical_execution_id",
+        "source_rows_observed": observed,
+        "accepted_count": len(retained),
+        "excluded_count": len(exclusions),
+        "truncated_count": max(0, len(accepted) - len(retained)),
+        "records": retained,
+        "exclusions": exclusions[-100:],
+        "authority": _authority(),
+    }
+
+
+def find_comparable_outcomes(
+    memory: Mapping[str, Any],
+    context: Mapping[str, Any],
+    *,
+    limit: int = 10,
+) -> tuple[dict[str, Any], ...]:
+    """Return deterministic similarity results; side is a mandatory match."""
+    if not 1 <= int(limit) <= 100:
+        raise ValueError("limit must be in [1, 100]")
+    side = _text(context.get("side"))
+    if side not in {"long", "short"}:
+        return ()
+    query_signals = set(_signal_tuple(context.get("signal_characteristics")))
+    weights = {
+        "strategy": 4,
+        "setup_family": 4,
+        "regime": 3,
+        "sector": 2,
+        "bucket": 2,
+        "volatility_state": 2,
+        "session_phase": 1,
+    }
+    ranked: list[dict[str, Any]] = []
+    records = memory.get("records")
+    if not isinstance(records, list):
+        return ()
+    for record in records:
+        if not isinstance(record, Mapping) or _text(record.get("side")) != side:
+            continue
+        score = 5
+        possible = 5 + sum(weights.values()) + 3
+        matches = ["side"]
+        for field, weight in weights.items():
+            query_value = _text(context.get(field), upper=field == "sector")
+            record_value = _text(record.get(field), upper=field == "sector")
+            if query_value and query_value == record_value:
+                score += weight
+                matches.append(field)
+        record_signals = set(_signal_tuple(record.get("signal_characteristics")))
+        if query_signals and record_signals:
+            overlap = len(query_signals & record_signals) / len(query_signals | record_signals)
+            score += round(3 * overlap, 6)
+            if overlap:
+                matches.append("signal_characteristics")
+        item = dict(record)
+        item["comparison_score"] = round(score / possible, 6)
+        item["matched_dimensions"] = matches
+        ranked.append(item)
+    ranked.sort(key=lambda item: (-item["comparison_score"], item["canonical_execution_id"]))
+    return tuple(ranked[:limit])
+
+
+def _review_identity(record: Mapping[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(record.get("cycle_id") or ""),
+        str(record.get("candidate_id") or ""),
+        str(record.get("input_fingerprint") or ""),
+    )
+
+
+def _confidence_bucket(value: float) -> str:
+    if value < 0.5:
+        return "low"
+    if value < 0.75:
+        return "medium"
+    return "high"
+
+
+def _score_group(rows: list[dict[str, Any]], settings: OutcomeMemoryConfig) -> dict[str, Any]:
+    count = len(rows)
+    symbols = Counter(row["symbol"] for row in rows)
+    concentration = max(symbols.values(), default=0) / max(1, count)
+    cost_complete = all(row["inference_cost_usd"] is not None for row in rows)
+    baseline = sum(row["rules_realized_pnl_usd"] for row in rows)
+    hypothetical = sum(row["ai_counterfactual_pnl_usd"] for row in rows)
+    incremental = hypothetical - baseline
+    total_cost = sum(row["inference_cost_usd"] or 0.0 for row in rows)
+    sufficient = count >= settings.min_scorecard_samples
+    unconcentrated = concentration <= settings.max_symbol_concentration
+    return {
+        "sample_count": count,
+        "symbol_count": len(symbols),
+        "max_symbol_concentration": round(concentration, 6),
+        "rules_realized_pnl_usd": round(baseline, 6),
+        "ai_counterfactual_pnl_usd": round(hypothetical, 6),
+        "incremental_pnl_before_cost_usd": round(incremental, 6),
+        "inference_cost_usd": round(total_cost, 6) if cost_complete else None,
+        "incremental_pnl_net_cost_usd": round(incremental - total_cost, 6) if cost_complete else None,
+        "average_realized_return_pct": round(sum(row["realized_return_pct"] for row in rows) / max(1, count), 6),
+        "average_mfe_pct": round(sum(row["mfe_pct"] for row in rows) / max(1, count), 6),
+        "average_mae_pct": round(sum(row["mae_pct"] for row in rows) / max(1, count), 6),
+        "exact_cost_coverage_complete": cost_complete,
+        "sample_sufficient": sufficient,
+        "concentration_acceptable": unconcentrated,
+        "conclusion": "observational_only" if sufficient and unconcentrated and cost_complete else "inconclusive",
+        "automatic_promotion": False,
+    }
+
+
+def build_counterfactual_scorecards(
+    memory: Mapping[str, Any],
+    review_records: Iterable[Mapping[str, Any]],
+    execution_bindings: Iterable[Mapping[str, Any]],
+    config: OutcomeMemoryConfig | None = None,
+) -> dict[str, Any]:
+    """Join reviews to outcomes only through exact, non-contradictory bindings."""
+    settings = config or OutcomeMemoryConfig()
+    memory_rows = memory.get("records", []) if memory.get("version") == VERSION else []
+    verified_memory = build_outcome_memory(
+        memory_rows if isinstance(memory_rows, list) else [],
+        settings,
+    )
+    outcomes = {
+        str(row.get("canonical_execution_id")): dict(row)
+        for row in verified_memory["records"]
+    }
+    binding_groups: dict[tuple[str, str, str], set[str]] = defaultdict(set)
+    for binding in execution_bindings:
+        if not isinstance(binding, Mapping):
+            continue
+        identity = _review_identity(binding)
+        execution_id = str(binding.get("canonical_execution_id") or "").strip()
+        if all(identity) and execution_id:
+            binding_groups[identity].add(execution_id)
+
+    exclusions: list[dict[str, Any]] = []
+    if memory.get("version") != VERSION:
+        exclusions.append({"reason": "memory_version_untrusted"})
+    exclusions.extend(
+        {"reason": f"memory_{row.get('reason')}", "canonical_execution_id": row.get("canonical_execution_id")}
+        for row in verified_memory["exclusions"]
+    )
+    joined: list[dict[str, Any]] = []
+    review_groups: dict[tuple[str, str, str], list[Mapping[str, Any]]] = defaultdict(list)
+    for review in review_records:
+        if not isinstance(review, Mapping):
+            exclusions.append({"reason": "review_not_mapping"})
+            continue
+        identity = _review_identity(review)
+        if not all(identity):
+            exclusions.append({"candidate_id": identity[1], "reason": "missing_review_identity"})
+            continue
+        review_groups[identity].append(review)
+
+    for identity in sorted(review_groups):
+        group = review_groups[identity]
+        if len(group) != 1:
+            exclusions.append({"candidate_id": identity[1], "reason": "duplicate_review_identity"})
+            continue
+        review = group[0]
+        if review.get("join_eligible") is not True:
+            exclusions.append({"candidate_id": identity[1], "reason": "review_not_join_eligible"})
+            continue
+        bound_ids = binding_groups.get(identity, set())
+        if len(bound_ids) != 1:
+            exclusions.append({"candidate_id": identity[1], "reason": "missing_or_contradictory_execution_binding"})
+            continue
+        execution_id = next(iter(bound_ids))
+        outcome = outcomes.get(execution_id)
+        if outcome is None:
+            exclusions.append({"candidate_id": identity[1], "reason": "canonical_outcome_missing"})
+            continue
+        result = review.get("result")
+        if not isinstance(result, Mapping):
+            exclusions.append({"candidate_id": identity[1], "reason": "result_missing"})
+            continue
+        decision = _text(result.get("decision"))
+        confidence = _number(result.get("confidence"))
+        telemetry = result.get("telemetry")
+        cost = _number(telemetry.get("cost_usd_exact")) if isinstance(telemetry, Mapping) else None
+        if decision not in {"agree", "reject"} or confidence is None or not 0.0 <= confidence <= 1.0:
+            exclusions.append({"candidate_id": identity[1], "reason": "invalid_shadow_decision"})
+            continue
+        if cost is not None and cost < 0.0:
+            exclusions.append({"candidate_id": identity[1], "reason": "invalid_inference_cost"})
+            continue
+        if _text(review.get("rules_decision")) != "enter":
+            exclusions.append({"candidate_id": identity[1], "reason": "nonexecuted_rules_decision"})
+            continue
+        rules_pnl = outcome["entry_notional_usd"] * outcome["realized_return_pct"] / 100.0
+        ai_pnl = rules_pnl if decision == "agree" else 0.0
+        joined.append({
+            "canonical_execution_id": execution_id,
+            "candidate_id": identity[1],
+            "symbol": outcome["symbol"],
+            "agreement_state": "agree" if decision == "agree" else "disagree_reject",
+            "confidence": confidence,
+            "confidence_bucket": _confidence_bucket(confidence),
+            "strategy": outcome["strategy"],
+            "setup": outcome["setup_family"],
+            "regime": outcome["regime"],
+            "sector": outcome["sector"],
+            "volatility_state": outcome["volatility_state"],
+            "calendar_segment": outcome["calendar_segment"],
+            "realized_return_pct": outcome["realized_return_pct"],
+            "mfe_pct": outcome["mfe_pct"],
+            "mae_pct": outcome["mae_pct"],
+            "rules_realized_pnl_usd": rules_pnl,
+            "ai_counterfactual_pnl_usd": ai_pnl,
+            "inference_cost_usd": cost,
+        })
+
+    segments: dict[str, dict[str, dict[str, Any]]] = {}
+    for field in (
+        "agreement_state",
+        "confidence_bucket",
+        "strategy",
+        "setup",
+        "regime",
+        "sector",
+        "volatility_state",
+        "calendar_segment",
+    ):
+        grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for row in joined:
+            grouped[str(row[field])].append(row)
+        segments[field] = {
+            key: _score_group(grouped[key], settings) for key in sorted(grouped)
+        }
+
+    return {
+        "status": "ok",
+        "overall": "pass" if joined else "warn",
+        "type": "shadow_ai_rules_counterfactual_scorecards",
+        "version": VERSION,
+        "joined_count": len(joined),
+        "excluded_count": len(exclusions),
+        "aggregate": _score_group(joined, settings),
+        "segments": segments,
+        "joined_rows": joined[-settings.max_records :],
+        "exclusions": exclusions[-100:],
+        "authority": _authority(),
+    }
+
+
+def _authority() -> dict[str, bool]:
+    return {
+        "research_only": True,
+        "canonical_sources_read_only": True,
+        "rebuildable_derived_output": True,
+        "execution_input": False,
+        "changes_rule_decisions": False,
+        "changes_strategy_or_thresholds": False,
+        "changes_risk_or_sizing": False,
+        "changes_accounting_or_canonical_history": False,
+        "places_or_cancels_orders": False,
+        "automatic_promotion": False,
+    }

--- a/shadow_ai_research_contract.json
+++ b/shadow_ai_research_contract.json
@@ -1,6 +1,6 @@
 {
-  "version": "shadow-ai-research-contract-2026-09-02-v3-reviewer",
-  "implementation_stage": "stage_3_async_adversarial_reviewer",
+  "version": "shadow-ai-research-contract-2026-09-02-v4-outcome-memory",
+  "implementation_stage": "stage_4_canonical_outcome_memory_and_scorecards",
   "policy": {
     "paper_only": true,
     "research_only": true,
@@ -159,9 +159,15 @@
   },
   "canonical_outcome_memory": {
     "enabled_in_stage_1": false,
+    "implemented": true,
+    "runtime_integrated": false,
+    "module": "shadow_ai_outcome_memory.py",
     "primary_key": "canonical_execution_id",
     "canonical_source_read_only": true,
     "rebuildable_derived_index": true,
+    "symbol_or_time_inferred_join_allowed": false,
+    "exact_review_execution_binding_required": true,
+    "integrity_qualified_path_evidence_required": true,
     "missing_or_contradictory_evidence_behavior": "fail_closed_no_join",
     "comparison_dimensions": [
       "strategy",
@@ -179,6 +185,7 @@
       "mfe",
       "mae",
       "realized_return",
+      "entry_notional_usd",
       "exit_reason",
       "holding_period",
       "canonical_source_ids",
@@ -187,6 +194,8 @@
   },
   "counterfactual_scorecard": {
     "enabled_in_stage_1": false,
+    "implemented": true,
+    "runtime_integrated": false,
     "execution_input": false,
     "measures_incremental_expectancy": true,
     "subtracts_inference_cost": true,
@@ -201,6 +210,8 @@
       "calendar_segment"
     ],
     "small_or_concentrated_samples": "inconclusive",
+    "missing_exact_cost_behavior": "net_metrics_null_and_inconclusive",
+    "sufficient_result_behavior": "observational_only",
     "automatic_promotion": false
   },
   "retention": {

--- a/test_change_safety_audit.py
+++ b/test_change_safety_audit.py
@@ -205,7 +205,18 @@ class ChangeSafetyAuditTests(unittest.TestCase):
             "test_architecture_stage_e_accounting.py",
             "test_architecture_stage_f_canary.py",
         ):
-            self.assertIn(core_test, tests)
+                self.assertIn(core_test, tests)
+
+    def test_shadow_ai_change_selects_complete_shadow_ai_regression_set(self) -> None:
+        tests = planned_regressions(("shadow_ai_outcome_memory.py",))
+
+        for shadow_test in (
+            "test_shadow_ai_research_contract.py",
+            "test_shadow_ai_research_client.py",
+            "test_shadow_ai_adversarial_reviewer.py",
+            "test_shadow_ai_outcome_memory.py",
+        ):
+            self.assertIn(shadow_test, tests)
 
 
 if __name__ == "__main__":

--- a/test_shadow_ai_outcome_memory.py
+++ b/test_shadow_ai_outcome_memory.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import copy
+import unittest
+
+from shadow_ai_outcome_memory import (
+    DERIVATION_VERSION,
+    OutcomeMemoryConfig,
+    build_counterfactual_scorecards,
+    build_outcome_memory,
+    find_comparable_outcomes,
+)
+
+
+def _outcome(execution_id: str = "entry-1", **overrides):
+    row = {
+        "canonical_execution_id": execution_id,
+        "canonical_source_ids": [execution_id, f"exit-{execution_id}"],
+        "canonical_evidence_status": "valid",
+        "path_source_id": f"path-{execution_id}",
+        "path_integrity_status": "valid",
+        "path_training_eligible": True,
+        "symbol": "CRWD",
+        "side": "long",
+        "strategy": "breakout",
+        "setup_family": "continuation",
+        "regime": "risk_on",
+        "sector": "technology",
+        "bucket": "growth",
+        "volatility_state": "normal",
+        "signal_characteristics": ["relative_volume", "new_high"],
+        "session_phase": "morning",
+        "calendar_segment": "2026-09",
+        "exit_reason": "trailing_stop",
+        "realized_return_pct": 2.5,
+        "mfe_pct": 4.0,
+        "mae_pct": -0.8,
+        "entry_notional_usd": 1000.0,
+        "holding_period_seconds": 7200,
+    }
+    row.update(overrides)
+    return row
+
+
+def _review(candidate: str = "CRWD:long:a", decision: str = "reject", cost=0.25):
+    return {
+        "join_eligible": True,
+        "cycle_id": "cycle-1",
+        "candidate_id": candidate,
+        "input_fingerprint": "fingerprint-1",
+        "rules_decision": "enter",
+        "result": {
+            "decision": decision,
+            "confidence": 0.8,
+            "telemetry": {"cost_usd_exact": cost},
+        },
+    }
+
+
+def _binding(candidate: str = "CRWD:long:a", execution_id: str = "entry-1"):
+    return {
+        "cycle_id": "cycle-1",
+        "candidate_id": candidate,
+        "input_fingerprint": "fingerprint-1",
+        "canonical_execution_id": execution_id,
+    }
+
+
+class ShadowAIOutcomeMemoryTests(unittest.TestCase):
+    def test_memory_is_read_only_bounded_and_rebuildable(self):
+        rows = [_outcome()]
+        before = copy.deepcopy(rows)
+        first = build_outcome_memory(rows)
+        second = build_outcome_memory(copy.deepcopy(rows))
+        self.assertEqual(rows, before)
+        self.assertEqual(first, second)
+        self.assertEqual(first["accepted_count"], 1)
+        self.assertEqual(first["records"][0]["derivation_version"], DERIVATION_VERSION)
+        self.assertTrue(first["authority"]["canonical_sources_read_only"])
+        self.assertFalse(first["authority"]["execution_input"])
+
+    def test_memory_fails_closed_on_invalid_evidence(self):
+        cases = [
+            ({"canonical_execution_id": ""}, "missing_required_fields"),
+            ({"canonical_source_ids": ["exit-entry-1"]}, "canonical_source_ids_do_not_include_primary"),
+            ({"canonical_evidence_status": "unknown"}, "canonical_evidence_not_valid"),
+            ({"path_integrity_status": "quarantined"}, "path_evidence_not_eligible"),
+            ({"path_training_eligible": False}, "path_evidence_not_eligible"),
+            ({"realized_return_pct": float("nan")}, "invalid_realized_return_pct"),
+            ({"mfe_pct": -0.1}, "invalid_mfe_pct"),
+            ({"mae_pct": 0.1}, "invalid_mae_pct"),
+            ({"entry_notional_usd": 0}, "invalid_entry_notional_usd"),
+            ({"holding_period_seconds": -1}, "invalid_holding_period_seconds"),
+        ]
+        for overrides, reason in cases:
+            with self.subTest(reason=reason):
+                payload = build_outcome_memory([_outcome(**overrides)])
+                self.assertEqual(payload["accepted_count"], 0)
+                self.assertEqual(payload["excluded_count"], 1)
+                self.assertIn(reason, payload["exclusions"][0]["reason"])
+
+    def test_duplicate_identical_row_is_deduplicated(self):
+        row = _outcome()
+        payload = build_outcome_memory([row, copy.deepcopy(row)])
+        self.assertEqual(payload["accepted_count"], 1)
+        self.assertEqual(payload["excluded_count"], 0)
+
+    def test_duplicate_contradictory_execution_id_is_fully_excluded(self):
+        payload = build_outcome_memory([_outcome(), _outcome(realized_return_pct=-2.0)])
+        self.assertEqual(payload["accepted_count"], 0)
+        self.assertEqual(
+            payload["exclusions"][0]["reason"],
+            "contradictory_rows_for_canonical_execution_id",
+        )
+
+    def test_memory_retention_is_bounded(self):
+        rows = [_outcome(f"entry-{index}") for index in range(3)]
+        payload = build_outcome_memory(rows, OutcomeMemoryConfig(max_records=2))
+        self.assertEqual(payload["accepted_count"], 2)
+        self.assertEqual(payload["truncated_count"], 1)
+
+    def test_comparables_require_side_and_rank_deterministically(self):
+        rows = [
+            _outcome("entry-z", strategy="mean_reversion", signal_characteristics=["oversold"]),
+            _outcome("entry-a"),
+            _outcome("entry-short", side="short"),
+        ]
+        context = {
+            "side": "long",
+            "strategy": "breakout",
+            "setup_family": "continuation",
+            "regime": "risk_on",
+            "sector": "TECHNOLOGY",
+            "bucket": "growth",
+            "volatility_state": "normal",
+            "session_phase": "morning",
+            "signal_characteristics": ["relative_volume", "new_high"],
+        }
+        memory = build_outcome_memory(rows)
+        comparables = find_comparable_outcomes(memory, context)
+        self.assertEqual(
+            [row["canonical_execution_id"] for row in comparables],
+            ["entry-a", "entry-z"],
+        )
+        self.assertEqual(comparables[0]["comparison_score"], 1.0)
+        self.assertEqual(find_comparable_outcomes(memory, {"side": "unknown"}), ())
+
+    def test_scorecard_exact_join_subtracts_inference_cost(self):
+        payload = build_counterfactual_scorecards(
+            build_outcome_memory([_outcome()]), [_review()], [_binding()]
+        )
+        aggregate = payload["aggregate"]
+        self.assertEqual(payload["joined_count"], 1)
+        self.assertEqual(aggregate["rules_realized_pnl_usd"], 25.0)
+        self.assertEqual(aggregate["ai_counterfactual_pnl_usd"], 0.0)
+        self.assertEqual(aggregate["incremental_pnl_before_cost_usd"], -25.0)
+        self.assertEqual(aggregate["incremental_pnl_net_cost_usd"], -25.25)
+        self.assertEqual(aggregate["conclusion"], "inconclusive")
+        self.assertFalse(aggregate["automatic_promotion"])
+
+    def test_agreement_preserves_rules_result_but_cost_is_incrementally_negative(self):
+        payload = build_counterfactual_scorecards(
+            build_outcome_memory([_outcome(realized_return_pct=-1.0)]),
+            [_review(decision="agree", cost=0.1)],
+            [_binding()],
+        )
+        aggregate = payload["aggregate"]
+        self.assertEqual(aggregate["rules_realized_pnl_usd"], -10.0)
+        self.assertEqual(aggregate["ai_counterfactual_pnl_usd"], -10.0)
+        self.assertEqual(aggregate["incremental_pnl_net_cost_usd"], -0.1)
+        self.assertIn("agree", payload["segments"]["agreement_state"])
+
+    def test_scorecard_fails_closed_without_exact_join(self):
+        cases = [
+            ([_review()], [], "missing_or_contradictory_execution_binding"),
+            ([_review()], [_binding(), _binding(execution_id="entry-2")], "missing_or_contradictory_execution_binding"),
+            ([{**_review(), "join_eligible": False}], [_binding()], "review_not_join_eligible"),
+            ([_review()], [_binding(execution_id="missing")], "canonical_outcome_missing"),
+            ([{**_review(), "rules_decision": "reject"}], [_binding()], "nonexecuted_rules_decision"),
+            ([_review(), _review()], [_binding()], "duplicate_review_identity"),
+        ]
+        memory = build_outcome_memory([_outcome()])
+        for reviews, bindings, reason in cases:
+            with self.subTest(reason=reason):
+                payload = build_counterfactual_scorecards(memory, reviews, bindings)
+                self.assertEqual(payload["joined_count"], 0)
+                self.assertEqual(payload["exclusions"][0]["reason"], reason)
+
+    def test_scorecard_revalidates_memory_and_rejects_untrusted_payload(self):
+        payload = build_counterfactual_scorecards(
+            {"version": "forged", "records": [_outcome()]},
+            [_review()],
+            [_binding()],
+        )
+        self.assertEqual(payload["joined_count"], 0)
+        self.assertEqual(payload["exclusions"][0]["reason"], "memory_version_untrusted")
+
+    def test_missing_exact_cost_keeps_net_metrics_inconclusive(self):
+        payload = build_counterfactual_scorecards(
+            build_outcome_memory([_outcome()]),
+            [_review(cost=None)],
+            [_binding()],
+            OutcomeMemoryConfig(min_scorecard_samples=2),
+        )
+        aggregate = payload["aggregate"]
+        self.assertFalse(aggregate["exact_cost_coverage_complete"])
+        self.assertIsNone(aggregate["inference_cost_usd"])
+        self.assertIsNone(aggregate["incremental_pnl_net_cost_usd"])
+        self.assertEqual(aggregate["conclusion"], "inconclusive")
+
+    def test_sufficient_diverse_sample_remains_observational_only(self):
+        outcomes, reviews, bindings = [], [], []
+        for index in range(4):
+            execution_id = f"entry-{index}"
+            candidate = f"candidate-{index}"
+            outcomes.append(_outcome(execution_id, symbol=f"SYM{index}"))
+            review = _review(candidate, decision="reject", cost=0.01)
+            review["cycle_id"] = f"cycle-{index}"
+            review["input_fingerprint"] = f"fingerprint-{index}"
+            binding = _binding(candidate, execution_id)
+            binding["cycle_id"] = f"cycle-{index}"
+            binding["input_fingerprint"] = f"fingerprint-{index}"
+            reviews.append(review)
+            bindings.append(binding)
+        payload = build_counterfactual_scorecards(
+            build_outcome_memory(outcomes),
+            reviews,
+            bindings,
+            OutcomeMemoryConfig(min_scorecard_samples=4, max_symbol_concentration=0.5),
+        )
+        self.assertEqual(payload["aggregate"]["conclusion"], "observational_only")
+        self.assertFalse(payload["authority"]["automatic_promotion"])
+        self.assertFalse(payload["authority"]["changes_rule_decisions"])
+
+    def test_config_and_limit_bounds_fail_closed(self):
+        with self.assertRaises(ValueError):
+            OutcomeMemoryConfig(max_records=0)
+        with self.assertRaises(ValueError):
+            find_comparable_outcomes(build_outcome_memory([]), {"side": "long"}, limit=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_shadow_ai_research_contract.py
+++ b/test_shadow_ai_research_contract.py
@@ -14,13 +14,13 @@ class ShadowAIResearchContractTests(unittest.TestCase):
     def setUpClass(cls):
         cls.contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
 
-    def test_stage_three_reviewer_has_no_execution_authority(self):
+    def test_stage_four_memory_has_no_execution_authority(self):
         contract = self.contract
         policy = contract["policy"]
 
         self.assertEqual(
             contract["implementation_stage"],
-            "stage_3_async_adversarial_reviewer",
+            "stage_4_canonical_outcome_memory_and_scorecards",
         )
         self.assertTrue(policy["paper_only"])
         self.assertTrue(policy["research_only"])
@@ -96,14 +96,26 @@ class ShadowAIResearchContractTests(unittest.TestCase):
         scorecard = self.contract["counterfactual_scorecard"]
 
         self.assertEqual(memory["primary_key"], "canonical_execution_id")
+        self.assertTrue(memory["implemented"])
+        self.assertFalse(memory["runtime_integrated"])
         self.assertTrue(memory["canonical_source_read_only"])
         self.assertTrue(memory["rebuildable_derived_index"])
+        self.assertFalse(memory["symbol_or_time_inferred_join_allowed"])
+        self.assertTrue(memory["exact_review_execution_binding_required"])
+        self.assertTrue(memory["integrity_qualified_path_evidence_required"])
         self.assertEqual(
             memory["missing_or_contradictory_evidence_behavior"],
             "fail_closed_no_join",
         )
         self.assertFalse(scorecard["execution_input"])
+        self.assertTrue(scorecard["implemented"])
+        self.assertFalse(scorecard["runtime_integrated"])
         self.assertTrue(scorecard["subtracts_inference_cost"])
+        self.assertEqual(
+            scorecard["missing_exact_cost_behavior"],
+            "net_metrics_null_and_inconclusive",
+        )
+        self.assertEqual(scorecard["sufficient_result_behavior"], "observational_only")
         self.assertFalse(scorecard["automatic_promotion"])
 
     def test_runtime_stages_require_every_governed_gate(self):


### PR DESCRIPTION
Advances Issue #157 Stage 4 with a runtime-disconnected, read-only canonical outcome-memory and AI-vs-rules scorecard library.

- requires integrity-qualified derived outcome rows keyed by immutable canonical execution ID
- forbids symbol/time lifecycle inference and requires exact review-to-execution bindings
- excludes missing, duplicate, or contradictory evidence fail-closed
- adds deterministic comparable-outcome retrieval
- calculates agreement/rejection counterfactual P&L and subtracts exact inference cost
- keeps incomplete, small, or concentrated evidence inconclusive and all sufficient results observational-only
- adds the entire shadow-AI invariant suite to impact-aware change-safety regression selection

No runtime hook, route, worker, provider transport, persistence owner, state/ledger write, execution input, strategy/risk/sizing change, or automatic promotion is introduced.

Local validation: 97 impact-aware/core/shadow tests passed; repository/Railway validation passed; structural/ownership/configuration/debt audits passed with zero new critical findings or warnings.

Closes the Stage 4 checklist portion of #157; Stage 5 remains separate.