### PR TITLE
Fix daily audit cycle contract version drift

### DIFF
--- a/.github/workflows/daily-operational-audit.yml
+++ b/.github/workflows/daily-operational-audit.yml
@@ -18,6 +18,7 @@ on:
       - "test_daily_operational_audit.py"
       - "test_runtime_repair_contracts.py"
       - "test_daily_data_integrity_overlay_v2.py"
+      - "test_daily_operational_audit_workflow.py"
       - "usercustomize.py"
       - ".github/workflows/daily-operational-audit.yml"
   workflow_dispatch:
@@ -45,13 +46,18 @@ jobs:
           python -m unittest -v \
             test_daily_operational_audit.py \
             test_runtime_repair_contracts.py \
-            test_daily_data_integrity_overlay_v2.py
+            test_daily_data_integrity_overlay_v2.py \
+            test_daily_operational_audit_workflow.py
 
       - name: Wait for the repaired Railway runtime
         id: deployment_ready
         run: |
           base=https://web-production-e1796.up.railway.app
-          expected=cycle-completion-contract-2026-08-04-v2-rebind-safe
+          expected=$(python - <<'PY'
+          import cycle_completion_contract as contract
+          print(contract.VERSION)
+          PY
+          )
           ready=false
           for attempt in $(seq 1 60); do
             if curl --silent --show-error --fail --max-time 20 \
@@ -104,6 +110,7 @@ jobs:
           python - <<'PY'
           import json
           from pathlib import Path
+          import cycle_completion_contract as cycle_contract
 
           bootstrap = json.loads(Path("bootstrap_status_live.json").read_text(encoding="utf-8"))
           daily = json.loads(Path("daily_operational_audit_live.json").read_text(encoding="utf-8"))
@@ -141,7 +148,7 @@ jobs:
           assert sections.get("12_next_action", {}).get("status") in {"none", "required"}
 
           assert cycle.get("status") == "ok" and cycle.get("installed") is True, cycle
-          assert cycle.get("version") == "cycle-completion-contract-2026-08-04-v2-rebind-safe", cycle
+          assert cycle.get("version") == cycle_contract.VERSION, cycle
           assert cycle.get("cycle_stale") is False, cycle
           assert provider.get("status") == "ok" and provider.get("installed") is True, provider
           assert state.get("status") == "ok", state

--- a/test_daily_operational_audit_workflow.py
+++ b/test_daily_operational_audit_workflow.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+WORKFLOW = Path(".github/workflows/daily-operational-audit.yml")
+
+
+class DailyOperationalAuditWorkflowTests(unittest.TestCase):
+    def test_cycle_contract_version_is_derived_from_runtime_source(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("import cycle_completion_contract as contract", text)
+        self.assertIn("print(contract.VERSION)", text)
+        self.assertIn("import cycle_completion_contract as cycle_contract", text)
+        self.assertIn('assert cycle.get("version") == cycle_contract.VERSION, cycle', text)
+
+    def test_obsolete_cycle_contract_literal_is_not_pinned(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        self.assertNotIn("cycle-completion-contract-2026-08-04-v2-rebind-safe", text)
+
+    def test_workflow_runs_this_regression(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        self.assertGreaterEqual(text.count("test_daily_operational_audit_workflow.py"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Demonstrated defect
The main-branch Daily Operational Audit Validation failed after PR #174 because `.github/workflows/daily-operational-audit.yml` still pinned `cycle-completion-contract-2026-08-04-v2-rebind-safe`, while the deployed/current source contract is `cycle-completion-contract-2026-09-03-v3-error-lifecycle`. The live endpoint itself returned `status=ok`, `overall=pass`, and `cycle_health=completed`; the stale workflow assertion created a false CI failure.

## Bounded fix
- Derive the expected cycle-contract version directly from `cycle_completion_contract.VERSION` in the checked-out exact head.
- Validate the live payload against that same source constant instead of duplicating a version literal.
- Add a focused regression proving the obsolete v2 literal is absent and the workflow remains source-derived.

## Safety boundary
Workflow/test-only. No runtime trading code, state, canonical ledger/history, halt, day peak, accounting, strategy, signals, sizing, hard-risk thresholds, live authority, ML/AI authority, or order authority changes.

The change is intended to restore trustworthy audit validation rather than weaken any runtime assertion.