### PR TITLE
Issue #157 Stage 5: bounded shadow-AI observability

### DIFF
--- a/POST_VALIDATION_SHADOW_AI_DESIGN.md
+++ b/POST_VALIDATION_SHADOW_AI_DESIGN.md
@@ -1,6 +1,6 @@
 # Post-Validation Shadow-AI Research Design
 
-Status: Stage 4 canonical outcome memory and scorecards implemented; runtime-disconnected
+Status: Stage 5 bounded observability implemented; reviewer/provider remain disabled
 Issue: #157  
 Runtime authority: unchanged; rules remain the sole execution authority
 
@@ -262,6 +262,28 @@ samples remain inconclusive. Even sufficient diverse evidence is labeled
 Read-only status/audit surfaces, source/cost/fallback telemetry, state-size and
 restart checks, settled Splendid acceptance, and a forward shadow evidence
 period. Any later authority discussion remains a separately authorized project.
+
+Implemented in `shadow_ai_observability.py` and
+`shadow_ai_evidence_store.py`. Runtime registration loads a separate research-
+evidence snapshot and exposes `/paper/shadow-ai-research-status` before the
+existing auto runner starts. The endpoint reports reviewer/worker state,
+decision and provider/model counts, source/citation coverage, fallbacks, token
+categories, exact inference cost coverage, and forward-evidence readiness.
+
+The evidence snapshot is capped at 500 records, 32 KB per record, and 8 MB
+overall. It uses canonical JSON, a SHA-256 checksum, atomic replacement, exact
+cycle/candidate/input identities, idempotent duplicate handling, and restart
+validation. Corruption or contradictory identity fails closed and is never
+overwritten automatically. Full prompts, raw reasoning/source bodies, secrets,
+and authorization values are rejected recursively. This file is neither
+portfolio state nor canonical execution evidence, and trading never reads it.
+
+The reviewer remains disabled by default with no bundled provider transport.
+Accordingly a clean disabled deployment writes no research records. Forward
+readiness requires an explicitly enabled/live worker, restart-valid evidence,
+at least 100 exact join-eligible records, no more than 20% unavailable results,
+and complete exact-cost coverage. Meeting those diagnostics still authorizes
+no promotion or execution behavior.
 
 ## Validation requirements
 

--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -50,6 +50,8 @@ SHADOW_AI_TESTS = (
     "test_shadow_ai_research_client.py",
     "test_shadow_ai_adversarial_reviewer.py",
     "test_shadow_ai_outcome_memory.py",
+    "test_shadow_ai_evidence_store.py",
+    "test_shadow_ai_observability.py",
 )
 
 

--- a/runtime_worker_registration.py
+++ b/runtime_worker_registration.py
@@ -14,7 +14,7 @@ from typing import Any, Dict
 
 import runtime_diagnostics as diagnostics
 
-VERSION = "runtime-worker-registration-2026-09-02-v7-shadow-ai-reviewer"
+VERSION = "runtime-worker-registration-2026-09-03-v8-shadow-ai-observability"
 _LOCK = threading.RLock()
 _REGISTERED_CORE_IDS: set[int] = set()
 _KICKOFF_STARTED: set[int] = set()
@@ -164,6 +164,8 @@ def register(core: Any, *, research_isolated: bool = True) -> Dict[str, Any]:
             import daily_audit_repair_overlay
             import run_report_guard
             import shadow_ai_adversarial_reviewer
+            import shadow_ai_evidence_store
+            import shadow_ai_observability
             import performance_risk_activation_guard
             import regime_integrity_underdeployment
             import regime_integrity_cache_guard
@@ -265,6 +267,10 @@ def register(core: Any, *, research_isolated: bool = True) -> Dict[str, Any]:
                     + str(run_report_guard_apply)
                 )
 
+            # Configure bounded research-evidence persistence and its read-only
+            # route before the disabled-by-default reviewer is installed.  This
+            # store is not portfolio state or canonical execution evidence.
+            shadow_ai_observability_result = shadow_ai_observability.install(core.app)
             shadow_ai_reviewer = shadow_ai_adversarial_reviewer.install()
 
             auto_runner = _start_auto_runner(core)
@@ -299,6 +305,8 @@ def register(core: Any, *, research_isolated: bool = True) -> Dict[str, Any]:
                 performance_audit_composition_guard.VERSION,
                 run_report_guard.VERSION,
                 shadow_ai_adversarial_reviewer.VERSION,
+                shadow_ai_evidence_store.VERSION,
+                shadow_ai_observability.VERSION,
             ]
             _REGISTERED_CORE_IDS.add(id(core))
             _LAST = {
@@ -315,6 +323,7 @@ def register(core: Any, *, research_isolated: bool = True) -> Dict[str, Any]:
                 "paper_underdeployment_time_guard": entry_time_guard_result,
                 "run_cycle_observer": run_report_guard_apply,
                 "shadow_ai_adversarial_reviewer": shadow_ai_reviewer,
+                "shadow_ai_observability": shadow_ai_observability_result,
                 "auto_runner": auto_runner,
             }
             diagnostics.record_module_event(

--- a/shadow_ai_adversarial_reviewer.py
+++ b/shadow_ai_adversarial_reviewer.py
@@ -50,11 +50,13 @@ class ShadowAIAdversarialReviewer:
         provider: ShadowAIProvider | None,
         config: ShadowAIReviewerConfig | None = None,
         now: Callable[[], datetime] | None = None,
+        evidence_sink: Callable[[Mapping[str, Any]], Mapping[str, Any]] | None = None,
     ) -> None:
         self.config = config or ShadowAIReviewerConfig()
         self.client = client
         self.provider = provider
         self._now = now or (lambda: datetime.now(timezone.utc))
+        self._evidence_sink = evidence_sink
         self._queue: queue.Queue[bytes | None] = queue.Queue(
             maxsize=self.config.max_items
         )
@@ -72,6 +74,8 @@ class ShadowAIAdversarialReviewer:
             "results_join_eligible": 0,
             "results_invalid_or_unavailable": 0,
             "snapshot_errors": 0,
+            "evidence_persisted": 0,
+            "evidence_persistence_errors": 0,
         }
         self._last_drop_reason: str | None = None
 
@@ -212,6 +216,7 @@ class ShadowAIAdversarialReviewer:
                         self._counters["results_join_eligible"] += 1
                     else:
                         self._counters["results_invalid_or_unavailable"] += 1
+                self._persist_evidence(record)
             except Exception as exc:
                 with self._lock:
                     self._counters["requests_completed"] += 1
@@ -223,6 +228,27 @@ class ShadowAIAdversarialReviewer:
                     }
             finally:
                 self._queue.task_done()
+
+    def configure_evidence_sink(
+        self,
+        sink: Callable[[Mapping[str, Any]], Mapping[str, Any]] | None,
+    ) -> None:
+        with self._lock:
+            self._evidence_sink = sink
+
+    def _persist_evidence(self, record: Mapping[str, Any]) -> None:
+        with self._lock:
+            sink = self._evidence_sink
+        if sink is None:
+            return
+        try:
+            result = sink(record)
+            persisted = result.get("status") in {"persisted", "deduplicated"}
+        except Exception:
+            persisted = False
+        with self._lock:
+            key = "evidence_persisted" if persisted else "evidence_persistence_errors"
+            self._counters[key] += 1
 
     def _classify_result(
         self,
@@ -378,6 +404,7 @@ class ShadowAIAdversarialReviewer:
 
 
 _GLOBAL_LOCK = threading.RLock()
+_EVIDENCE_SINK: Callable[[Mapping[str, Any]], Mapping[str, Any]] | None = None
 _REVIEWER = ShadowAIAdversarialReviewer(
     client=ShadowAIResearchClient(),
     provider=None,
@@ -398,6 +425,7 @@ def install(
                 client=client or ShadowAIResearchClient(),
                 provider=provider,
                 config=config,
+                evidence_sink=_EVIDENCE_SINK,
             )
         return _REVIEWER.start()
 
@@ -408,3 +436,12 @@ def observe_cycle(report: Mapping[str, Any]) -> dict[str, Any]:
 
 def status_payload() -> dict[str, Any]:
     return _REVIEWER.status_payload()
+
+
+def configure_evidence_sink(
+    sink: Callable[[Mapping[str, Any]], Mapping[str, Any]] | None,
+) -> None:
+    global _EVIDENCE_SINK
+    with _GLOBAL_LOCK:
+        _EVIDENCE_SINK = sink
+        _REVIEWER.configure_evidence_sink(sink)

--- a/shadow_ai_evidence_store.py
+++ b/shadow_ai_evidence_store.py
@@ -1,0 +1,269 @@
+"""Atomic bounded persistence for non-authoritative shadow-AI evidence.
+
+The store is separate from portfolio state and the canonical execution ledger.
+It accepts only the already-sanitized reviewer record, keeps a bounded snapshot,
+and fails closed on checksum or identity conflicts.  No trading code reads this
+file as an execution input.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+
+VERSION = "shadow-ai-evidence-store-2026-09-03-v1"
+SCHEMA_VERSION = "shadow-ai-evidence-v1"
+FORBIDDEN_KEYS = {
+    "api_key",
+    "authorization",
+    "full_prompt",
+    "prompt",
+    "raw_reasoning",
+    "raw_source_body",
+    "secret",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceStoreConfig:
+    path: str
+    max_records: int = 500
+    max_record_bytes: int = 32_000
+    max_store_bytes: int = 8_000_000
+
+    def __post_init__(self) -> None:
+        if not str(self.path).strip():
+            raise ValueError("path is required")
+        if not 1 <= int(self.max_records) <= 5_000:
+            raise ValueError("max_records must be in [1, 5000]")
+        if not 1_024 <= int(self.max_record_bytes) <= 128_000:
+            raise ValueError("max_record_bytes must be in [1024, 128000]")
+        if not 65_536 <= int(self.max_store_bytes) <= 32_000_000:
+            raise ValueError("max_store_bytes must be in [65536, 32000000]")
+
+
+def default_evidence_path() -> str:
+    root = (
+        os.environ.get("STATE_DIR")
+        or os.environ.get("PERSISTENT_STATE_DIR")
+        or os.environ.get("RAILWAY_VOLUME_MOUNT_PATH")
+        or "."
+    )
+    return str(Path(root) / "shadow_ai_research_evidence.json")
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _checksum(records: list[dict[str, Any]]) -> str:
+    return hashlib.sha256(_canonical_json(records).encode("utf-8")).hexdigest()
+
+
+def _forbidden_key(value: Any) -> str | None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            normalized = str(key).strip().lower()
+            if (
+                normalized in FORBIDDEN_KEYS
+                or normalized.endswith(
+                    (
+                        "_api_key",
+                        "_authorization",
+                        "_secret",
+                        "_password",
+                        "_credential",
+                        "_prompt",
+                    )
+                )
+                or normalized in {"access_token", "refresh_token", "bearer_token"}
+            ):
+                return normalized
+            nested = _forbidden_key(item)
+            if nested:
+                return nested
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            nested = _forbidden_key(item)
+            if nested:
+                return nested
+    return None
+
+
+def _identity(record: Mapping[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(record.get("cycle_id") or "").strip(),
+        str(record.get("candidate_id") or "").strip(),
+        str(record.get("input_fingerprint") or "").strip(),
+    )
+
+
+class ShadowAIEvidenceStore:
+    def __init__(self, config: EvidenceStoreConfig) -> None:
+        self.config = config
+        self._lock = threading.RLock()
+        self._records: list[dict[str, Any]] = []
+        self._loaded = False
+        self._integrity_error: str | None = None
+        self._writes = 0
+        self._deduplicated = 0
+        self._rejected = 0
+
+    def load(self) -> dict[str, Any]:
+        with self._lock:
+            path = Path(self.config.path)
+            if not path.exists():
+                self._records = []
+                self._loaded = True
+                self._integrity_error = None
+                return self.status_payload()
+            try:
+                if path.stat().st_size > self.config.max_store_bytes:
+                    raise ValueError("store_size_bound_exceeded")
+                payload = json.loads(path.read_text(encoding="utf-8"))
+                if not isinstance(payload, dict):
+                    raise ValueError("envelope_not_mapping")
+                if payload.get("schema_version") != SCHEMA_VERSION:
+                    raise ValueError("schema_version_mismatch")
+                records = payload.get("records")
+                if not isinstance(records, list):
+                    raise ValueError("records_not_list")
+                if len(records) > self.config.max_records:
+                    raise ValueError("retention_bound_exceeded")
+                if not all(isinstance(row, dict) for row in records):
+                    raise ValueError("record_not_mapping")
+                if any(
+                    len(_canonical_json(row).encode("utf-8"))
+                    > self.config.max_record_bytes
+                    for row in records
+                ):
+                    raise ValueError("record_size_bound_exceeded")
+                if payload.get("checksum") != _checksum(records):
+                    raise ValueError("checksum_mismatch")
+                identities = [_identity(row) for row in records]
+                if any(not all(identity) for identity in identities):
+                    raise ValueError("record_identity_missing")
+                if len(identities) != len(set(identities)):
+                    raise ValueError("duplicate_record_identity")
+                if any(_forbidden_key(row) for row in records):
+                    raise ValueError("forbidden_content_key")
+                self._records = json.loads(_canonical_json(records))
+                self._loaded = True
+                self._integrity_error = None
+            except Exception as exc:
+                self._records = []
+                self._loaded = True
+                self._integrity_error = f"{type(exc).__name__}:{exc}"
+            return self.status_payload()
+
+    def append(self, record: Mapping[str, Any]) -> dict[str, Any]:
+        with self._lock:
+            if not self._loaded:
+                self.load()
+            if self._integrity_error:
+                self._rejected += 1
+                return {"status": "rejected", "reason": "store_integrity_error"}
+            if not isinstance(record, Mapping):
+                self._rejected += 1
+                return {"status": "rejected", "reason": "record_not_mapping"}
+            identity = _identity(record)
+            if not all(identity):
+                self._rejected += 1
+                return {"status": "rejected", "reason": "record_identity_missing"}
+            forbidden = _forbidden_key(record)
+            if forbidden:
+                self._rejected += 1
+                return {"status": "rejected", "reason": f"forbidden_key:{forbidden}"}
+            try:
+                frozen = _canonical_json(record)
+            except (TypeError, ValueError):
+                self._rejected += 1
+                return {"status": "rejected", "reason": "record_not_json_safe"}
+            if len(frozen.encode("utf-8")) > self.config.max_record_bytes:
+                self._rejected += 1
+                return {"status": "rejected", "reason": "record_too_large"}
+            normalized = json.loads(frozen)
+            existing = [row for row in self._records if _identity(row) == identity]
+            if existing:
+                if _canonical_json(existing[0]) == frozen:
+                    self._deduplicated += 1
+                    return {"status": "deduplicated", "record_count": len(self._records)}
+                self._rejected += 1
+                return {"status": "rejected", "reason": "contradictory_record_identity"}
+            candidate = (self._records + [normalized])[-self.config.max_records :]
+            try:
+                self._write(candidate)
+            except Exception as exc:
+                self._rejected += 1
+                return {"status": "rejected", "reason": f"write_failed:{type(exc).__name__}"}
+            self._records = candidate
+            self._writes += 1
+            return {"status": "persisted", "record_count": len(self._records)}
+
+    def records_snapshot(self) -> tuple[dict[str, Any], ...]:
+        with self._lock:
+            if not self._loaded:
+                self.load()
+            return tuple(json.loads(_canonical_json(row)) for row in self._records)
+
+    def status_payload(self) -> dict[str, Any]:
+        with self._lock:
+            path = Path(self.config.path)
+            return {
+                "status": "ok" if not self._integrity_error else "error",
+                "overall": "pass" if not self._integrity_error else "warn",
+                "type": "shadow_ai_evidence_store_status",
+                "version": VERSION,
+                "schema_version": SCHEMA_VERSION,
+                "loaded": self._loaded,
+                "integrity_valid": self._integrity_error is None,
+                "integrity_error": self._integrity_error,
+                "record_count": len(self._records),
+                "max_records": self.config.max_records,
+                "max_record_bytes": self.config.max_record_bytes,
+                "max_store_bytes": self.config.max_store_bytes,
+                "file_exists": path.exists(),
+                "file_bytes": path.stat().st_size if path.exists() else 0,
+                "restart_loadable": bool(self._loaded and not self._integrity_error),
+                "writes": self._writes,
+                "deduplicated": self._deduplicated,
+                "rejected": self._rejected,
+                "authority": {
+                    "research_evidence_only": True,
+                    "separate_from_portfolio_state": True,
+                    "separate_from_canonical_ledger": True,
+                    "changes_trading_behavior": False,
+                    "execution_input": False,
+                    "places_or_cancels_orders": False,
+                },
+            }
+
+    def _write(self, records: list[dict[str, Any]]) -> None:
+        path = Path(self.config.path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        envelope = {
+            "schema_version": SCHEMA_VERSION,
+            "version": VERSION,
+            "checksum": _checksum(records),
+            "records": records,
+        }
+        data = (_canonical_json(envelope) + "\n").encode("utf-8")
+        if len(data) > self.config.max_store_bytes:
+            raise ValueError("store_size_bound_exceeded")
+        temporary = path.with_name(path.name + ".tmp")
+        with open(temporary, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)

--- a/shadow_ai_observability.py
+++ b/shadow_ai_observability.py
@@ -1,0 +1,186 @@
+"""Read-only Stage 5 observability for the shadow-AI research subsystem."""
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Mapping
+
+import shadow_ai_adversarial_reviewer as reviewer
+from shadow_ai_evidence_store import (
+    EvidenceStoreConfig,
+    ShadowAIEvidenceStore,
+    VERSION as STORE_VERSION,
+    default_evidence_path,
+)
+
+
+VERSION = "shadow-ai-observability-2026-09-03-v1"
+MIN_FORWARD_RESULTS = 100
+MAX_UNAVAILABLE_RATE = 0.20
+_REGISTERED_APP_IDS: set[int] = set()
+_STORE = ShadowAIEvidenceStore(EvidenceStoreConfig(path=default_evidence_path()))
+
+
+def _nonnegative_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+    return parsed if parsed >= 0 else 0
+
+
+def _telemetry(records: tuple[dict[str, Any], ...]) -> dict[str, Any]:
+    decisions: Counter[str] = Counter()
+    providers: Counter[str] = Counter()
+    models: Counter[str] = Counter()
+    prompt_tokens = completion_tokens = reasoning_tokens = cached_tokens = 0
+    citations = source_count = fallback_count = exact_cost_rows = 0
+    total_cost = 0.0
+    join_eligible = 0
+    unique_cycles: set[str] = set()
+    for record in records:
+        result = record.get("result") if isinstance(record.get("result"), Mapping) else {}
+        telemetry = result.get("telemetry") if isinstance(result.get("telemetry"), Mapping) else {}
+        decision = str(result.get("decision") or "unknown")
+        decisions[decision] += 1
+        providers[str(telemetry.get("provider") or "unknown")] += 1
+        models[str(telemetry.get("model") or "unknown")] += 1
+        prompt_tokens += _nonnegative_int(telemetry.get("prompt_tokens"))
+        completion_tokens += _nonnegative_int(telemetry.get("completion_tokens"))
+        reasoning_tokens += _nonnegative_int(telemetry.get("reasoning_tokens"))
+        cached_tokens += _nonnegative_int(telemetry.get("cached_tokens"))
+        source_count += _nonnegative_int(telemetry.get("source_count"))
+        result_citations = result.get("citations")
+        citations += len(result_citations) if isinstance(result_citations, list) else 0
+        fallback_count += int(bool(result.get("fallback_used")))
+        cost = telemetry.get("cost_usd_exact")
+        if isinstance(cost, (int, float)) and not isinstance(cost, bool) and cost >= 0:
+            exact_cost_rows += 1
+            total_cost += float(cost)
+        join_eligible += int(record.get("join_eligible") is True)
+        if record.get("cycle_id"):
+            unique_cycles.add(str(record.get("cycle_id")))
+    count = len(records)
+    unavailable = decisions.get("unavailable", 0)
+    return {
+        "record_count": count,
+        "unique_cycle_count": len(unique_cycles),
+        "join_eligible_count": join_eligible,
+        "decision_counts": dict(sorted(decisions.items())),
+        "provider_counts": dict(sorted(providers.items())),
+        "model_counts": dict(sorted(models.items())),
+        "fallback_count": fallback_count,
+        "fallback_rate": round(fallback_count / count, 6) if count else None,
+        "unavailable_count": unavailable,
+        "unavailable_rate": round(unavailable / count, 6) if count else None,
+        "citation_count": citations,
+        "provider_source_count": source_count,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "reasoning_tokens": reasoning_tokens,
+        "cached_tokens": cached_tokens,
+        "exact_cost_rows": exact_cost_rows,
+        "exact_cost_coverage_complete": bool(count and exact_cost_rows == count),
+        "total_inference_cost_usd_exact": round(total_cost, 8) if count and exact_cost_rows == count else None,
+    }
+
+
+def build_payload() -> dict[str, Any]:
+    reviewer_status = reviewer.status_payload()
+    store_status = _STORE.status_payload()
+    records = _STORE.records_snapshot() if store_status.get("integrity_valid") else ()
+    telemetry = _telemetry(records)
+    reviewer_enabled = reviewer_status.get("enabled") is True
+    worker_alive = reviewer_status.get("worker_alive") is True
+    enough_results = telemetry["join_eligible_count"] >= MIN_FORWARD_RESULTS
+    unavailable_rate = telemetry["unavailable_rate"]
+    availability_ok = unavailable_rate is not None and unavailable_rate <= MAX_UNAVAILABLE_RATE
+    cost_complete = telemetry["exact_cost_coverage_complete"]
+    durable = store_status.get("restart_loadable") is True
+    forward_eligible = bool(
+        reviewer_enabled
+        and worker_alive
+        and durable
+        and enough_results
+        and availability_ok
+        and cost_complete
+    )
+    if not reviewer_enabled:
+        evidence_state = "not_started_reviewer_disabled"
+    elif not durable:
+        evidence_state = "blocked_store_integrity"
+    elif not enough_results:
+        evidence_state = "collecting"
+    elif not availability_ok or not cost_complete:
+        evidence_state = "inconclusive_quality_or_cost_coverage"
+    else:
+        evidence_state = "forward_observation_threshold_met"
+    overall = "warn" if store_status.get("integrity_valid") is False else "pass"
+    return {
+        "status": "ok" if overall == "pass" else "warn",
+        "overall": overall,
+        "type": "shadow_ai_research_observability",
+        "version": VERSION,
+        "reviewer": reviewer_status,
+        "evidence_store": store_status,
+        "telemetry": telemetry,
+        "outcome_memory": {
+            "implemented": True,
+            "runtime_integrated": False,
+            "canonical_sources_read_only": True,
+            "exact_execution_binding_required": True,
+        },
+        "counterfactual_scorecards": {
+            "implemented": True,
+            "runtime_integrated": False,
+            "automatic_promotion": False,
+            "state": "awaiting_exact_completed_outcome_bindings",
+        },
+        "forward_evidence": {
+            "state": evidence_state,
+            "eligible": forward_eligible,
+            "minimum_join_eligible_results": MIN_FORWARD_RESULTS,
+            "maximum_unavailable_rate": MAX_UNAVAILABLE_RATE,
+            "enough_results": enough_results,
+            "availability_ok": availability_ok,
+            "exact_cost_coverage_complete": cost_complete,
+            "restart_durable": durable,
+            "promotion_authorized": False,
+        },
+        "authority": {
+            "read_only_observability": True,
+            "rules_engine_sole_execution_authority": True,
+            "execution_input": False,
+            "changes_strategy_or_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "changes_accounting_or_canonical_history": False,
+            "places_or_cancels_orders": False,
+            "automatic_promotion": False,
+        },
+    }
+
+
+def install(flask_app: Any = None) -> dict[str, Any]:
+    store_status = _STORE.load()
+    reviewer.configure_evidence_sink(_STORE.append)
+    if flask_app is not None and id(flask_app) not in _REGISTERED_APP_IDS:
+        from flask import jsonify
+
+        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+        if "/paper/shadow-ai-research-status" not in existing:
+            flask_app.add_url_rule(
+                "/paper/shadow-ai-research-status",
+                "shadow_ai_research_status",
+                lambda: jsonify(build_payload()),
+            )
+        _REGISTERED_APP_IDS.add(id(flask_app))
+    return {
+        "status": "ok" if store_status.get("integrity_valid") else "warn",
+        "version": VERSION,
+        "store_version": STORE_VERSION,
+        "route_registered": flask_app is not None,
+        "reviewer_evidence_sink_configured": True,
+        "reviewer_enabled": reviewer.status_payload().get("enabled") is True,
+        "execution_input": False,
+    }

--- a/shadow_ai_research_contract.json
+++ b/shadow_ai_research_contract.json
@@ -1,6 +1,6 @@
 {
-  "version": "shadow-ai-research-contract-2026-09-02-v4-outcome-memory",
-  "implementation_stage": "stage_4_canonical_outcome_memory_and_scorecards",
+  "version": "shadow-ai-research-contract-2026-09-03-v5-observability",
+  "implementation_stage": "stage_5_observability_and_forward_evidence",
   "policy": {
     "paper_only": true,
     "research_only": true,
@@ -213,6 +213,34 @@
     "missing_exact_cost_behavior": "net_metrics_null_and_inconclusive",
     "sufficient_result_behavior": "observational_only",
     "automatic_promotion": false
+  },
+  "observability": {
+    "implemented": true,
+    "runtime_integrated": true,
+    "module": "shadow_ai_observability.py",
+    "read_only_route": "/paper/shadow-ai-research-status",
+    "evidence_store_module": "shadow_ai_evidence_store.py",
+    "separate_from_portfolio_state": true,
+    "separate_from_canonical_ledger": true,
+    "atomic_replace": true,
+    "checksum_validated_on_restart": true,
+    "corrupt_store_behavior": "fail_closed_no_overwrite",
+    "max_records": 500,
+    "max_record_bytes": 32000,
+    "max_store_bytes": 8000000,
+    "disabled_reviewer_writes_records": false,
+    "execution_reads_evidence_store": false,
+    "automatic_promotion": false
+  },
+  "forward_evidence": {
+    "minimum_join_eligible_results": 100,
+    "maximum_unavailable_rate": 0.2,
+    "exact_cost_coverage_required": true,
+    "restart_durability_required": true,
+    "reviewer_enabled_required": true,
+    "worker_alive_required": true,
+    "threshold_authorizes_promotion": false,
+    "provider_transport_enablement_is_separate": true
   },
   "retention": {
     "bounded": true,

--- a/test_change_safety_audit.py
+++ b/test_change_safety_audit.py
@@ -215,6 +215,8 @@ class ChangeSafetyAuditTests(unittest.TestCase):
             "test_shadow_ai_research_client.py",
             "test_shadow_ai_adversarial_reviewer.py",
             "test_shadow_ai_outcome_memory.py",
+            "test_shadow_ai_evidence_store.py",
+            "test_shadow_ai_observability.py",
         ):
             self.assertIn(shadow_test, tests)
 

--- a/test_self_check_runtime_classification.py
+++ b/test_self_check_runtime_classification.py
@@ -246,9 +246,14 @@ class SelfCheckRuntimeClassificationTests(unittest.TestCase):
             "shadow_ai_reviewer = shadow_ai_adversarial_reviewer.install()",
             observer_index,
         )
+        observability_index = source.index(
+            "shadow_ai_observability_result = shadow_ai_observability.install(core.app)",
+            observer_index,
+        )
         runner_index = source.index("auto_runner = _start_auto_runner(core)", observer_index)
         self.assertLess(diagnostics_index, observer_index)
-        self.assertLess(observer_index, reviewer_index)
+        self.assertLess(observer_index, observability_index)
+        self.assertLess(observability_index, reviewer_index)
         self.assertLess(reviewer_index, runner_index)
 
 

--- a/test_shadow_ai_adversarial_reviewer.py
+++ b/test_shadow_ai_adversarial_reviewer.py
@@ -9,6 +9,7 @@ from shadow_ai_adversarial_reviewer import (
     ShadowAIAdversarialReviewer,
     ShadowAIReviewerConfig,
 )
+import shadow_ai_adversarial_reviewer as reviewer_module
 from shadow_ai_research_client import (
     SCHEMA_VERSION,
     ShadowAIClientConfig,
@@ -215,6 +216,56 @@ class ShadowAIAdversarialReviewerTests(unittest.TestCase):
             ShadowAIReviewerConfig(max_requests_per_cycle=11)
         with self.assertRaises(ValueError):
             ShadowAIReviewerConfig(result_history_limit=501)
+
+    def test_completed_record_is_persisted_without_execution_wait(self):
+        persisted = []
+        reviewer = self.enabled_reviewer(lambda payload, _timeout: provider_response(payload))
+        reviewer.configure_evidence_sink(
+            lambda value: persisted.append(dict(value)) or {"status": "persisted"}
+        )
+        try:
+            reviewer.start()
+            reviewer.enqueue_report(report())
+            self.wait_completed(reviewer)
+            self.assertEqual(len(persisted), 1)
+            self.assertEqual(reviewer.status_payload()["counters"]["evidence_persisted"], 1)
+            self.assertFalse(persisted[0]["authority"]["execution_input"])
+        finally:
+            reviewer.stop()
+
+    def test_evidence_sink_failure_does_not_stop_worker(self):
+        def broken_sink(_value):
+            raise OSError("simulated persistence failure")
+
+        reviewer = self.enabled_reviewer(lambda payload, _timeout: provider_response(payload))
+        reviewer.configure_evidence_sink(broken_sink)
+        try:
+            reviewer.start()
+            reviewer.enqueue_report(report())
+            self.wait_completed(reviewer)
+            status = reviewer.status_payload()
+            self.assertEqual(status["counters"]["evidence_persistence_errors"], 1)
+            self.assertTrue(status["worker_alive"])
+            self.assertEqual(status["counters"]["results_join_eligible"], 1)
+        finally:
+            reviewer.stop()
+
+    def test_module_sink_survives_later_reconfiguration(self):
+        sink = lambda _value: {"status": "persisted"}
+        prior_reviewer = reviewer_module._REVIEWER
+        prior_sink = reviewer_module._EVIDENCE_SINK
+        try:
+            reviewer_module.configure_evidence_sink(sink)
+            reviewer_module.install(
+                client=ShadowAIResearchClient(),
+                provider=None,
+                config=ShadowAIReviewerConfig(enabled=False),
+            )
+            self.assertIs(reviewer_module._REVIEWER._evidence_sink, sink)
+        finally:
+            reviewer_module._REVIEWER.stop()
+            reviewer_module._REVIEWER = prior_reviewer
+            reviewer_module._EVIDENCE_SINK = prior_sink
 
 
 if __name__ == "__main__":

--- a/test_shadow_ai_evidence_store.py
+++ b/test_shadow_ai_evidence_store.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from shadow_ai_evidence_store import EvidenceStoreConfig, ShadowAIEvidenceStore
+
+
+def record(index: int = 1) -> dict:
+    return {
+        "cycle_id": f"cycle-{index}",
+        "candidate_id": f"TEST{index}:long",
+        "input_fingerprint": f"fingerprint-{index}",
+        "join_eligible": True,
+        "result": {
+            "decision": "agree",
+            "citations": [],
+            "fallback_used": False,
+            "telemetry": {"provider": "fake", "model": "fake-v1", "cost_usd_exact": 0.01},
+        },
+    }
+
+
+class ShadowAIEvidenceStoreTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.directory = tempfile.TemporaryDirectory()
+        self.path = str(Path(self.directory.name) / "evidence.json")
+
+    def tearDown(self) -> None:
+        self.directory.cleanup()
+
+    def store(self, **overrides) -> ShadowAIEvidenceStore:
+        return ShadowAIEvidenceStore(EvidenceStoreConfig(path=self.path, **overrides))
+
+    def test_missing_store_loads_as_valid_empty_without_creating_file(self):
+        status = self.store().load()
+        self.assertTrue(status["integrity_valid"])
+        self.assertTrue(status["restart_loadable"])
+        self.assertEqual(status["record_count"], 0)
+        self.assertFalse(Path(self.path).exists())
+
+    def test_atomic_snapshot_is_restart_loadable(self):
+        first = self.store()
+        self.assertEqual(first.append(record())["status"], "persisted")
+        restarted = self.store()
+        status = restarted.load()
+        self.assertTrue(status["integrity_valid"])
+        self.assertEqual(restarted.records_snapshot(), (record(),))
+        self.assertFalse(Path(self.path + ".tmp").exists())
+
+    def test_retention_is_bounded(self):
+        store = self.store(max_records=2)
+        for index in range(1, 4):
+            self.assertEqual(store.append(record(index))["status"], "persisted")
+        self.assertEqual([row["cycle_id"] for row in store.records_snapshot()], ["cycle-2", "cycle-3"])
+
+    def test_duplicate_is_idempotent_and_conflict_fails_closed(self):
+        store = self.store()
+        store.append(record())
+        self.assertEqual(store.append(record())["status"], "deduplicated")
+        changed = record()
+        changed["result"]["decision"] = "reject"
+        rejected = store.append(changed)
+        self.assertEqual(rejected, {"status": "rejected", "reason": "contradictory_record_identity"})
+
+    def test_corrupt_checksum_is_not_overwritten(self):
+        store = self.store()
+        store.append(record())
+        payload = json.loads(Path(self.path).read_text(encoding="utf-8"))
+        payload["records"][0]["join_eligible"] = False
+        Path(self.path).write_text(json.dumps(payload), encoding="utf-8")
+        before = Path(self.path).read_bytes()
+
+        restarted = self.store()
+        status = restarted.load()
+        self.assertFalse(status["integrity_valid"])
+        self.assertEqual(restarted.append(record(2))["reason"], "store_integrity_error")
+        self.assertEqual(Path(self.path).read_bytes(), before)
+
+    def test_forbidden_and_oversized_records_are_rejected(self):
+        store = self.store(max_record_bytes=1_024)
+        forbidden = record()
+        forbidden["result"]["prompt"] = "do not persist"
+        self.assertIn("forbidden_key", store.append(forbidden)["reason"])
+        secret = record(2)
+        secret["result"]["access_token"] = "do not persist"
+        self.assertIn("forbidden_key", store.append(secret)["reason"])
+        oversized = record(3)
+        oversized["result"]["risk_factors"] = ["x" * 2_000]
+        self.assertEqual(store.append(oversized)["reason"], "record_too_large")
+
+    def test_store_status_has_no_trading_authority(self):
+        authority = self.store().load()["authority"]
+        self.assertTrue(authority["research_evidence_only"])
+        self.assertTrue(authority["separate_from_portfolio_state"])
+        self.assertTrue(authority["separate_from_canonical_ledger"])
+        self.assertFalse(authority["execution_input"])
+        self.assertFalse(authority["places_or_cancels_orders"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_shadow_ai_observability.py
+++ b/test_shadow_ai_observability.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import shadow_ai_observability as observability
+from shadow_ai_evidence_store import EvidenceStoreConfig, ShadowAIEvidenceStore
+
+
+def evidence(index: int, *, decision: str = "agree", cost=0.01) -> dict:
+    return {
+        "cycle_id": f"cycle-{index}",
+        "candidate_id": f"TEST{index}:long",
+        "input_fingerprint": f"fingerprint-{index}",
+        "join_eligible": decision != "unavailable",
+        "result": {
+            "decision": decision,
+            "fallback_used": decision == "unavailable",
+            "citations": [{"url": "https://example.com"}],
+            "telemetry": {
+                "provider": "fake",
+                "model": "fake-v1",
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "reasoning_tokens": 2,
+                "cached_tokens": 3,
+                "source_count": 1,
+                "cost_usd_exact": cost,
+            },
+        },
+    }
+
+
+class ShadowAIObservabilityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.directory = tempfile.TemporaryDirectory()
+        self.store = ShadowAIEvidenceStore(
+            EvidenceStoreConfig(path=str(Path(self.directory.name) / "evidence.json"))
+        )
+        self.store.load()
+        self.store_patch = mock.patch.object(observability, "_STORE", self.store)
+        self.store_patch.start()
+
+    def tearDown(self) -> None:
+        self.store_patch.stop()
+        self.directory.cleanup()
+
+    def reviewer_status(self, enabled=False, alive=False):
+        return {
+            "enabled": enabled,
+            "worker_alive": alive,
+            "worker_count": int(alive),
+            "authority": {"places_or_cancels_orders": False},
+        }
+
+    def test_disabled_empty_state_is_read_only_and_not_started(self):
+        with mock.patch.object(observability.reviewer, "status_payload", return_value=self.reviewer_status()):
+            payload = observability.build_payload()
+        self.assertEqual(payload["overall"], "pass")
+        self.assertEqual(payload["forward_evidence"]["state"], "not_started_reviewer_disabled")
+        self.assertFalse(payload["forward_evidence"]["eligible"])
+        self.assertFalse(payload["authority"]["execution_input"])
+        self.assertFalse(payload["authority"]["places_or_cancels_orders"])
+
+    def test_telemetry_aggregates_sources_tokens_fallbacks_and_exact_cost(self):
+        self.store.append(evidence(1))
+        self.store.append(evidence(2, decision="unavailable"))
+        with mock.patch.object(observability.reviewer, "status_payload", return_value=self.reviewer_status(True, True)):
+            telemetry = observability.build_payload()["telemetry"]
+        self.assertEqual(telemetry["record_count"], 2)
+        self.assertEqual(telemetry["citation_count"], 2)
+        self.assertEqual(telemetry["provider_source_count"], 2)
+        self.assertEqual(telemetry["fallback_count"], 1)
+        self.assertEqual(telemetry["prompt_tokens"], 20)
+        self.assertEqual(telemetry["total_inference_cost_usd_exact"], 0.02)
+
+    def test_threshold_never_authorizes_promotion(self):
+        for index in range(observability.MIN_FORWARD_RESULTS):
+            self.store.append(evidence(index))
+        with mock.patch.object(observability.reviewer, "status_payload", return_value=self.reviewer_status(True, True)):
+            payload = observability.build_payload()
+        self.assertTrue(payload["forward_evidence"]["eligible"])
+        self.assertFalse(payload["forward_evidence"]["promotion_authorized"])
+        self.assertFalse(payload["counterfactual_scorecards"]["automatic_promotion"])
+
+    def test_missing_exact_cost_remains_inconclusive(self):
+        for index in range(observability.MIN_FORWARD_RESULTS):
+            self.store.append(evidence(index, cost=None))
+        with mock.patch.object(observability.reviewer, "status_payload", return_value=self.reviewer_status(True, True)):
+            payload = observability.build_payload()
+        self.assertFalse(payload["forward_evidence"]["eligible"])
+        self.assertEqual(payload["forward_evidence"]["state"], "inconclusive_quality_or_cost_coverage")
+
+    def test_malformed_optional_token_telemetry_does_not_break_status(self):
+        row = evidence(1)
+        row["result"]["telemetry"]["prompt_tokens"] = "invalid"
+        self.store.append(row)
+        with mock.patch.object(observability.reviewer, "status_payload", return_value=self.reviewer_status(True, True)):
+            telemetry = observability.build_payload()["telemetry"]
+        self.assertEqual(telemetry["prompt_tokens"], 0)
+
+    def test_install_registers_read_only_route_and_sink(self):
+        class Rules:
+            def __init__(self, app):
+                self.app = app
+
+            def iter_rules(self):
+                return [types.SimpleNamespace(rule=path) for path in self.app.routes]
+
+        class App:
+            def __init__(self):
+                self.routes = {}
+                self.url_map = Rules(self)
+
+            def add_url_rule(self, path, _endpoint, function):
+                self.routes[path] = function
+
+        app = App()
+        fake_flask = types.SimpleNamespace(jsonify=lambda value: value)
+        with mock.patch.dict("sys.modules", {"flask": fake_flask}), mock.patch.object(
+            observability.reviewer, "configure_evidence_sink"
+        ) as configure, mock.patch.object(
+            observability.reviewer, "status_payload", return_value=self.reviewer_status()
+        ):
+            result = observability.install(app)
+            response = app.routes["/paper/shadow-ai-research-status"]()
+        self.assertTrue(result["route_registered"])
+        configure.assert_called_once()
+        self.assertFalse(response["authority"]["places_or_cancels_orders"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_shadow_ai_research_contract.py
+++ b/test_shadow_ai_research_contract.py
@@ -14,13 +14,13 @@ class ShadowAIResearchContractTests(unittest.TestCase):
     def setUpClass(cls):
         cls.contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
 
-    def test_stage_four_memory_has_no_execution_authority(self):
+    def test_stage_five_observability_has_no_execution_authority(self):
         contract = self.contract
         policy = contract["policy"]
 
         self.assertEqual(
             contract["implementation_stage"],
-            "stage_4_canonical_outcome_memory_and_scorecards",
+            "stage_5_observability_and_forward_evidence",
         )
         self.assertTrue(policy["paper_only"])
         self.assertTrue(policy["research_only"])
@@ -131,6 +131,23 @@ class ShadowAIResearchContractTests(unittest.TestCase):
             "behavior_change_requires_validation_policy",
         ]
         self.assertTrue(all(validation[name] for name in required))
+
+    def test_observability_is_bounded_restart_validated_and_read_only(self):
+        status = self.contract["observability"]
+        forward = self.contract["forward_evidence"]
+
+        self.assertTrue(status["implemented"])
+        self.assertTrue(status["runtime_integrated"])
+        self.assertEqual(status["read_only_route"], "/paper/shadow-ai-research-status")
+        self.assertTrue(status["separate_from_portfolio_state"])
+        self.assertTrue(status["separate_from_canonical_ledger"])
+        self.assertTrue(status["atomic_replace"])
+        self.assertTrue(status["checksum_validated_on_restart"])
+        self.assertEqual(status["corrupt_store_behavior"], "fail_closed_no_overwrite")
+        self.assertFalse(status["execution_reads_evidence_store"])
+        self.assertFalse(status["automatic_promotion"])
+        self.assertFalse(forward["threshold_authorizes_promotion"])
+        self.assertTrue(forward["provider_transport_enablement_is_separate"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Scope

Implements the bounded Stage 5 observability boundary for Issue #157:

- adds a separate atomic/checksummed research-evidence store capped at 500 records, 32 KB per record, and 8 MB total;
- validates restart integrity and fails closed without overwriting corrupt or contradictory evidence;
- excludes prompts, raw reasoning/source bodies, secrets, authorization, and credential fields;
- adds read-only `/paper/shadow-ai-research-status` telemetry for decisions, sources/citations, fallbacks, token categories, exact inference cost, durability, and forward-readiness;
- persists completed reviewer records off the execution thread while keeping persistence failures nonblocking;
- extends the mandatory change-safety selector to the complete Stage 5 shadow-AI suite.

The reviewer and client remain disabled by default, no provider transport is bundled, and no strategy, signal, selection, sizing, risk, accounting, canonical history, live/ML authority, or order behavior changes. Even sufficient forward evidence cannot authorize automatic promotion.

## Local evidence

- 74 focused shadow-AI/change-safety/runtime tests pass.
- repository and Railway validation pass (312 Python files; zero compile/static errors).
- structural audit reports zero new critical findings and zero new warnings.
- architecture ownership, typed configuration, and architecture-debt gates pass.
- remote branch tree exactly matches the locally inspected tree `86f18abcfa135e9de8f3ee198ee234b092266207`.

Closes the implementation portion of #157 Stage 5; provider transport/reviewer enablement remains a separate explicit configuration decision.