### PR TITLE
Fix Performance Audit V2 signal-time ATR integrity

### DIFF
--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -54,7 +54,10 @@ SHADOW_AI_TESTS = (
     "test_shadow_ai_observability.py",
 )
 STATE_SERIALIZATION_TESTS = ("test_issue165_state_serialization.py",)
-PERFORMANCE_EVIDENCE_INTEGRITY_TESTS = ("test_issue167_forward_evidence_integrity.py",)
+PERFORMANCE_EVIDENCE_INTEGRITY_TESTS = (
+    "test_issue167_forward_evidence_integrity.py",
+    "test_issue170_performance_atr_integrity.py",
+)
 SYSTEM_SENTINEL_TESTS = (
     "test_system_sentinel.py",
     "test_system_sentinel_runtime.py",
@@ -134,7 +137,9 @@ def _is_state_serialization_path(path: str) -> bool:
 def _is_performance_evidence_integrity_path(path: str) -> bool:
     return Path(path.lower()).name in {
         "performance_audit_lab.py",
+        "performance_audit_lab_v2.py",
         "test_issue167_forward_evidence_integrity.py",
+        "test_issue170_performance_atr_integrity.py",
     }
 
 

--- a/performance_audit_lab_v2.py
+++ b/performance_audit_lab_v2.py
@@ -26,7 +26,7 @@ import performance_audit_lab as base
 np = base.np
 pd = base.pd
 
-VERSION = "performance-audit-lab-v2-2026-08-03-v1"
+VERSION = "performance-audit-lab-v2-2026-09-03-v2-signal-atr-integrity"
 ENABLED = os.environ.get("PERFORMANCE_AUDIT_V2_ENABLED", "true").lower() not in {
     "0", "false", "no", "off"
 }
@@ -393,9 +393,14 @@ def _simulate_next_open(
                 if shares <= 0:
                     continue
                 cash -= allocation
+                # The entry executes at the next session's open, so its initial
+                # stop may only use information known when the order was queued.
+                # Using this execution session's completed ATR would leak its
+                # High/Low/Close into the opening decision.
+                signal_atr_pct = _f(order.get("signal_atr_pct"), stop_loss)
                 atr_stop = max(
                     stop_loss,
-                    min(0.045, _f(row.get("atr_pct"), stop_loss) * 1.25),
+                    min(0.045, signal_atr_pct * 1.25),
                 )
                 positions[symbol] = {
                     "entry": price,
@@ -417,6 +422,8 @@ def _simulate_next_open(
                         "allocation": allocation,
                         "regime": order.get("regime"),
                         "execution": "next_session_open",
+                        "signal_atr_pct": signal_atr_pct,
+                        "initial_stop_pct": atr_stop,
                     }
                 )
         pending = []
@@ -507,6 +514,10 @@ def _simulate_next_open(
                     "signal_date": date,
                     "regime": today_regime,
                     "policy": dict(policy_today),
+                    "signal_atr_pct": _f(
+                        row.get("atr_pct"),
+                        _f(policy_today.get("stop_loss"), 0.015),
+                    ),
                 }
             )
 

--- a/test_change_safety_audit.py
+++ b/test_change_safety_audit.py
@@ -227,12 +227,16 @@ class ChangeSafetyAuditTests(unittest.TestCase):
                 planned_regressions((path,)),
             )
 
-    def test_performance_evidence_change_selects_issue167_regression(self) -> None:
-        for path in ("performance_audit_lab.py", "test_issue167_forward_evidence_integrity.py"):
-            self.assertIn(
-                "test_issue167_forward_evidence_integrity.py",
-                planned_regressions((path,)),
-            )
+    def test_performance_evidence_change_selects_complete_integrity_regressions(self) -> None:
+        for path in (
+            "performance_audit_lab.py",
+            "performance_audit_lab_v2.py",
+            "test_issue167_forward_evidence_integrity.py",
+            "test_issue170_performance_atr_integrity.py",
+        ):
+            tests = planned_regressions((path,))
+            self.assertIn("test_issue167_forward_evidence_integrity.py", tests)
+            self.assertIn("test_issue170_performance_atr_integrity.py", tests)
 
     def test_system_sentinel_change_selects_complete_sentinel_regression_set(self) -> None:
         for path in ("system_sentinel.py", "system_sentinel_runtime.py"):

--- a/test_issue170_performance_atr_integrity.py
+++ b/test_issue170_performance_atr_integrity.py
@@ -1,0 +1,94 @@
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+import performance_audit_lab_v2 as lab
+
+
+def _policy():
+    return {
+        "score_floor": 0.0,
+        "min_confirmations": 0,
+        "min_volume_ratio": 0.0,
+        "min_relative_strength": -1.0,
+        "require_ma50": False,
+        "max_positions": 1,
+        "target_allocation": 0.10,
+        "max_exposure": 0.20,
+        "stop_loss": 0.01,
+        "max_hold_days": 10,
+        "rebalance_days": 1,
+        "allowed_symbols": None,
+    }
+
+
+def _features(signal_atr, execution_atr, execution_low):
+    dates = pd.to_datetime(["2026-01-05", "2026-01-06"])
+    frame = pd.DataFrame(
+        [
+            {
+                "Open": 100.0,
+                "High": 101.0,
+                "Low": 99.0,
+                "Close": 100.0,
+                "score": 0.02,
+                "atr_pct": signal_atr,
+            },
+            {
+                "Open": 100.0,
+                "High": 140.0,
+                "Low": execution_low,
+                "Close": 100.0,
+                "score": 0.02,
+                "atr_pct": execution_atr,
+            },
+        ],
+        index=dates,
+    )
+    return {"TEST": frame}, list(dates)
+
+
+class PerformanceAtrIntegrityTests(unittest.TestCase):
+    def _run(self, signal_atr, execution_atr, execution_low):
+        features, dates = _features(signal_atr, execution_atr, execution_low)
+        regime_map = {"neutral": _policy()}
+        with patch.object(lab, "np", np), patch.object(
+            lab.base, "np", np
+        ), patch.object(lab, "_regime", return_value="neutral"), patch.object(
+            lab, "_eligible", return_value=True
+        ):
+            return lab._simulate_next_open(features, regime_map, dates)
+
+    def test_execution_session_atr_cannot_widen_initial_stop(self):
+        result = self._run(signal_atr=0.01, execution_atr=0.50, execution_low=98.0)
+
+        entry = next(row for row in result["trades"] if row["action"] == "entry")
+        exit_row = next(row for row in result["trades"] if row["action"] == "exit")
+        self.assertEqual(entry["signal_atr_pct"], 0.01)
+        self.assertEqual(entry["initial_stop_pct"], 0.0125)
+        self.assertEqual(exit_row["reason"], "stop_loss")
+        self.assertEqual(exit_row["price"], 98.75)
+
+    def test_signal_session_atr_controls_initial_stop(self):
+        result = self._run(signal_atr=0.03, execution_atr=0.01, execution_low=97.0)
+
+        entry = next(row for row in result["trades"] if row["action"] == "entry")
+        exit_row = next(row for row in result["trades"] if row["action"] == "exit")
+        self.assertEqual(entry["signal_atr_pct"], 0.03)
+        self.assertEqual(entry["initial_stop_pct"], 0.0375)
+        self.assertEqual(exit_row["reason"], "end_of_test")
+
+    def test_missing_signal_atr_fails_closed_to_policy_stop(self):
+        result = self._run(signal_atr=float("nan"), execution_atr=0.50, execution_low=98.5)
+
+        entry = next(row for row in result["trades"] if row["action"] == "entry")
+        exit_row = next(row for row in result["trades"] if row["action"] == "exit")
+        self.assertEqual(entry["signal_atr_pct"], 0.01)
+        self.assertEqual(entry["initial_stop_pct"], 0.0125)
+        self.assertEqual(exit_row["reason"], "stop_loss")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #170.

## Change
- binds ATR at the signal-session close when queuing a next-open entry;
- derives the initial stop exclusively from that bound value;
- records signal ATR and initial stop percentage for auditability;
- falls back conservatively to the configured policy stop when signal ATR is missing/invalid;
- adds focused regressions and makes both performance-integrity suites mandatory for changes to either audit lab.

## Safety boundary
Research evidence integrity only. No runtime hook, production state write, canonical/accounting/history mutation, strategy threshold, sizing, risk limit, live/ML authority, or order path changes.

## Local evidence
- focused and Change Safety tests: 22 passed;
- exact-head Change Safety plan: 69 passed, status pass, zero failures/new critical findings;
- diff check and Python compilation passed.

Merge only after all required exact-head GitHub gates pass.