### PR TITLE
Issue #193: isolate and resume Performance Audit V2

### DIFF
--- a/.github/workflows/performance-audit-v2-research.yml
+++ b/.github/workflows/performance-audit-v2-research.yml
@@ -1,0 +1,85 @@
+name: Performance Audit V2 Isolated Research
+
+on:
+  workflow_dispatch:
+    inputs:
+      period:
+        description: Historical period
+        required: true
+        default: 5y
+        type: choice
+        options: [2y, 3y, 5y, 10y]
+      max_symbols:
+        description: Bounded research universe size (20-75)
+        required: true
+        default: "45"
+        type: string
+      include_ablation:
+        description: Run the resumable one-variable ablation stage
+        required: true
+        default: true
+        type: boolean
+      resume_run_id:
+        description: Optional prior workflow run ID whose checkpoint should be restored
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: performance-audit-v2-isolated-research
+  cancel-in-progress: false
+
+jobs:
+  baseline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Restore resumable checkpoint
+        if: inputs.resume_run_id != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: performance-audit-v2-evidence
+          path: performance-audit-v2-evidence
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.resume_run_id }}
+
+      - name: Install research dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Run isolated V2 baseline
+        env:
+          PERFORMANCE_AUDIT_V2_AUTO_BACKTEST_ENABLED: "false"
+          PERFORMANCE_AUDIT_V2_ENABLED: "true"
+          RESEARCH_PERIOD: ${{ inputs.period }}
+          RESEARCH_MAX_SYMBOLS: ${{ inputs.max_symbols }}
+          RESEARCH_INCLUDE_ABLATION: ${{ inputs.include_ablation }}
+        run: |
+          args=(
+            --period "$RESEARCH_PERIOD"
+            --max-symbols "$RESEARCH_MAX_SYMBOLS"
+            --checkpoint performance-audit-v2-evidence/checkpoint.json
+            --output performance-audit-v2-evidence/result.json
+          )
+          if [ "$RESEARCH_INCLUDE_ABLATION" != "true" ]; then
+            args+=(--no-ablation)
+          fi
+          python performance_audit_v2_offline.py "${args[@]}"
+
+      - name: Upload result and resumable checkpoint
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-audit-v2-evidence
+          path: performance-audit-v2-evidence
+          if-no-files-found: error
+          retention-days: 30

--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -60,6 +60,7 @@ STATE_SERIALIZATION_TESTS = (
 PERFORMANCE_EVIDENCE_INTEGRITY_TESTS = (
     "test_issue167_forward_evidence_integrity.py",
     "test_issue170_performance_atr_integrity.py",
+    "test_issue193_performance_v2_isolation.py",
 )
 SYSTEM_SENTINEL_TESTS = (
     "test_system_sentinel.py",
@@ -144,8 +145,10 @@ def _is_performance_evidence_integrity_path(path: str) -> bool:
     return Path(path.lower()).name in {
         "performance_audit_lab.py",
         "performance_audit_lab_v2.py",
+        "performance_audit_v2_offline.py",
         "test_issue167_forward_evidence_integrity.py",
         "test_issue170_performance_atr_integrity.py",
+        "test_issue193_performance_v2_isolation.py",
     }
 
 

--- a/performance_audit_v2_offline.py
+++ b/performance_audit_v2_offline.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Run Performance Audit V2 in a dedicated, persistent research process.
+
+This entry point deliberately has no Flask, paper-runner, broker, or order
+surface.  Its JSON checkpoint can be restored by a later isolated run, so the
+expensive core result and completed ablation variants are not repeated.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any
+
+
+VERSION = "performance-audit-v2-offline-2026-09-08-v1"
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"checkpoint must contain a JSON object: {path}")
+    return value
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=path.parent, delete=False
+    ) as handle:
+        json.dump(value, handle, indent=2, sort_keys=True, default=str)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+        temporary = Path(handle.name)
+    os.replace(temporary, path)
+
+
+class OfflineResearchCore:
+    """Minimal durable state adapter; intentionally not a trading core."""
+
+    def __init__(self, checkpoint: Path) -> None:
+        self.checkpoint = checkpoint
+        stored = _read_json(checkpoint)
+        portfolio = stored.get("portfolio", stored)
+        self.portfolio = portfolio if isinstance(portfolio, dict) else {}
+
+    @staticmethod
+    def local_ts_text() -> str:
+        return dt.datetime.now(dt.timezone.utc).isoformat()
+
+    def save_state(self, portfolio: dict[str, Any]) -> None:
+        self.portfolio = portfolio
+        _atomic_json(
+            self.checkpoint,
+            {
+                "format_version": 1,
+                "runner_version": VERSION,
+                "saved_utc": self.local_ts_text(),
+                "portfolio": portfolio,
+            },
+        )
+
+
+def execute(
+    *,
+    period: str,
+    max_symbols: int,
+    include_ablation: bool,
+    checkpoint: Path,
+    output: Path,
+    force: bool = False,
+) -> dict[str, Any]:
+    # Imports occur only after automatic/web-owned research is disabled.
+    os.environ["PERFORMANCE_AUDIT_V2_AUTO_BACKTEST_ENABLED"] = "false"
+    import performance_audit_lab_v2 as lab
+    import performance_audit_v2_async_route as resumable
+
+    core = OfflineResearchCore(checkpoint)
+    section = lab._section(core)
+    if force:
+        section.pop("resilient_core_checkpoint", None)
+        section.pop("resilient_ablation_partial", None)
+    prior_checkpoint = resumable._matching_checkpoint(section, period, max_symbols)
+    prior_partial = section.get("resilient_ablation_partial")
+    can_resume = bool(prior_checkpoint or isinstance(prior_partial, dict))
+    section["queued_request"] = {
+        "period": period,
+        "max_symbols": max_symbols,
+        "force": force,
+        "include_ablation": include_ablation,
+        "resume": can_resume and not force,
+    }
+    section["status"] = "queued"
+    core.save_state(core.portfolio)
+
+    resumable._background_run(
+        core,
+        period=period,
+        max_symbols=max_symbols,
+        force=force,
+        include_ablation=include_ablation,
+    )
+
+    section = lab._section(core)
+    result = section.get("latest")
+    if not isinstance(result, dict) or section.get("status") != "ok":
+        runner = section.get("resilient_runner")
+        error = section.get("async_launcher_error")
+        failure = {
+            "status": "error",
+            "type": "performance_audit_v2_offline_result",
+            "runner_version": VERSION,
+            "engine_version": lab.VERSION,
+            "error": error or "isolated research run did not produce an ok result",
+            "runner": runner if isinstance(runner, dict) else {},
+        }
+        _atomic_json(output, failure)
+        return failure
+
+    artifact = {
+        "status": "ok",
+        "type": "performance_audit_v2_offline_result",
+        "runner_version": VERSION,
+        "engine_version": lab.VERSION,
+        "generated_utc": OfflineResearchCore.local_ts_text(),
+        "source_commit": os.environ.get("GITHUB_SHA") or os.environ.get("SOURCE_COMMIT"),
+        "execution_boundary": {
+            "isolated_process": True,
+            "production_web_worker": False,
+            "paper_runner": False,
+            "broker_access": False,
+            "order_authority": False,
+        },
+        "request": {
+            "period": period,
+            "max_symbols": max_symbols,
+            "include_ablation": include_ablation,
+            "resumed": can_resume and not force,
+        },
+        "result": result,
+    }
+    _atomic_json(output, artifact)
+    return artifact
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--period", default="5y", choices=("2y", "3y", "5y", "10y"))
+    parser.add_argument("--max-symbols", type=int, default=45)
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--no-ablation", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+    if not 20 <= args.max_symbols <= 75:
+        parser.error("--max-symbols must be between 20 and 75")
+    result = execute(
+        period=args.period,
+        max_symbols=args.max_symbols,
+        include_ablation=not args.no_ablation,
+        checkpoint=args.checkpoint,
+        output=args.output,
+        force=args.force,
+    )
+    return 0 if result.get("status") == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test_issue193_performance_v2_isolation.py
+++ b/test_issue193_performance_v2_isolation.py
@@ -1,0 +1,119 @@
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+import performance_audit_lab_v2 as lab
+import performance_audit_v2_async_route as resumable
+import performance_audit_v2_offline as offline
+
+
+class PerformanceAuditV2IsolationTests(unittest.TestCase):
+    def test_offline_execution_persists_result_without_runtime_authority(self):
+        with tempfile.TemporaryDirectory() as directory:
+            checkpoint = Path(directory) / "checkpoint.json"
+            output = Path(directory) / "result.json"
+            result = {"status": "ok", "profiles": {}, "ablation": {}}
+
+            def complete(core, **kwargs):
+                section = lab._section(core)
+                section["latest"] = result
+                section["status"] = "ok"
+                core.save_state(core.portfolio)
+
+            with mock.patch.object(resumable, "_background_run", side_effect=complete):
+                artifact = offline.execute(
+                    period="5y",
+                    max_symbols=45,
+                    include_ablation=True,
+                    checkpoint=checkpoint,
+                    output=output,
+                )
+
+            self.assertEqual(artifact["status"], "ok")
+            self.assertTrue(artifact["execution_boundary"]["isolated_process"])
+            self.assertFalse(artifact["execution_boundary"]["production_web_worker"])
+            self.assertFalse(artifact["execution_boundary"]["broker_access"])
+            self.assertFalse(artifact["execution_boundary"]["order_authority"])
+            self.assertEqual(json.loads(output.read_text())["result"], result)
+            self.assertTrue(checkpoint.exists())
+
+    def test_matching_checkpoint_is_marked_for_resume(self):
+        with tempfile.TemporaryDirectory() as directory:
+            checkpoint = Path(directory) / "checkpoint.json"
+            output = Path(directory) / "result.json"
+            core = offline.OfflineResearchCore(checkpoint)
+            section = lab._section(core)
+            section["resilient_core_checkpoint"] = {
+                "period": "5y",
+                "max_symbols": 45,
+                "result": {"status": "ok", "profiles": {}},
+            }
+            core.save_state(core.portfolio)
+
+            def complete(reloaded, **kwargs):
+                request = lab._section(reloaded)["queued_request"]
+                self.assertTrue(request["resume"])
+                state = lab._section(reloaded)
+                state["latest"] = {"status": "ok"}
+                state["status"] = "ok"
+
+            with mock.patch.object(resumable, "_background_run", side_effect=complete):
+                artifact = offline.execute(
+                    period="5y",
+                    max_symbols=45,
+                    include_ablation=True,
+                    checkpoint=checkpoint,
+                    output=output,
+                )
+            self.assertTrue(artifact["request"]["resumed"])
+
+    def test_failure_is_durable_and_fail_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            checkpoint = Path(directory) / "checkpoint.json"
+            output = Path(directory) / "result.json"
+
+            def fail(core, **kwargs):
+                section = lab._section(core)
+                section["status"] = "error"
+                section["async_launcher_error"] = "RuntimeError: provider unavailable"
+                core.save_state(core.portfolio)
+
+            with mock.patch.object(resumable, "_background_run", side_effect=fail):
+                artifact = offline.execute(
+                    period="5y",
+                    max_symbols=45,
+                    include_ablation=True,
+                    checkpoint=checkpoint,
+                    output=output,
+                )
+            self.assertEqual(artifact["status"], "error")
+            self.assertIn("provider unavailable", artifact["error"])
+            self.assertEqual(json.loads(output.read_text())["status"], "error")
+
+    def test_import_disables_automatic_research(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            offline.execute.__globals__["os"].environ.pop(
+                "PERFORMANCE_AUDIT_V2_AUTO_BACKTEST_ENABLED", None
+            )
+            with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+                resumable, "_background_run"
+            ) as background:
+                core_result = Path(directory) / "result.json"
+                offline.execute(
+                    period="5y",
+                    max_symbols=45,
+                    include_ablation=False,
+                    checkpoint=Path(directory) / "checkpoint.json",
+                    output=core_result,
+                )
+                background.assert_called_once()
+                self.assertEqual(
+                    os.environ["PERFORMANCE_AUDIT_V2_AUTO_BACKTEST_ENABLED"], "false"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #193

## Summary
- adds a standalone Performance Audit V2 process with no Flask, paper-runner, broker, or order surface
- persists the core result and per-variant ablation checkpoints for explicit resume
- adds a concurrency-guarded manual GitHub Actions research workflow, including optional restoration from a prior run artifact
- adds focused isolation, resume, durable-error, and fail-closed regressions to the mandatory Change Safety selection

## Safety boundary
This does not register the orphaned async web route, start research in Splendid, access production state, place orders, change strategy/risk/sizing, or grant AI/ML authority. The five-year baseline will run only after every required exact-head gate passes and this bounded change merges.

## Local validation
- 89 impact-aware/canonical invariant tests passed
- repository validation passed
- structural audit: zero new critical and zero new warnings
- architecture ownership and typed configuration passed
- architecture-debt regression passed
- exact-head local Change Safety decision passed