### PR TITLE
Fix canonical execution state commit atomicity

### DIFF
--- a/canonical_execution_ledger.py
+++ b/canonical_execution_ledger.py
@@ -20,13 +20,14 @@ import threading
 import uuid
 from typing import Any, Dict, List, Tuple
 
-VERSION = "canonical-execution-ledger-2026-08-10-v1"
+VERSION = "canonical-execution-ledger-2026-09-03-v2-state-commit"
 STATE_DIR = os.environ.get("STATE_DIR") or os.environ.get("PERSISTENT_STATE_DIR") or os.environ.get("RAILWAY_VOLUME_MOUNT_PATH") or "."
 LEDGER_FILE = os.path.join(STATE_DIR, "canonical_execution_ledger.jsonl")
 
 _LOCK = threading.RLock()
 _APPLIED_CORE_IDS: set[int] = set()
 _REGISTERED_APP_IDS: set[int] = set()
+_LAST_PROJECTION_COMMIT: Dict[str, Any] = {}
 
 
 def _d(value: Any) -> Dict[str, Any]:
@@ -177,6 +178,51 @@ def _mark_ledger_failure(core: Any, error: Exception) -> None:
     pf["risk_controls"] = risk
 
 
+def _mark_projection_failure(core: Any, event: Dict[str, Any], error: Exception) -> None:
+    pf = _portfolio(core)
+    risk = _d(pf.setdefault("risk_controls", {}))
+    risk["canonical_state_projection_error"] = f"{type(error).__name__}: {error}"
+    risk["canonical_state_projection_error_local"] = _now(core)
+    risk["canonical_state_projection_execution_id"] = event.get("execution_id")
+    if not bool(risk.get("halted", False)):
+        risk["halted"] = True
+        risk["halt_reason"] = "canonical execution state projection commit failed"
+    pf["risk_controls"] = risk
+
+
+def _persist_projection(core: Any, event: Dict[str, Any]) -> None:
+    """Durably mirror a canonical execution before execution flow continues."""
+    global _LAST_PROJECTION_COMMIT
+    save = getattr(core, "save_state", None)
+    if not callable(save):
+        _LAST_PROJECTION_COMMIT = {
+            "status": "not_available",
+            "execution_id": event.get("execution_id"),
+            "recorded_local": _now(core),
+        }
+        return
+    try:
+        try:
+            save(_portfolio(core))
+        except TypeError:
+            save()
+    except Exception as exc:
+        _mark_projection_failure(core, event, exc)
+        _LAST_PROJECTION_COMMIT = {
+            "status": "fail",
+            "execution_id": event.get("execution_id"),
+            "recorded_local": _now(core),
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+        raise
+    _LAST_PROJECTION_COMMIT = {
+        "status": "committed",
+        "execution_id": event.get("execution_id"),
+        "event_hash": event.get("event_hash"),
+        "recorded_local": _now(core),
+    }
+
+
 def apply(core: Any = None) -> Dict[str, Any]:
     if core is None:
         return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
@@ -193,6 +239,7 @@ def apply(core: Any = None) -> Dict[str, Any]:
     @functools.wraps(prior)
     def wrapped(action, symbol, side, px, shares, extra=None):
         linked_extra = dict(extra) if isinstance(extra, dict) else {}
+        event: Dict[str, Any] = {}
         try:
             event = append_execution(action, symbol, side, px, shares, linked_extra, core)
             linked_extra["execution_id"] = event.get("execution_id")
@@ -202,7 +249,9 @@ def apply(core: Any = None) -> Dict[str, Any]:
         except Exception as exc:
             _mark_ledger_failure(core, exc)
             linked_extra["canonical_execution_ledger_error"] = f"{type(exc).__name__}: {exc}"
-        return prior(action, symbol, side, px, shares, linked_extra)
+        result = prior(action, symbol, side, px, shares, linked_extra)
+        _persist_projection(core, event)
+        return result
 
     wrapped._canonical_execution_ledger_version = VERSION  # type: ignore[attr-defined]
     wrapped._canonical_execution_ledger_prior = prior  # type: ignore[attr-defined]
@@ -237,6 +286,8 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "errors": (parse_errors + chain_errors)[:5],
         "historical_recovery_source": False,
         "authoritative_for_new_executions": bool(hooked and healthy),
+        "state_projection_commit_immediate": True,
+        "last_state_projection_commit": dict(_LAST_PROJECTION_COMMIT),
         "authority": {
             "records_execution_events": True,
             "repairs_historical_state": False,

--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -53,7 +53,10 @@ SHADOW_AI_TESTS = (
     "test_shadow_ai_evidence_store.py",
     "test_shadow_ai_observability.py",
 )
-STATE_SERIALIZATION_TESTS = ("test_issue165_state_serialization.py",)
+STATE_SERIALIZATION_TESTS = (
+    "test_issue165_state_serialization.py",
+    "test_issue172_canonical_state_commit.py",
+)
 PERFORMANCE_EVIDENCE_INTEGRITY_TESTS = (
     "test_issue167_forward_evidence_integrity.py",
     "test_issue170_performance_atr_integrity.py",
@@ -131,6 +134,9 @@ def _is_state_serialization_path(path: str) -> bool:
         "state_io_hardening.py",
         "cycle_completion_contract.py",
         "test_issue165_state_serialization.py",
+        "test_issue172_canonical_state_commit.py",
+        "v4_canonical_state_reconciliation.py",
+        "canonical_execution_ledger.py",
     }
 
 

--- a/data_integrity_startup_bridge.py
+++ b/data_integrity_startup_bridge.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-VERSION = "data-integrity-startup-bridge-2026-09-02-v40-v4-validation-release"
+VERSION = "data-integrity-startup-bridge-2026-09-03-v41-issue172-reconciliation"
 MODULES = (
     "final_daily_audit_compactor",
     "daily_audit_entry_count_bridge",
@@ -95,6 +95,10 @@ MODULES = (
     # the final v3->v4 state owner. It can change only v4 validation metadata
     # after the configured forward evidence and accounting gates pass.
     "verified_v4_validation_release",
+    # Exact Issue #172 write-ahead-ledger recovery.  It runs last, accepts only
+    # the demonstrated v4 two-exit divergence, archives evidence, reconciles
+    # state from immutable canonical rows, and preserves the lifecycle halt.
+    "v4_canonical_state_reconciliation",
 )
 
 

--- a/state_io_hardening.py
+++ b/state_io_hardening.py
@@ -39,6 +39,7 @@ SERIALIZE_RETRY_SLEEP = 0.01
 
 _THREAD_LOCK = threading.RLock()
 _RUN_LOCK = threading.RLock()
+_STATUS_LOCK = threading.Lock()
 _RUN_STATE: Dict[str, Any] = {
     "active": False,
     "started_ts": None,
@@ -303,15 +304,16 @@ def _record_status(event: str, extra: Optional[Dict[str, Any]] = None) -> None:
     }
     if extra:
         payload.update(extra)
-    _LAST_STATUS = payload
-    try:
-        _ensure_parent(STATE_IO_STATUS_FILE)
-        tmp = STATE_IO_STATUS_FILE + ".tmp"
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(payload, f, indent=2, sort_keys=True, default=_json_default)
-        os.replace(tmp, STATE_IO_STATUS_FILE)
-    except Exception:
-        pass
+    with _STATUS_LOCK:
+        _LAST_STATUS = payload
+        try:
+            _ensure_parent(STATE_IO_STATUS_FILE)
+            tmp = STATE_IO_STATUS_FILE + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(payload, f, indent=2, sort_keys=True, default=_json_default)
+            os.replace(tmp, STATE_IO_STATUS_FILE)
+        except Exception:
+            pass
 
 
 def status_payload(module: Any | None = None) -> Dict[str, Any]:

--- a/state_io_hardening.py
+++ b/state_io_hardening.py
@@ -21,7 +21,7 @@ import threading
 import time
 from typing import Any, Dict, Optional
 
-VERSION = "state-io-hardening-2026-09-03-v2-stable-serialization"
+VERSION = "state-io-hardening-2026-09-03-v3-mutation-lock"
 
 STATE_DIR = os.environ.get("STATE_DIR") or os.environ.get("PERSISTENT_STATE_DIR") or os.environ.get("RAILWAY_VOLUME_MOUNT_PATH") or "."
 STATE_FILENAME = os.environ.get("STATE_FILENAME", os.environ.get("STATE_FILE", "state.json"))
@@ -38,7 +38,7 @@ SERIALIZE_RETRIES = 5
 SERIALIZE_RETRY_SLEEP = 0.01
 
 _THREAD_LOCK = threading.RLock()
-_RUN_LOCK = threading.Lock()
+_RUN_LOCK = threading.RLock()
 _RUN_STATE: Dict[str, Any] = {
     "active": False,
     "started_ts": None,
@@ -337,6 +337,7 @@ def status_payload(module: Any | None = None) -> Dict[str, Any]:
         "protections": {
             "atomic_save_state": True,
             "stable_pre_serialization": True,
+            "guarded_run_mutation_lock_serialization": True,
             "bounded_concurrent_mutation_retries": SERIALIZE_RETRIES,
             "retrying_json_reads": True,
             "backup_fallback_reads": True,
@@ -392,15 +393,20 @@ def install(module: Any) -> Dict[str, Any]:
     def hardened_save_state(state, *args, **kwargs):
         if not isinstance(state, dict):
             state = dict(state or {}) if state is not None else {}
-        with _THREAD_LOCK:
-            with _FileLock(exclusive=True):
-                backup = backup_current_state()
-                atomic_json_write(state_file, state)
-                _record_status("atomic_save_state", {
-                    "backup": backup,
-                    "state_quality_after": _quality(state),
-                    "state_size_after": _size(state_file),
-                })
+        # Do not serialize while guarded_run_cycle is between a position
+        # mutation and its execution mirror.  This lock is reentrant because an
+        # execution commit saves from inside that same guarded cycle.
+        with _RUN_LOCK:
+            with _THREAD_LOCK:
+                with _FileLock(exclusive=True):
+                    backup = backup_current_state()
+                    atomic_json_write(state_file, state)
+                    _record_status("atomic_save_state", {
+                        "backup": backup,
+                        "state_quality_after": _quality(state),
+                        "state_size_after": _size(state_file),
+                        "run_mutation_lock_held": True,
+                    })
         return None
 
     def guarded_run_cycle(*args, **kwargs):

--- a/test_issue165_state_serialization.py
+++ b/test_issue165_state_serialization.py
@@ -12,6 +12,22 @@ import state_io_hardening as state_io
 
 
 class Issue165StateSerializationTests(unittest.TestCase):
+    def test_save_waits_inside_core_mutation_lock(self):
+        events = []
+
+        core = types.SimpleNamespace(
+            STATE_FILE="unused.json",
+            load_state=lambda: {},
+            save_state=lambda _state: None,
+        )
+        with mock.patch.object(state_io, "backup_current_state", return_value={}), mock.patch.object(
+            state_io, "atomic_json_write", side_effect=lambda _path, _state: events.append("write") or True
+        ), mock.patch.object(state_io, "_record_status"):
+            state_io.install(core)
+            core.save_state({"cash": 100.0})
+
+        self.assertEqual(events, ["write"])
+
     def test_atomic_write_retries_transient_dictionary_mutation(self):
         real_dumps = json.dumps
         attempts = []

--- a/test_issue172_canonical_state_commit.py
+++ b/test_issue172_canonical_state_commit.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import copy
+import json
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import canonical_execution_ledger as ledger
+import v4_canonical_state_reconciliation as recovery
+
+
+def _row(execution_id, event_hash, action, symbol, price, shares):
+    return {
+        "execution_id": execution_id,
+        "event_hash": event_hash,
+        "previous_event_hash": "",
+        "ledger_version": ledger.VERSION,
+        "recorded_local": "2026-09-03 09:59:24 CDT",
+        "accounting_epoch_id": recovery.EPOCH_ID,
+        "action": action,
+        "symbol": symbol,
+        "side": "short",
+        "price": price,
+        "shares": shares,
+        "exit_reason": "structure_stop_short" if action == "exit" else None,
+    }
+
+
+def _fixture():
+    mu_entry = _row("mu-entry", "mu-entry-hash", "entry", "MU", 935.83, 1.079923684)
+    stx_entry = _row("stx-entry", "stx-entry-hash", "entry", "STX", 783.175, 1.290454899)
+    mu_exit_id, stx_exit_id = sorted(recovery.EXPECTED_MISSING)
+    expected_a = recovery.EXPECTED_MISSING[mu_exit_id]
+    expected_b = recovery.EXPECTED_MISSING[stx_exit_id]
+    missing = {
+        expected_a["symbol"]: _row(mu_exit_id, expected_a["event_hash"], "exit", expected_a["symbol"], expected_a["price"], expected_a["shares"]),
+        expected_b["symbol"]: _row(stx_exit_id, expected_b["event_hash"], "exit", expected_b["symbol"], expected_b["price"], expected_b["shares"]),
+    }
+    rows = [mu_entry, stx_entry, missing["MU"], missing["STX"]]
+    trades = []
+    for row in rows[:2]:
+        trades.append({
+            "time": "2026-09-03 09:20:00 CDT",
+            "action": row["action"], "symbol": row["symbol"], "side": row["side"],
+            "price": row["price"], "shares": row["shares"],
+            "execution_id": row["execution_id"],
+            "accounting_epoch_id": recovery.EPOCH_ID,
+            "canonical_ledger_event_hash": row["event_hash"],
+            "canonical_ledger_version": ledger.VERSION,
+        })
+    positions = {
+        "MU": {"side": "short", "entry": 935.83, "shares": 1.079923684, "margin": 935.83 * 1.079923684, "last_price": 940.0},
+        "STX": {"side": "short", "entry": 783.175, "shares": 1.290454899, "margin": 783.175 * 1.290454899, "last_price": 786.0},
+    }
+    cash = 10000.0 - sum(pos["margin"] for pos in positions.values())
+    state = {
+        "accounting_epoch_id": recovery.EPOCH_ID,
+        "paper_accounting_epoch": {"id": recovery.EPOCH_ID, "validation_hold": False},
+        "initial_cash": 10000.0,
+        "cash": cash,
+        "equity": cash + sum(pos["margin"] for pos in positions.values()),
+        "positions": positions,
+        "trades": trades,
+        "realized_pnl": {"today": 0.0, "total": -400.0},
+        "performance": {"open_positions": copy.deepcopy(positions), "unrealized_pnl": 0.0},
+        "risk_controls": {
+            "halted": True, "halt_reason": recovery.HALT_REASON,
+            "day_start_equity": 10000.0, "day_peak_equity": 10025.0,
+        },
+        "history": [10000.0, 10005.0],
+    }
+    return rows, state
+
+
+class Issue172CanonicalStateCommitTests(unittest.TestCase):
+    def test_execution_mirror_is_persisted_before_record_trade_returns(self):
+        with tempfile.TemporaryDirectory() as directory:
+            ledger_path = Path(directory) / "ledger.jsonl"
+            portfolio = {"risk_controls": {"halted": False}, "accounting_epoch_id": "epoch-test", "trades": []}
+            calls = []
+            saves = []
+
+            def mirror(action, symbol, side, px, shares, extra=None):
+                row = {"action": action, "symbol": symbol, "side": side, "price": px, "shares": shares, **(extra or {})}
+                calls.append(row)
+                portfolio["trades"].append(row)
+
+            def save(state):
+                saves.append({
+                    "execution_ids": [row.get("execution_id") for row in state.get("trades", [])],
+                    "ledger_rows": len(ledger_path.read_text().splitlines()),
+                })
+
+            core = types.SimpleNamespace(
+                portfolio=portfolio, record_trade=mirror, save_state=save,
+                local_ts_text=lambda: "2026-09-03 12:00:00 CDT",
+            )
+            with mock.patch.object(ledger, "LEDGER_FILE", str(ledger_path)):
+                ledger.apply(core)
+                core.record_trade("entry", "QQQ", "long", 100, 2, {})
+                status = ledger.status_payload(core)
+
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(saves, [{"execution_ids": [calls[0]["execution_id"]], "ledger_rows": 1}])
+            self.assertEqual(status["last_state_projection_commit"]["status"], "committed")
+
+    def test_projection_persist_failure_halts_and_propagates(self):
+        with tempfile.TemporaryDirectory() as directory:
+            portfolio = {"risk_controls": {"halted": False}, "accounting_epoch_id": "epoch-test", "trades": []}
+            calls = []
+
+            def mirror(action, symbol, side, px, shares, extra=None):
+                row = {"action": action, "symbol": symbol, "side": side, "price": px, "shares": shares, **(extra or {})}
+                calls.append(row)
+                portfolio["trades"].append(row)
+
+            def fail_save(_state):
+                raise OSError("volume unavailable")
+
+            core = types.SimpleNamespace(
+                portfolio=portfolio, record_trade=mirror, save_state=fail_save,
+                local_ts_text=lambda: "2026-09-03 12:00:00 CDT",
+            )
+            with mock.patch.object(ledger, "LEDGER_FILE", str(Path(directory) / "ledger.jsonl")):
+                ledger.apply(core)
+                with self.assertRaisesRegex(OSError, "volume unavailable"):
+                    core.record_trade("exit", "QQQ", "long", 100, 1, {})
+
+            self.assertEqual(len(calls), 1)
+            self.assertTrue(portfolio["risk_controls"]["halted"])
+            self.assertEqual(portfolio["risk_controls"]["halt_reason"], "canonical execution state projection commit failed")
+            self.assertEqual(portfolio["risk_controls"]["canonical_state_projection_execution_id"], calls[0]["execution_id"])
+
+    def test_exact_ledger_only_exits_reconcile_state_and_preserve_halt(self):
+        rows, state = _fixture()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            ledger_path = root / "canonical.jsonl"
+            ledger_path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+            saved = []
+            core = types.SimpleNamespace(
+                portfolio=state,
+                local_ts_text=lambda: "2026-09-03 12:00:00 CDT",
+                save_state=lambda value: saved.append(copy.deepcopy(value)),
+            )
+            with mock.patch.object(ledger, "LEDGER_FILE", str(ledger_path)), mock.patch.object(
+                ledger, "_read_rows", return_value=(copy.deepcopy(rows), [])
+            ), mock.patch.object(ledger, "_verify_rows", return_value=(True, [])), mock.patch.object(
+                recovery, "STATE_DIR", str(root)
+            ), mock.patch.object(recovery, "MARKER_FILE", str(root / "marker.json")):
+                result = recovery.apply(core)
+
+            self.assertEqual(result["status"], "completed")
+            self.assertTrue(saved)
+            self.assertEqual(saved[-1]["positions"], {})
+            self.assertEqual(len(saved[-1]["trades"]), 4)
+            self.assertTrue(saved[-1]["risk_controls"]["halted"])
+            self.assertEqual(saved[-1]["risk_controls"]["halt_reason"], recovery.HALT_REASON)
+            self.assertEqual(saved[-1]["history"], [10000.0, 10005.0])
+            self.assertFalse(result["canonical_history_rewritten"])
+            self.assertFalse(result["risk_halt_cleared"])
+            self.assertTrue((root / "marker.json").exists())
+            self.assertTrue(list((root / "forensic_archives").glob("*_issue172_canonical_state_divergence")))
+
+    def test_nonexact_missing_set_is_observational_only(self):
+        rows, state = _fixture()
+        rows = rows[:-1]
+        saves = []
+        core = types.SimpleNamespace(portfolio=state, save_state=lambda value: saves.append(value))
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+            ledger, "_read_rows", return_value=(copy.deepcopy(rows), [])
+        ), mock.patch.object(ledger, "_verify_rows", return_value=(True, [])), mock.patch.object(
+            recovery, "MARKER_FILE", str(Path(directory) / "marker.json")
+        ):
+            result = recovery.apply(core)
+
+        self.assertEqual(result["status"], "not_applicable")
+        self.assertEqual(saves, [])
+        self.assertFalse(result["canonical_history_rewritten"])
+        self.assertFalse(result["risk_halt_cleared"])
+
+    def test_reconciliation_is_blocked_outside_paper_runtime(self):
+        rows, state = _fixture()
+        saves = []
+        core = types.SimpleNamespace(portfolio=state, save_state=lambda value: saves.append(value))
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+            recovery, "MARKER_FILE", str(Path(directory) / "marker.json")
+        ), mock.patch.object(recovery.v3, "_paper_only", return_value=False):
+            result = recovery.apply(core)
+
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(result["reason"], "paper_runtime_required")
+        self.assertEqual(saves, [])
+
+    def test_interrupted_marker_fails_closed_without_state_write(self):
+        _, state = _fixture()
+        saves = []
+        core = types.SimpleNamespace(portfolio=state, save_state=lambda value: saves.append(value))
+        with tempfile.TemporaryDirectory() as directory:
+            marker_path = Path(directory) / "marker.json"
+            marker_path.write_text(json.dumps({"status": "repair_started"}), encoding="utf-8")
+            with mock.patch.object(recovery, "MARKER_FILE", str(marker_path)):
+                result = recovery.apply(core)
+
+        self.assertEqual(result["status"], "fail")
+        self.assertEqual(result["reason"], "interrupted_reconciliation_requires_inspection")
+        self.assertEqual(saves, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/v4_canonical_state_reconciliation.py
+++ b/v4_canonical_state_reconciliation.py
@@ -1,0 +1,385 @@
+"""Exact Issue #172 recovery for canonical exits missing from portfolio state.
+
+The canonical ledger is the write-ahead source of truth.  This one-time paper
+recovery accepts only the demonstrated v4 shape: two exact terminal exits are
+present in the valid ledger, absent from state.trades, and their matching short
+positions remain open in state under the exact lifecycle-integrity halt.  It
+archives the pre-repair state and ledger, applies only those two exits, preserves
+the halt/risk/history/epoch records, and never edits canonical history.
+"""
+from __future__ import annotations
+
+import copy
+import datetime as dt
+import hashlib
+import json
+import os
+import shutil
+import threading
+from typing import Any, Dict, List, Tuple
+
+import verified_v3_successor_epoch_migration as v3
+
+VERSION = "v4-canonical-state-reconciliation-2026-09-03-v1-issue172"
+EPOCH_ID = "stable-paper-v4-20260826-successor01"
+HALT_REASON = "canonical execution lifecycle integrity halt"
+STATE_DIR = os.environ.get("STATE_DIR") or os.environ.get("PERSISTENT_STATE_DIR") or os.environ.get("RAILWAY_VOLUME_MOUNT_PATH") or "."
+MARKER_FILE = os.path.join(STATE_DIR, "issue172_v4_canonical_state_reconciliation.json")
+EXPECTED_MISSING = {
+    "30c048c400aa44a68a2748609f8b807f": {
+        "event_hash": "936aec884007c268c6223bd94d0b226a462aa7f89bc92f05d83edecddeaa6314",
+        "symbol": "MU", "side": "short", "action": "exit", "price": 944.375, "shares": 1.079923684,
+    },
+    "f318d4513c5f4f119cfaa577d5f685a9": {
+        "event_hash": "b1fd75f23d2d8327eebaf9d640bae9202c117a51f9b0de2f50d70fb77da56ad4",
+        "symbol": "STX", "side": "short", "action": "exit", "price": 789.848572, "shares": 1.290454899,
+    },
+}
+_LOCK = threading.RLock()
+_REGISTERED_APP_IDS: set[int] = set()
+_LAST: Dict[str, Any] = {}
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or isinstance(value, bool):
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def _now(core: Any = None) -> str:
+    try:
+        return str(core.local_ts_text())
+    except Exception:
+        return dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _read_marker() -> Dict[str, Any]:
+    try:
+        with open(MARKER_FILE, "r", encoding="utf-8") as handle:
+            value = json.load(handle)
+        return value if isinstance(value, dict) else {}
+    except Exception:
+        return {}
+
+
+def _atomic_json(path: str, payload: Dict[str, Any]) -> None:
+    folder = os.path.dirname(os.path.abspath(path))
+    os.makedirs(folder, exist_ok=True)
+    tmp = f"{path}.{os.getpid()}.{threading.get_ident()}.tmp"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, sort_keys=True, separators=(",", ":"), default=str)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def _close(left: Any, right: Any, tolerance: float) -> bool:
+    return abs(_f(left) - _f(right)) <= tolerance
+
+
+def _exact_missing_rows(rows: List[Dict[str, Any]]) -> Tuple[Dict[str, Dict[str, Any]], List[str]]:
+    found: Dict[str, Dict[str, Any]] = {}
+    issues: List[str] = []
+    for row in rows:
+        execution_id = str(row.get("execution_id") or "")
+        expected = EXPECTED_MISSING.get(execution_id)
+        if expected is None:
+            continue
+        checks = (
+            str(row.get("accounting_epoch_id") or "") == EPOCH_ID,
+            str(row.get("event_hash") or "") == expected["event_hash"],
+            str(row.get("symbol") or "").upper() == expected["symbol"],
+            str(row.get("side") or "").lower() == expected["side"],
+            str(row.get("action") or "").lower() == expected["action"],
+            _close(row.get("price"), expected["price"], 5e-7),
+            _close(row.get("shares"), expected["shares"], 5e-10),
+        )
+        if not all(checks):
+            issues.append(f"missing_exit_signature_mismatch:{execution_id}")
+        elif execution_id in found:
+            issues.append(f"duplicate_missing_exit:{execution_id}")
+        else:
+            found[execution_id] = row
+    if set(found) != set(EXPECTED_MISSING):
+        issues.append("exact_missing_exit_set_not_present")
+    return found, issues
+
+
+def _preflight(core: Any) -> Dict[str, Any]:
+    pf = v3._portfolio(core)
+    issues: List[str] = []
+    if v3._epoch_id(pf) != EPOCH_ID:
+        issues.append("active_epoch_not_exact_v4")
+    risk = _d(pf.get("risk_controls"))
+    if not bool(risk.get("halted")) or str(risk.get("halt_reason") or "") != HALT_REASON:
+        issues.append("exact_lifecycle_halt_not_active")
+
+    try:
+        import canonical_execution_ledger as ledger
+        with ledger._LOCK:
+            rows, parse_errors = ledger._read_rows()
+            chain_valid, chain_errors = ledger._verify_rows(rows)
+    except Exception as exc:
+        return {"status": "fail", "issues": [f"ledger_read_error:{type(exc).__name__}:{exc}"]}
+    if parse_errors or not chain_valid:
+        issues.append("canonical_ledger_not_valid")
+    execution_ids = [str(row.get("execution_id") or "") for row in rows]
+    if not all(execution_ids) or len(execution_ids) != len(set(execution_ids)):
+        issues.append("canonical_execution_ids_not_unique")
+
+    v4_rows = [row for row in rows if str(row.get("accounting_epoch_id") or "") == EPOCH_ID]
+    state_rows = [row for row in _l(pf.get("trades")) if isinstance(row, dict)]
+    state_by_id = {str(row.get("execution_id") or ""): row for row in state_rows if str(row.get("execution_id") or "")}
+    v4_by_id = {str(row.get("execution_id") or ""): row for row in v4_rows}
+    missing_ids = set(v4_by_id) - set(state_by_id)
+    state_only_ids = set(state_by_id) - set(v4_by_id)
+    if missing_ids != set(EXPECTED_MISSING):
+        issues.append("state_missing_execution_set_not_exact")
+    if state_only_ids:
+        issues.append("state_contains_noncanonical_execution")
+    for execution_id, state_row in state_by_id.items():
+        canonical = v4_by_id.get(execution_id)
+        if canonical is None or str(state_row.get("canonical_ledger_event_hash") or "") != str(canonical.get("event_hash") or ""):
+            issues.append(f"state_canonical_binding_mismatch:{execution_id}")
+
+    missing_rows, signature_issues = _exact_missing_rows(v4_rows)
+    issues.extend(signature_issues)
+    positions = _d(pf.get("positions"))
+    if set(positions) != {"MU", "STX"}:
+        issues.append("stale_position_set_not_exact")
+    for expected in EXPECTED_MISSING.values():
+        position = _d(positions.get(expected["symbol"]))
+        if str(position.get("side") or "").lower() != "short":
+            issues.append(f"stale_position_side_mismatch:{expected['symbol']}")
+        if not _close(position.get("shares", position.get("qty")), expected["shares"], 5e-6):
+            issues.append(f"stale_position_quantity_mismatch:{expected['symbol']}")
+
+    try:
+        import paper_bidirectional_accounting_guard as accounting
+        rebuilt = accounting.analyze_ledger(pf, core)
+    except Exception as exc:
+        rebuilt = {"coverage_complete": False, "error": f"{type(exc).__name__}:{exc}"}
+    if not bool(rebuilt.get("coverage_complete")) or int(rebuilt.get("coverage_issue_count") or 0) or int(rebuilt.get("economic_issue_count") or 0):
+        issues.append("pre_repair_state_accounting_not_clean")
+
+    return {
+        "status": "ok" if not issues else "fail",
+        "issues": issues,
+        "rows": rows,
+        "v4_rows": v4_rows,
+        "state_rows": state_rows,
+        "state_by_id": state_by_id,
+        "missing_rows": missing_rows,
+        "ledger_file": str(getattr(ledger, "LEDGER_FILE", "")),
+        "rebuilt_before": rebuilt,
+    }
+
+
+def _mirror_row(row: Dict[str, Any]) -> Dict[str, Any]:
+    mirror = {
+        "time": str(row.get("recorded_local") or ""),
+        "action": str(row.get("action") or ""),
+        "symbol": str(row.get("symbol") or ""),
+        "side": str(row.get("side") or ""),
+        "price": round(_f(row.get("price")), 4),
+        "shares": round(_f(row.get("shares")), 6),
+        "execution_id": str(row.get("execution_id") or ""),
+        "accounting_epoch_id": str(row.get("accounting_epoch_id") or ""),
+        "canonical_ledger_event_hash": str(row.get("event_hash") or ""),
+        "canonical_ledger_version": str(row.get("ledger_version") or ""),
+    }
+    excluded = {
+        "execution_id", "ledger_version", "recorded_local", "accounting_epoch_id",
+        "action", "symbol", "side", "price", "shares", "previous_event_hash", "event_hash",
+    }
+    for key, value in row.items():
+        if key not in excluded:
+            mirror[key] = copy.deepcopy(value)
+    return mirror
+
+
+def _archive(core: Any, pf: Dict[str, Any], ledger_file: str) -> Dict[str, Any]:
+    stamp = dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    folder = os.path.join(STATE_DIR, "forensic_archives", f"{stamp}_issue172_canonical_state_divergence")
+    os.makedirs(folder, exist_ok=False)
+    state_path = os.path.join(folder, "state_before.json")
+    _atomic_json(state_path, pf)
+    ledger_copy = None
+    if ledger_file and os.path.exists(ledger_file):
+        ledger_copy = os.path.join(folder, "canonical_execution_ledger_immutable_copy.jsonl")
+        shutil.copy2(ledger_file, ledger_copy)
+    return {"archive_dir": folder, "state_file": state_path, "ledger_copy": ledger_copy}
+
+
+def _repair(core: Any, preflight: Dict[str, Any]) -> Dict[str, Any]:
+    pf = v3._portfolio(core)
+    successor = copy.deepcopy(pf)
+    state_by_id = _d(preflight.get("state_by_id"))
+    ordered_trades: List[Dict[str, Any]] = []
+    realized_delta = 0.0
+    cash_delta = 0.0
+    for row in _l(preflight.get("v4_rows")):
+        execution_id = str(row.get("execution_id") or "")
+        if execution_id in state_by_id:
+            ordered_trades.append(copy.deepcopy(state_by_id[execution_id]))
+            continue
+        expected = EXPECTED_MISSING[execution_id]
+        position = _d(_d(pf.get("positions")).get(expected["symbol"]))
+        entry = _f(position.get("entry", position.get("entry_price")))
+        qty = _f(row.get("shares"))
+        exit_price = _f(row.get("price"))
+        pnl = (entry - exit_price) * qty
+        realized_delta += pnl
+        cash_delta += (entry * qty) + pnl
+        ordered_trades.append(_mirror_row(row))
+
+    successor["trades"] = ordered_trades[-500:]
+    successor["cash"] = _f(pf.get("cash")) + cash_delta
+    successor["equity"] = successor["cash"]
+    successor["positions"] = {}
+    realized = _d(successor.setdefault("realized_pnl", {}))
+    realized["today"] = round(_f(realized.get("today")) + realized_delta, 2)
+    realized["total"] = round(_f(realized.get("total")) + realized_delta, 2)
+    successor["realized_pnl"] = realized
+    performance = _d(successor.setdefault("performance", {}))
+    performance["open_positions"] = {}
+    performance["unrealized_pnl"] = 0.0
+    performance["realized_pnl_today"] = realized["today"]
+    performance["realized_pnl_total"] = realized["total"]
+    successor["performance"] = performance
+    # Preserve the exact active halt and every risk/day-peak field.  Release is
+    # a separate governed decision after settled post-deploy validation.
+    successor["risk_controls"] = copy.deepcopy(_d(pf.get("risk_controls")))
+    successor["issue172_reconciliation"] = {
+        "version": VERSION,
+        "status": "reconciled_halt_preserved",
+        "completed_local": _now(core),
+        "execution_ids": sorted(EXPECTED_MISSING),
+        "realized_delta": round(realized_delta, 6),
+        "cash_delta": round(cash_delta, 6),
+        "canonical_history_rewritten": False,
+        "risk_halt_cleared": False,
+    }
+
+    try:
+        import paper_bidirectional_accounting_guard as accounting
+        rebuilt_after = accounting.analyze_ledger(successor, core)
+    except Exception as exc:
+        raise RuntimeError(f"post-repair accounting unavailable:{type(exc).__name__}:{exc}") from exc
+    if not bool(rebuilt_after.get("coverage_complete")) or int(rebuilt_after.get("coverage_issue_count") or 0) or int(rebuilt_after.get("economic_issue_count") or 0):
+        raise RuntimeError("post-repair accounting projection is not complete")
+    if _d(rebuilt_after.get("open_positions")):
+        raise RuntimeError("post-repair canonical projection is not flat")
+    if not _close(successor.get("cash"), rebuilt_after.get("cash"), 0.05):
+        raise RuntimeError("post-repair cash does not match deterministic accounting")
+
+    archive = _archive(core, copy.deepcopy(pf), str(preflight.get("ledger_file") or ""))
+    marker = {
+        "status": "repair_started", "overall": "warn", "version": VERSION,
+        "started_local": _now(core), "archive": archive,
+        "execution_ids": sorted(EXPECTED_MISSING),
+    }
+    _atomic_json(MARKER_FILE, marker)
+    save = getattr(core, "save_state", None)
+    if not callable(save):
+        raise RuntimeError("core.save_state unavailable")
+    try:
+        save(successor)
+    except TypeError:
+        save()
+    pf.clear()
+    pf.update(successor)
+    marker.update({
+        "status": "completed", "overall": "pass", "completed_local": _now(core),
+        "canonical_history_rewritten": False, "risk_halt_cleared": False,
+        "cash": successor.get("cash"), "equity": successor.get("equity"),
+        "positions": [], "state_trade_rows": len(ordered_trades),
+        "rebuilt_after": rebuilt_after,
+    })
+    _atomic_json(MARKER_FILE, marker)
+    return marker
+
+
+def apply(core: Any = None) -> Dict[str, Any]:
+    global _LAST
+    if core is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
+    with _LOCK:
+        marker = _read_marker()
+        if marker.get("status") == "completed":
+            _LAST = marker
+            return dict(marker)
+        if marker.get("status") == "repair_started":
+            result = {
+                "status": "fail", "overall": "fail", "version": VERSION,
+                "reason": "interrupted_reconciliation_requires_inspection",
+                "marker": marker, "canonical_history_rewritten": False,
+                "risk_halt_cleared": False,
+            }
+            _LAST = result
+            return result
+        if not v3._paper_only():
+            result = {
+                "status": "blocked", "overall": "fail", "version": VERSION,
+                "reason": "paper_runtime_required", "canonical_history_rewritten": False,
+                "risk_halt_cleared": False,
+            }
+            _LAST = result
+            return result
+        preflight = _preflight(core)
+        if preflight.get("status") != "ok":
+            result = {
+                "status": "not_applicable", "overall": "pass", "version": VERSION,
+                "reason": "exact_issue172_shape_not_present", "preflight_issues": preflight.get("issues", []),
+                "canonical_history_rewritten": False, "risk_halt_cleared": False,
+            }
+            _LAST = result
+            return result
+        try:
+            result = _repair(core, preflight)
+        except Exception as exc:
+            result = {
+                "status": "fail", "overall": "fail", "version": VERSION,
+                "error": f"{type(exc).__name__}: {exc}", "canonical_history_rewritten": False,
+                "risk_halt_cleared": False,
+            }
+        _LAST = result
+        return dict(result)
+
+
+def status_payload(core: Any = None) -> Dict[str, Any]:
+    marker = _read_marker()
+    payload = marker or _LAST
+    if payload:
+        return dict(payload)
+    if core is None:
+        return {"status": "pending", "overall": "warn", "version": VERSION}
+    preflight = _preflight(core)
+    return {
+        "status": "ready" if preflight.get("status") == "ok" else "not_applicable",
+        "overall": "warn" if preflight.get("status") == "ok" else "pass",
+        "version": VERSION, "preflight_issues": preflight.get("issues", []),
+        "canonical_history_rewritten": False, "risk_halt_cleared": False,
+    }
+
+
+def register_routes(flask_app: Any, core: Any = None) -> Dict[str, Any]:
+    if flask_app is not None and id(flask_app) not in _REGISTERED_APP_IDS:
+        from flask import jsonify
+        path = "/paper/v4-canonical-state-reconciliation-status"
+        existing = {getattr(rule, "rule", "") for rule in flask_app.url_map.iter_rules()}
+        if path not in existing:
+            flask_app.add_url_rule(path, "v4_canonical_state_reconciliation_status", lambda: jsonify(status_payload(core)))
+        _REGISTERED_APP_IDS.add(id(flask_app))
+    return status_payload(core)


### PR DESCRIPTION
Closes #172 (repair stage; governed halt release remains separate).

## Problem
Canonical MU/STX terminal exits were fsynced while the persisted portfolio projection remained stale across a restart. A later cycle correctly detected the duplicate lifecycle and latched the canonical execution integrity halt.

## Bounded fix
- Persist the canonical state mirror before `record_trade` returns.
- Serialize state saves against the guarded run-cycle mutation boundary with a reentrant lock.
- Add an exact, paper-only one-time v4 reconciliation for only the two demonstrated MU/STX exit rows.
- Archive pre-repair state and ledger evidence.
- Preserve the exact active halt, day peaks, history, epoch, and immutable canonical ledger.
- Fail closed on projection-save errors, live runtime, nonexact evidence, or an interrupted recovery marker.
- Add read-only reconciliation status and focused regressions.

## Safety
No strategy, signals, ranking, sizing, exposure, hard-risk limits, live authority, ML/AI authority, order authority, credentials, or canonical history are changed. The halt is deliberately not cleared by this PR.

## Local validation
- 16 focused execution/state/recovery tests pass.
- Change Safety: pass (77 selected regressions).
- Refactor audit: zero new critical or warning findings; zero import cycles.
- Architecture-debt regression: pass.
- Repository/config validation: pass.
- Exact Gunicorn smoke must pass in CI; the local sandbox reached deferred loading but blocks outbound ticker bootstrap traffic.