### PR TITLE
Fix startup state serialization race

### DIFF
--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -53,6 +53,7 @@ SHADOW_AI_TESTS = (
     "test_shadow_ai_evidence_store.py",
     "test_shadow_ai_observability.py",
 )
+STATE_SERIALIZATION_TESTS = ("test_issue165_state_serialization.py",)
 
 
 @dataclass(frozen=True)
@@ -115,6 +116,14 @@ def _is_legacy_external_paper_runner_path(path: str) -> bool:
 
 def _is_shadow_ai_path(path: str) -> bool:
     return Path(path.lower()).name.startswith(("shadow_ai_", "test_shadow_ai_"))
+
+
+def _is_state_serialization_path(path: str) -> bool:
+    return Path(path.lower()).name in {
+        "state_io_hardening.py",
+        "cycle_completion_contract.py",
+        "test_issue165_state_serialization.py",
+    }
 
 
 def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ...]]:
@@ -205,6 +214,8 @@ def planned_regressions(paths: Iterable[str]) -> tuple[str, ...]:
         tests.extend(LEGACY_EXTERNAL_PAPER_RUNNER_TESTS)
     if any(_is_shadow_ai_path(path) for path in path_tuple):
         tests.extend(SHADOW_AI_TESTS)
+    if any(_is_state_serialization_path(path) for path in path_tuple):
+        tests.extend(STATE_SERIALIZATION_TESTS)
     existing: list[str] = []
     seen: set[str] = set()
     for test in tests:

--- a/cycle_completion_contract.py
+++ b/cycle_completion_contract.py
@@ -14,7 +14,7 @@ import time
 import uuid
 from typing import Any, Dict
 
-VERSION = "cycle-completion-contract-2026-08-04-v2-rebind-safe"
+VERSION = "cycle-completion-contract-2026-09-03-v3-error-lifecycle"
 STALE_SECONDS = float(os.environ.get("AUTO_CYCLE_STALE_SECONDS", "720"))
 _LOCK = threading.RLock()
 _APPLIED: set[int] = set()
@@ -120,6 +120,7 @@ def _complete(
         current_auto = _auto(core)
         same_current_cycle = current_auto.get("cycle_id") == cycle_id
         no_other_active_cycle = not active
+        previous_error = current_auto.get("last_error")
         current_auto.update({
             "last_completed_cycle_id": cycle_id,
             "last_completed_cycle_status": status,
@@ -144,6 +145,15 @@ def _complete(
                 current_auto["cycle_error"] = error
             else:
                 current_auto.pop("cycle_error", None)
+                if previous_error:
+                    current_auto["last_recovered_error"] = previous_error
+                    current_auto["last_recovered_error_trace"] = current_auto.get(
+                        "last_error_trace"
+                    )
+                    current_auto["last_recovered_error_local"] = completed_local
+                    current_auto["last_recovered_error_cycle_id"] = cycle_id
+                    current_auto["last_error"] = None
+                    current_auto["last_error_trace"] = None
         _LAST = {
             "status": "error" if error else "ok",
             "overall": "warn" if error else "pass",

--- a/state_io_hardening.py
+++ b/state_io_hardening.py
@@ -21,7 +21,7 @@ import threading
 import time
 from typing import Any, Dict, Optional
 
-VERSION = "state-io-hardening-2026-05-13"
+VERSION = "state-io-hardening-2026-09-03-v2-stable-serialization"
 
 STATE_DIR = os.environ.get("STATE_DIR") or os.environ.get("PERSISTENT_STATE_DIR") or os.environ.get("RAILWAY_VOLUME_MOUNT_PATH") or "."
 STATE_FILENAME = os.environ.get("STATE_FILENAME", os.environ.get("STATE_FILE", "state.json"))
@@ -34,6 +34,8 @@ STATE_IO_STATUS_FILE = os.path.join(STATE_DIR or ".", "state_io_status.json")
 
 READ_RETRIES = int(os.environ.get("STATE_IO_READ_RETRIES", "4"))
 READ_RETRY_SLEEP = float(os.environ.get("STATE_IO_READ_RETRY_SLEEP", "0.05"))
+SERIALIZE_RETRIES = 5
+SERIALIZE_RETRY_SLEEP = 0.01
 
 _THREAD_LOCK = threading.RLock()
 _RUN_LOCK = threading.Lock()
@@ -214,13 +216,35 @@ def backup_current_state() -> Dict[str, Any]:
         }
 
 
+def _stable_json_text(payload: Dict[str, Any]) -> str:
+    for attempt in range(SERIALIZE_RETRIES):
+        try:
+            return json.dumps(
+                payload,
+                default=_json_default,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        except RuntimeError as exc:
+            message = str(exc).lower()
+            concurrent_mutation = (
+                "dictionary changed size during iteration" in message
+                or "dictionary keys changed during iteration" in message
+            )
+            if not concurrent_mutation or attempt + 1 >= SERIALIZE_RETRIES:
+                raise
+            time.sleep(SERIALIZE_RETRY_SLEEP * (attempt + 1))
+    raise RuntimeError("state serialization retry bound exhausted")
+
+
 def atomic_json_write(path: str, payload: Dict[str, Any]) -> bool:
     _ensure_parent(path)
     folder = _folder(path)
     base = os.path.basename(path)
     tmp = os.path.join(folder, f".{base}.{os.getpid()}.{threading.get_ident()}.tmp")
+    serialized = _stable_json_text(payload)
     with open(tmp, "w", encoding="utf-8") as f:
-        json.dump(payload, f, default=_json_default, ensure_ascii=False, separators=(",", ":"))
+        f.write(serialized)
         f.flush()
         os.fsync(f.fileno())
     os.replace(tmp, path)
@@ -312,6 +336,8 @@ def status_payload(module: Any | None = None) -> Dict[str, Any]:
         },
         "protections": {
             "atomic_save_state": True,
+            "stable_pre_serialization": True,
+            "bounded_concurrent_mutation_retries": SERIALIZE_RETRIES,
             "retrying_json_reads": True,
             "backup_fallback_reads": True,
             "thread_and_file_locking": True,

--- a/test_change_safety_audit.py
+++ b/test_change_safety_audit.py
@@ -220,6 +220,13 @@ class ChangeSafetyAuditTests(unittest.TestCase):
         ):
             self.assertIn(shadow_test, tests)
 
+    def test_state_serialization_change_selects_issue165_regression(self) -> None:
+        for path in ("state_io_hardening.py", "cycle_completion_contract.py"):
+            self.assertIn(
+                "test_issue165_state_serialization.py",
+                planned_regressions((path,)),
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_issue165_state_serialization.py
+++ b/test_issue165_state_serialization.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import cycle_completion_contract as completion
+import state_io_hardening as state_io
+
+
+class Issue165StateSerializationTests(unittest.TestCase):
+    def test_atomic_write_retries_transient_dictionary_mutation(self):
+        real_dumps = json.dumps
+        attempts = []
+
+        def unstable(value, *args, **kwargs):
+            attempts.append(1)
+            if len(attempts) < 3:
+                raise RuntimeError("dictionary changed size during iteration")
+            return real_dumps(value, *args, **kwargs)
+
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+            state_io.json, "dumps", side_effect=unstable
+        ), mock.patch.object(state_io.time, "sleep") as sleep:
+            path = str(Path(directory) / "state.json")
+            self.assertTrue(state_io.atomic_json_write(path, {"cash": 100.0}))
+            self.assertEqual(
+                json.loads(Path(path).read_text(encoding="utf-8")),
+                {"cash": 100.0},
+            )
+            self.assertEqual(len(attempts), 3)
+            self.assertEqual(sleep.call_count, 2)
+
+    def test_atomic_write_does_not_hide_persistent_mutation(self):
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+            state_io.json,
+            "dumps",
+            side_effect=RuntimeError("dictionary keys changed during iteration"),
+        ), mock.patch.object(state_io.time, "sleep"):
+            path = str(Path(directory) / "state.json")
+            with self.assertRaises(RuntimeError):
+                state_io.atomic_json_write(path, {"cash": 100.0})
+            self.assertFalse(Path(path).exists())
+
+    def test_successful_later_skip_preserves_then_clears_prior_error(self):
+        portfolio = {
+            "auto_runner": {
+                "last_error": "dictionary changed size during iteration",
+                "last_error_trace": "trace",
+            }
+        }
+        core = types.SimpleNamespace(
+            portfolio=portfolio,
+            local_ts_text=lambda: "2026-09-03 00:25:49 CDT",
+            save_state=lambda _state: None,
+        )
+        cycle_id = "auto-skip-cycle"
+        completion._ACTIVE[id(core)] = {cycle_id}
+
+        completion._complete(
+            core,
+            cycle_id=cycle_id,
+            source="auto",
+            started=1.0,
+            status="skipped",
+        )
+
+        auto = portfolio["auto_runner"]
+        self.assertIsNone(auto["last_error"])
+        self.assertIsNone(auto["last_error_trace"])
+        self.assertEqual(auto["last_recovered_error"], "dictionary changed size during iteration")
+        self.assertEqual(auto["last_recovered_error_trace"], "trace")
+        self.assertEqual(auto["last_recovered_error_cycle_id"], cycle_id)
+        self.assertEqual(auto["last_completed_cycle_status"], "skipped")
+
+    def test_failed_cycle_never_clears_error(self):
+        portfolio = {"auto_runner": {"last_error": "existing"}}
+        core = types.SimpleNamespace(
+            portfolio=portfolio,
+            local_ts_text=lambda: "2026-09-03 00:25:49 CDT",
+            save_state=lambda _state: None,
+        )
+        cycle_id = "auto-failed-cycle"
+        completion._ACTIVE[id(core)] = {cycle_id}
+        completion._complete(
+            core,
+            cycle_id=cycle_id,
+            source="auto",
+            started=1.0,
+            status="error",
+            error="RuntimeError: still broken",
+        )
+        self.assertEqual(portfolio["auto_runner"]["last_error"], "existing")
+        self.assertEqual(portfolio["auto_runner"]["cycle_error"], "RuntimeError: still broken")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #165.

## Demonstrated defect

Settled Splendid on `2752f37` recorded `dictionary changed size during iteration` during startup. A later valid closed-market cycle completed, but the error remained active, leaving self-check WARN and daily audit FAIL while accounting, canonical ledger, v4 release, risk, and worker liveness were otherwise clean.

## Bounded repair

- serialize the live state to a stable JSON string with five bounded retries for only the two Python concurrent-dictionary mutation RuntimeErrors before any temporary file is written;
- preserve all other serialization failures and fail after the retry bound;
- only after a later cycle returns successfully, preserve any stale active error as recovered telemetry and clear the active fields;
- add four focused regressions plus automatic Change Safety selection.

No canonical/history/accounting/day-peak evidence is edited. No halt/hold is cleared. No strategy, signal, ranking, sizing, exposure, risk limit, provider, order, live, ML, or AI authority changes.

## Local evidence

- 4 Issue #165 focused tests and 27 selected lifecycle/change-safety tests pass;
- repository/Railway validation passes across 313 Python files with zero compile/static errors;
- structural audit: zero new critical findings and zero new warnings;
- ownership, typed configuration, and architecture-debt gates pass;
- remote branch tree exactly matches inspected local tree `df3cc9dda5830e1a950549e3dca010b0fbdee0d0`.

The wider runtime suite's only local error was an unavailable optional `yfinance` package in this workspace; the required GitHub workflow installs declared dependencies before executing the exact-head gates.