### PR TITLE
Add read-only runtime system sentinel

### DIFF
--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -55,6 +55,10 @@ SHADOW_AI_TESTS = (
 )
 STATE_SERIALIZATION_TESTS = ("test_issue165_state_serialization.py",)
 PERFORMANCE_EVIDENCE_INTEGRITY_TESTS = ("test_issue167_forward_evidence_integrity.py",)
+SYSTEM_SENTINEL_TESTS = (
+    "test_system_sentinel.py",
+    "test_system_sentinel_runtime.py",
+)
 
 
 @dataclass(frozen=True)
@@ -132,6 +136,10 @@ def _is_performance_evidence_integrity_path(path: str) -> bool:
         "performance_audit_lab.py",
         "test_issue167_forward_evidence_integrity.py",
     }
+
+
+def _is_system_sentinel_path(path: str) -> bool:
+    return "system_sentinel" in Path(path.lower()).name
 
 
 def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ...]]:
@@ -226,6 +234,8 @@ def planned_regressions(paths: Iterable[str]) -> tuple[str, ...]:
         tests.extend(STATE_SERIALIZATION_TESTS)
     if any(_is_performance_evidence_integrity_path(path) for path in path_tuple):
         tests.extend(PERFORMANCE_EVIDENCE_INTEGRITY_TESTS)
+    if any(_is_system_sentinel_path(path) for path in path_tuple):
+        tests.extend(SYSTEM_SENTINEL_TESTS)
     existing: list[str] = []
     seen: set[str] = set()
     for test in tests:

--- a/runtime_worker_registration.py
+++ b/runtime_worker_registration.py
@@ -14,7 +14,7 @@ from typing import Any, Dict
 
 import runtime_diagnostics as diagnostics
 
-VERSION = "runtime-worker-registration-2026-09-03-v8-shadow-ai-observability"
+VERSION = "runtime-worker-registration-2026-09-03-v9-system-sentinel"
 _LOCK = threading.RLock()
 _REGISTERED_CORE_IDS: set[int] = set()
 _KICKOFF_STARTED: set[int] = set()
@@ -166,6 +166,7 @@ def register(core: Any, *, research_isolated: bool = True) -> Dict[str, Any]:
             import shadow_ai_adversarial_reviewer
             import shadow_ai_evidence_store
             import shadow_ai_observability
+            import system_sentinel_runtime
             import performance_risk_activation_guard
             import regime_integrity_underdeployment
             import regime_integrity_cache_guard
@@ -273,6 +274,10 @@ def register(core: Any, *, research_isolated: bool = True) -> Dict[str, Any]:
             shadow_ai_observability_result = shadow_ai_observability.install(core.app)
             shadow_ai_reviewer = shadow_ai_adversarial_reviewer.install()
 
+            # Register the sentinel as an on-demand read-only route. It starts
+            # no worker and is not part of the execution or cycle path.
+            system_sentinel_result = system_sentinel_runtime.install(core.app, core)
+
             auto_runner = _start_auto_runner(core)
             if auto_runner.get("status") != "ok":
                 raise RuntimeError(
@@ -307,6 +312,7 @@ def register(core: Any, *, research_isolated: bool = True) -> Dict[str, Any]:
                 shadow_ai_adversarial_reviewer.VERSION,
                 shadow_ai_evidence_store.VERSION,
                 shadow_ai_observability.VERSION,
+                system_sentinel_runtime.VERSION,
             ]
             _REGISTERED_CORE_IDS.add(id(core))
             _LAST = {
@@ -324,6 +330,7 @@ def register(core: Any, *, research_isolated: bool = True) -> Dict[str, Any]:
                 "run_cycle_observer": run_report_guard_apply,
                 "shadow_ai_adversarial_reviewer": shadow_ai_reviewer,
                 "shadow_ai_observability": shadow_ai_observability_result,
+                "system_sentinel_runtime": system_sentinel_result,
                 "auto_runner": auto_runner,
             }
             diagnostics.record_module_event(

--- a/system_sentinel_runtime.py
+++ b/system_sentinel_runtime.py
@@ -1,0 +1,178 @@
+"""Read-only runtime observability for the advisory system sentinel.
+
+The route composes existing diagnostics only when requested.  It starts no
+worker, performs no repair, and never reads or writes canonical files directly.
+"""
+from __future__ import annotations
+
+import math
+import os
+from typing import Any, Callable, Mapping
+
+import system_sentinel
+
+
+VERSION = "system-sentinel-runtime-2026-09-03-v1"
+_REGISTERED_APP_IDS: set[int] = set()
+
+
+def _d(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _default_collectors() -> dict[str, Callable[[Any], Mapping[str, Any]]]:
+    import canonical_execution_ledger
+    import daily_operational_audit
+    import fast_self_check_override
+    import final_daily_audit_compactor
+    import paper_bidirectional_accounting_guard
+    import runtime_worker_registration
+
+    def daily(core: Any) -> Mapping[str, Any]:
+        full = daily_operational_audit.build_payload(core)
+        return final_daily_audit_compactor.compact_payload(full, core)
+
+    return {
+        "self_check": fast_self_check_override.build_payload,
+        "daily_audit": daily,
+        "accounting": paper_bidirectional_accounting_guard.status_payload,
+        "execution_ledger": canonical_execution_ledger.status_payload,
+        "runtime_registration": lambda _core: runtime_worker_registration.status(),
+    }
+
+
+def collect_snapshot(
+    core: Any,
+    *,
+    collectors: Mapping[str, Callable[[Any], Mapping[str, Any]]] | None = None,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Collect bounded diagnostic dictionaries without mutating runtime state."""
+    rows: dict[str, dict[str, Any]] = {}
+    errors: dict[str, str] = {}
+    for name, collector in dict(collectors or _default_collectors()).items():
+        try:
+            rows[name] = _d(collector(core))
+        except Exception as exc:
+            rows[name] = {}
+            errors[name] = f"{type(exc).__name__}: {exc}"
+
+    self_check = rows.get("self_check", {})
+    daily = rows.get("daily_audit", {})
+    account = _d(self_check.get("account"))
+    runner = _d(self_check.get("auto_runner"))
+    risk = _d(self_check.get("risk"))
+    portfolio = _d(getattr(core, "portfolio", {})) if core is not None else {}
+    persisted_risk = _d(portfolio.get("risk_controls"))
+    equity = account.get("equity", portfolio.get("equity"))
+    try:
+        equity_eligible = (
+            not isinstance(equity, bool)
+            and math.isfinite(float(equity))
+            and float(equity) > 0.0
+        )
+    except (TypeError, ValueError, OverflowError):
+        equity_eligible = False
+
+    registration = _d(rows.get("runtime_registration", {}).get("last"))
+    startup_status = "ready" if registration.get("status") == "ok" else "fail"
+    market_data = dict(_d(daily.get("market_data")))
+    observed_gap = market_data.get("in_flight_or_unclassified_requests")
+    try:
+        gap = max(0, int(observed_gap or 0))
+    except (TypeError, ValueError, OverflowError):
+        gap = 0
+    # The provider counter is incremented before its terminal classification.
+    # Existing authoritative audit semantics therefore allow one concurrent
+    # in-flight request when the aggregate market-data status still passes.
+    market_data["observed_in_flight_or_unclassified_requests"] = gap
+    if market_data.get("status") == "pass" and gap <= 1:
+        market_data["in_flight_or_unclassified_requests"] = 0
+
+    snapshot = {
+        "valuation": {
+            "status": "ok" if equity_eligible else "fail",
+            "equity": equity,
+            "risk_baseline_eligible": equity_eligible,
+        },
+        "accounting": rows.get("accounting", {}),
+        "execution_ledger": rows.get("execution_ledger", {}),
+        "risk": {
+            "day_start_equity": persisted_risk.get("day_start_equity"),
+            "day_peak_equity": persisted_risk.get("day_peak_equity"),
+            "halted": risk.get("halted", persisted_risk.get("halted")),
+        },
+        "startup": {
+            "status": startup_status,
+            "phase": "runtime_worker_registration",
+            "error": registration.get("error"),
+        },
+        "runner": {
+            "active_error": runner.get("last_error_active") is True,
+            "last_error": runner.get("last_error"),
+            "last_attempt": runner.get("last_attempt"),
+        },
+        "market_data": market_data,
+    }
+    return snapshot, errors
+
+
+def build_payload(
+    core: Any,
+    *,
+    collectors: Mapping[str, Callable[[Any], Mapping[str, Any]]] | None = None,
+) -> dict[str, Any]:
+    snapshot, collection_errors = collect_snapshot(core, collectors=collectors)
+    result = system_sentinel.report(snapshot)
+    result.update(
+        {
+            "overall": "pass" if result["status"] == "quiet" and not collection_errors else "warn",
+            "runtime_version": VERSION,
+            "generated_commit_sha": os.environ.get("RAILWAY_GIT_COMMIT_SHA"),
+            "collection_errors": collection_errors,
+            "snapshot": snapshot,
+            "coverage": {
+                "runtime_observed": [
+                    "valuation", "accounting", "execution", "risk",
+                    "startup_runtime", "runner", "market_data",
+                ],
+                "ci_observed": ["configuration", "architecture"],
+                "ci_source": "mandatory exact-head Change Safety and architecture gates",
+            },
+            "authority": {
+                "advisory_only": True,
+                "read_only_on_demand": True,
+                "starts_worker": False,
+                "writes_production_state": False,
+                "opens_or_merges_pull_requests": False,
+                "clears_halts": False,
+                "places_or_cancels_orders": False,
+                "changes_strategy_or_thresholds": False,
+                "changes_risk_or_sizing": False,
+                "changes_live_or_ml_authority": False,
+            },
+        }
+    )
+    return result
+
+
+def install(flask_app: Any = None, core: Any = None) -> dict[str, Any]:
+    if flask_app is not None and id(flask_app) not in _REGISTERED_APP_IDS:
+        from flask import jsonify
+
+        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+        if "/paper/system-sentinel-status" not in existing:
+            flask_app.add_url_rule(
+                "/paper/system-sentinel-status",
+                "paper_system_sentinel_status",
+                lambda: jsonify(build_payload(core)),
+            )
+        _REGISTERED_APP_IDS.add(id(flask_app))
+    return {
+        "status": "ok" if flask_app is not None and core is not None else "pending",
+        "overall": "pass" if flask_app is not None and core is not None else "warn",
+        "version": VERSION,
+        "route_registered": flask_app is not None,
+        "read_only_on_demand": True,
+        "worker_started": False,
+        "authority": "advisory_only",
+    }

--- a/system_sentinel_runtime.py
+++ b/system_sentinel_runtime.py
@@ -14,6 +14,7 @@ import system_sentinel
 
 VERSION = "system-sentinel-runtime-2026-09-03-v1"
 _REGISTERED_APP_IDS: set[int] = set()
+_INSTALL_STATUS_BY_CORE: dict[int, dict[str, Any]] = {}
 
 
 def _d(value: Any) -> dict[str, Any]:
@@ -26,7 +27,6 @@ def _default_collectors() -> dict[str, Callable[[Any], Mapping[str, Any]]]:
     import fast_self_check_override
     import final_daily_audit_compactor
     import paper_bidirectional_accounting_guard
-    import runtime_worker_registration
 
     def daily(core: Any) -> Mapping[str, Any]:
         full = daily_operational_audit.build_payload(core)
@@ -37,7 +37,7 @@ def _default_collectors() -> dict[str, Callable[[Any], Mapping[str, Any]]]:
         "daily_audit": daily,
         "accounting": paper_bidirectional_accounting_guard.status_payload,
         "execution_ledger": canonical_execution_ledger.status_payload,
-        "runtime_registration": lambda _core: runtime_worker_registration.status(),
+        "startup": lambda observed_core: _INSTALL_STATUS_BY_CORE.get(id(observed_core), {}),
     }
 
 
@@ -73,8 +73,8 @@ def collect_snapshot(
     except (TypeError, ValueError, OverflowError):
         equity_eligible = False
 
-    registration = _d(rows.get("runtime_registration", {}).get("last"))
-    startup_status = "ready" if registration.get("status") == "ok" else "fail"
+    startup = rows.get("startup", {})
+    startup_status = "ready" if startup.get("status") == "ok" else "fail"
     market_data = dict(_d(daily.get("market_data")))
     observed_gap = market_data.get("in_flight_or_unclassified_requests")
     try:
@@ -104,7 +104,7 @@ def collect_snapshot(
         "startup": {
             "status": startup_status,
             "phase": "runtime_worker_registration",
-            "error": registration.get("error"),
+            "error": startup.get("error"),
         },
         "runner": {
             "active_error": runner.get("last_error_active") is True,
@@ -167,7 +167,7 @@ def install(flask_app: Any = None, core: Any = None) -> dict[str, Any]:
                 lambda: jsonify(build_payload(core)),
             )
         _REGISTERED_APP_IDS.add(id(flask_app))
-    return {
+    result = {
         "status": "ok" if flask_app is not None and core is not None else "pending",
         "overall": "pass" if flask_app is not None and core is not None else "warn",
         "version": VERSION,
@@ -176,3 +176,6 @@ def install(flask_app: Any = None, core: Any = None) -> dict[str, Any]:
         "worker_started": False,
         "authority": "advisory_only",
     }
+    if core is not None:
+        _INSTALL_STATUS_BY_CORE[id(core)] = dict(result)
+    return result

--- a/test_change_safety_audit.py
+++ b/test_change_safety_audit.py
@@ -234,6 +234,12 @@ class ChangeSafetyAuditTests(unittest.TestCase):
                 planned_regressions((path,)),
             )
 
+    def test_system_sentinel_change_selects_complete_sentinel_regression_set(self) -> None:
+        for path in ("system_sentinel.py", "system_sentinel_runtime.py"):
+            tests = planned_regressions((path,))
+            self.assertIn("test_system_sentinel.py", tests)
+            self.assertIn("test_system_sentinel_runtime.py", tests)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_self_check_runtime_classification.py
+++ b/test_self_check_runtime_classification.py
@@ -246,6 +246,10 @@ class SelfCheckRuntimeClassificationTests(unittest.TestCase):
             "shadow_ai_reviewer = shadow_ai_adversarial_reviewer.install()",
             observer_index,
         )
+        sentinel_index = source.index(
+            "system_sentinel_result = system_sentinel_runtime.install(core.app, core)",
+            observer_index,
+        )
         observability_index = source.index(
             "shadow_ai_observability_result = shadow_ai_observability.install(core.app)",
             observer_index,
@@ -254,7 +258,8 @@ class SelfCheckRuntimeClassificationTests(unittest.TestCase):
         self.assertLess(diagnostics_index, observer_index)
         self.assertLess(observer_index, observability_index)
         self.assertLess(observability_index, reviewer_index)
-        self.assertLess(reviewer_index, runner_index)
+        self.assertLess(reviewer_index, sentinel_index)
+        self.assertLess(sentinel_index, runner_index)
 
 
 if __name__ == "__main__":

--- a/test_system_sentinel_runtime.py
+++ b/test_system_sentinel_runtime.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+import sys
+import unittest
+from unittest.mock import patch
+
+import system_sentinel_runtime as runtime
+
+
+def _collectors(*, accounting=None, ledger=None, active_error=False):
+    return {
+        "self_check": lambda core: {
+            "account": {"equity": 12_000.0},
+            "risk": {"halted": False},
+            "auto_runner": {
+                "last_error_active": active_error,
+                "last_error": "boom" if active_error else None,
+                "last_attempt": "now",
+            },
+        },
+        "daily_audit": lambda core: {
+            "market_data": {
+                "status": "pass",
+                "accounting_complete_at_snapshot": True,
+                "in_flight_or_unclassified_requests": 0,
+            }
+        },
+        "accounting": lambda core: accounting or {
+            "status": "ok", "coverage_complete": True,
+            "coverage_issue_count": 0, "economic_issue_count": 0,
+        },
+        "execution_ledger": lambda core: ledger or {
+            "chain_valid": True, "row_count": 3,
+        },
+        "runtime_registration": lambda core: {"last": {"status": "ok"}},
+    }
+
+
+class SystemSentinelRuntimeTests(unittest.TestCase):
+    def setUp(self):
+        runtime._REGISTERED_APP_IDS.clear()
+        self.core = SimpleNamespace(
+            portfolio={
+                "equity": 12_000.0,
+                "risk_controls": {
+                    "day_start_equity": 12_000.0,
+                    "day_peak_equity": 12_100.0,
+                    "halted": False,
+                },
+            }
+        )
+
+    def test_clean_runtime_is_quiet_and_read_only(self):
+        before = repr(self.core.portfolio)
+        payload = runtime.build_payload(self.core, collectors=_collectors())
+        self.assertEqual(payload["status"], "quiet")
+        self.assertEqual(payload["overall"], "pass")
+        self.assertEqual(payload["incident_count"], 0)
+        self.assertEqual(repr(self.core.portfolio), before)
+        self.assertFalse(payload["authority"]["writes_production_state"])
+        self.assertFalse(payload["authority"]["starts_worker"])
+
+    def test_runtime_faults_are_classified_with_mandatory_tests(self):
+        payload = runtime.build_payload(
+            self.core,
+            collectors=_collectors(
+                accounting={
+                    "status": "partial", "coverage_complete": False,
+                    "coverage_issue_count": 1, "economic_issue_count": 1,
+                },
+                ledger={"chain_valid": False, "row_count": 4},
+                active_error=True,
+            ),
+        )
+        reasons = {row["reason_code"] for row in payload["incidents"]}
+        self.assertEqual(
+            reasons,
+            {"accounting_integrity_failure", "execution_chain_invalid", "runner_active_error"},
+        )
+        self.assertEqual(payload["overall"], "warn")
+        self.assertTrue(all(row["selected_tests"] for row in payload["incidents"]))
+
+    def test_collection_failure_is_visible_and_cannot_break_route(self):
+        collectors = _collectors()
+
+        def broken(core):
+            raise RuntimeError("diagnostic unavailable")
+
+        collectors["daily_audit"] = broken
+        payload = runtime.build_payload(self.core, collectors=collectors)
+        self.assertEqual(payload["overall"], "warn")
+        self.assertIn("daily_audit", payload["collection_errors"])
+
+    def test_one_expected_concurrent_provider_request_is_not_false_incident(self):
+        collectors = _collectors()
+        collectors["daily_audit"] = lambda core: {
+            "market_data": {
+                "status": "pass",
+                "accounting_complete_at_snapshot": True,
+                "in_flight_or_unclassified_requests": 1,
+            }
+        }
+        payload = runtime.build_payload(self.core, collectors=collectors)
+        self.assertEqual(payload["status"], "quiet")
+        self.assertEqual(
+            payload["snapshot"]["market_data"]["observed_in_flight_or_unclassified_requests"],
+            1,
+        )
+        self.assertEqual(
+            payload["snapshot"]["market_data"]["in_flight_or_unclassified_requests"],
+            0,
+        )
+
+    def test_route_registration_is_idempotent_and_starts_no_worker(self):
+        class FakeApp:
+            def __init__(self):
+                self._rules = []
+                self.url_map = SimpleNamespace(
+                    iter_rules=lambda: [SimpleNamespace(rule=row) for row in self._rules]
+                )
+
+            def add_url_rule(self, path, endpoint, view):
+                self._rules.append(path)
+
+        app = FakeApp()
+        fake_flask = SimpleNamespace(jsonify=lambda payload: payload)
+        with patch.dict(sys.modules, {"flask": fake_flask}):
+            first = runtime.install(app, self.core)
+            second = runtime.install(app, self.core)
+        rules = [rule.rule for rule in app.url_map.iter_rules()]
+        self.assertEqual(rules.count("/paper/system-sentinel-status"), 1)
+        self.assertEqual(first["status"], "ok")
+        self.assertEqual(second["status"], "ok")
+        self.assertFalse(first["worker_started"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_system_sentinel_runtime.py
+++ b/test_system_sentinel_runtime.py
@@ -33,13 +33,14 @@ def _collectors(*, accounting=None, ledger=None, active_error=False):
         "execution_ledger": lambda core: ledger or {
             "chain_valid": True, "row_count": 3,
         },
-        "runtime_registration": lambda core: {"last": {"status": "ok"}},
+        "startup": lambda core: {"status": "ok"},
     }
 
 
 class SystemSentinelRuntimeTests(unittest.TestCase):
     def setUp(self):
         runtime._REGISTERED_APP_IDS.clear()
+        runtime._INSTALL_STATUS_BY_CORE.clear()
         self.core = SimpleNamespace(
             portfolio={
                 "equity": 12_000.0,


### PR DESCRIPTION
Advances #96 with a bounded runtime-observability stage.

## Boundary
- Registers `/paper/system-sentinel-status` as an on-demand read-only route.
- Composes existing self-check, daily-audit, accounting, ledger, risk, runner, startup, and market-data diagnostics.
- Produces deterministic advisory incidents, suspected causes, bounded remediation guidance, and mandatory test selections.
- Starts no worker, performs no repair, opens/merges no PR, writes no state, clears no halt, and has no strategy/risk/live/ML/order authority.
- Leaves configuration and architecture enforcement in the mandatory exact-head CI gates and reports that split explicitly.

## Validation
- 99 focused and canonical invariant tests pass.
- Repository/Railway validation passes across 314 Python files.
- Structural audit reports zero new critical findings and zero new warnings.
- Ownership, typed-configuration, and architecture-debt gates pass.
- Change Safety automatically selects both sentinel suites for future sentinel changes.

This does not close #96; automatic GitHub issue/draft-PR output and any allowlisted non-authoritative self-healing remain out of scope.