### PR TITLE
Fix append-only handoff updates for repo agent

### DIFF
--- a/scripts/repo_agent.py
+++ b/scripts/repo_agent.py
@@ -24,12 +24,11 @@ MAX_INSTRUCTION = 4000
 MAX_CONTEXT_CHARS = 120000
 MAX_FILES = 8
 MAX_FILE_CHARS = 120000
+HANDOFF_PATH = "PROJECT_HANDOFF_CURRENT.md"
 
-# The first version is deliberately unable to rewrite its own authority,
-# repository workflows, or the authoritative project handoff.
-PROTECTED_EXACT = {
-    "PROJECT_HANDOFF_CURRENT.md",
-}
+# Repository workflows remain unconditionally protected. The authoritative
+# handoff may be updated only by an explicit handoff-only instruction and only
+# through the append-only guard below.
 PROTECTED_PREFIXES = (
     ".github/",
     ".git/",
@@ -46,7 +45,8 @@ Non-negotiable boundaries:
 - Never fabricate trades, execution-ledger rows, accounting history, prices, fills, or test evidence.
 - Never bypass the canonical execution ledger/accounting pipeline.
 - Prefer regression tests for correctness defects.
-- Do not edit GitHub workflows or PROJECT_HANDOFF_CURRENT.md; those are protected by the runner too.
+- Do not edit GitHub workflows.
+- PROJECT_HANDOFF_CURRENT.md may be edited only when the instruction explicitly requests a handoff-only update; such edits must preserve the entire existing file byte-for-byte and append new continuity text only.
 - Produce reviewable changes only. A human and CI decide whether to merge.
 
 Return exactly one JSON object with:
@@ -115,11 +115,11 @@ def build_context(instruction: str) -> str:
     pieces: list[str] = []
     total = 0
 
-    handoff = ROOT / "PROJECT_HANDOFF_CURRENT.md"
+    handoff = ROOT / HANDOFF_PATH
     if handoff.exists():
         text = handoff.read_text(encoding="utf-8", errors="replace")
         text = text[:30000]
-        pieces.append(f"\n===== PROJECT_HANDOFF_CURRENT.md =====\n{text}")
+        pieces.append(f"\n===== {HANDOFF_PATH} =====\n{text}")
         total += len(text)
 
     keys = keywords(instruction)
@@ -128,7 +128,7 @@ def build_context(instruction: str) -> str:
         if not safe_text_file(path):
             continue
         rel = path.relative_to(ROOT).as_posix()
-        if rel == "PROJECT_HANDOFF_CURRENT.md":
+        if rel == HANDOFF_PATH:
             continue
         try:
             text = path.read_text(encoding="utf-8", errors="replace")
@@ -212,11 +212,20 @@ def call_openai(instruction: str, context: str) -> dict[str, Any]:
     return result
 
 
-def validate_path(raw: str) -> Path:
+def handoff_only_requested(instruction: str) -> bool:
+    lowered = instruction.lower()
+    return HANDOFF_PATH.lower() in lowered and any(
+        token in lowered for token in ("handoff", "append", "continuity", "documentation-only", "documentation only")
+    )
+
+
+def validate_path(raw: str, *, allow_handoff: bool = False) -> Path:
     raw = raw.replace("\\", "/").strip()
     if not raw or raw.startswith("/") or ".." in Path(raw).parts:
         raise RuntimeError(f"Unsafe path from agent: {raw!r}")
-    if raw in PROTECTED_EXACT or raw.startswith(PROTECTED_PREFIXES):
+    if raw == HANDOFF_PATH and not allow_handoff:
+        raise RuntimeError(f"Agent attempted to modify protected path: {raw}")
+    if raw.startswith(PROTECTED_PREFIXES):
         raise RuntimeError(f"Agent attempted to modify protected path: {raw}")
     path = (ROOT / raw).resolve()
     if ROOT not in path.parents and path != ROOT:
@@ -224,12 +233,27 @@ def validate_path(raw: str) -> Path:
     return path
 
 
-def apply_files(result: dict[str, Any]) -> list[str]:
+def validate_handoff_append(path: Path, content: str) -> None:
+    original = path.read_text(encoding="utf-8") if path.exists() else ""
+    if not original:
+        raise RuntimeError("Authoritative handoff is missing or empty; append-only update refused.")
+    if not content.startswith(original):
+        raise RuntimeError("Handoff update must preserve the entire existing file byte-for-byte and append only.")
+    if len(content) <= len(original):
+        raise RuntimeError("Handoff update did not append new continuity content.")
+
+
+def apply_files(result: dict[str, Any], instruction: str) -> list[str]:
     files = result.get("files") or []
     if not isinstance(files, list) or not files:
         raise RuntimeError("Agent proposed no files.")
     if len(files) > MAX_FILES:
         raise RuntimeError(f"Agent proposed {len(files)} files; maximum is {MAX_FILES}.")
+
+    allow_handoff = handoff_only_requested(instruction)
+    proposed_paths = [str(item.get("path") or "") for item in files if isinstance(item, dict)]
+    if HANDOFF_PATH in proposed_paths and (not allow_handoff or proposed_paths != [HANDOFF_PATH]):
+        raise RuntimeError("Authoritative handoff updates must be explicitly requested and handoff-only.")
 
     changed: list[str] = []
     for item in files:
@@ -241,7 +265,9 @@ def apply_files(result: dict[str, Any]) -> list[str]:
             raise RuntimeError(f"Agent did not provide string content for {rel!r}.")
         if len(content) > MAX_FILE_CHARS:
             raise RuntimeError(f"Agent output for {rel} exceeds size limit.")
-        path = validate_path(rel)
+        path = validate_path(rel, allow_handoff=allow_handoff)
+        if rel == HANDOFF_PATH:
+            validate_handoff_append(path, content)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
         changed.append(path.relative_to(ROOT).as_posix())
@@ -300,7 +326,7 @@ def main() -> None:
     context = build_context(instruction)
     print(f"Grounded context size: {len(context)} characters")
     result = call_openai(instruction, context)
-    changed = apply_files(result)
+    changed = apply_files(result, instruction)
     print("Agent proposed:", ", ".join(changed))
     validate_changes()
     create_pr(result, changed, instruction)

--- a/test_repo_agent_preflight.py
+++ b/test_repo_agent_preflight.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 import scripts.repo_agent as repo_agent
 
 
@@ -20,3 +22,53 @@ def test_repo_agent_protects_authority_files():
 def test_repo_agent_allows_safe_repo_file():
     path = repo_agent.validate_path("REPO_AGENT_TEST.md")
     assert path == (Path.cwd() / "REPO_AGENT_TEST.md").resolve()
+
+
+def test_repo_agent_allows_explicit_handoff_only_append(tmp_path, monkeypatch):
+    monkeypatch.setattr(repo_agent, "ROOT", tmp_path.resolve())
+    handoff = tmp_path / repo_agent.HANDOFF_PATH
+    handoff.write_text("existing handoff\n", encoding="utf-8")
+
+    changed = repo_agent.apply_files(
+        {
+            "files": [
+                {
+                    "path": repo_agent.HANDOFF_PATH,
+                    "content": "existing handoff\n\n## New audit\nPASS\n",
+                }
+            ]
+        },
+        "Append a documentation-only continuity update to PROJECT_HANDOFF_CURRENT.md.",
+    )
+
+    assert changed == [repo_agent.HANDOFF_PATH]
+    assert handoff.read_text(encoding="utf-8") == "existing handoff\n\n## New audit\nPASS\n"
+
+
+def test_repo_agent_rejects_handoff_rewrite_even_when_requested(tmp_path, monkeypatch):
+    monkeypatch.setattr(repo_agent, "ROOT", tmp_path.resolve())
+    handoff = tmp_path / repo_agent.HANDOFF_PATH
+    handoff.write_text("existing handoff\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="append only"):
+        repo_agent.apply_files(
+            {"files": [{"path": repo_agent.HANDOFF_PATH, "content": "rewritten handoff\n"}]},
+            "Append a documentation-only continuity update to PROJECT_HANDOFF_CURRENT.md.",
+        )
+
+
+def test_repo_agent_rejects_handoff_mixed_with_other_files(tmp_path, monkeypatch):
+    monkeypatch.setattr(repo_agent, "ROOT", tmp_path.resolve())
+    handoff = tmp_path / repo_agent.HANDOFF_PATH
+    handoff.write_text("existing handoff\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="handoff-only"):
+        repo_agent.apply_files(
+            {
+                "files": [
+                    {"path": repo_agent.HANDOFF_PATH, "content": "existing handoff\nnew audit\n"},
+                    {"path": "OTHER.md", "content": "unexpected\n"},
+                ]
+            },
+            "Append a documentation-only continuity update to PROJECT_HANDOFF_CURRENT.md.",
+        )


### PR DESCRIPTION
Fixes Issue #176's demonstrated continuity-tooling failure. The repo agent still protects workflows and the authoritative handoff by default, but an explicit handoff-only instruction may now append continuity text only. Existing PROJECT_HANDOFF_CURRENT.md content must remain an exact prefix; rewrites, truncation, mixed-file changes, and implicit handoff edits fail closed. Adds focused regressions for explicit append, rewrite rejection, and mixed-file rejection. Paper-only tooling change; no strategy, sizing, risk, state, ledger, execution, live, or ML authority change.