### PR TITLE
Issue #198: bind V2 signal ATR to selected symbol

### DIFF
--- a/.github/performance-audit-v2-request.json
+++ b/.github/performance-audit-v2-request.json
@@ -1,5 +1,5 @@
 {
-  "request_id": "baseline-2026-09-08-v1",
+  "request_id": "baseline-2026-09-08-v2-issue198",
   "period": "5y",
   "max_symbols": 45,
   "include_ablation": true,

--- a/performance_audit_lab_v2.py
+++ b/performance_audit_lab_v2.py
@@ -26,7 +26,7 @@ import performance_audit_lab as base
 np = base.np
 pd = base.pd
 
-VERSION = "performance-audit-lab-v2-2026-09-03-v2-signal-atr-integrity"
+VERSION = "performance-audit-lab-v2-2026-09-08-v3-symbol-atr-binding"
 ENABLED = os.environ.get("PERFORMANCE_AUDIT_V2_ENABLED", "true").lower() not in {
     "0", "false", "no", "off"
 }
@@ -506,7 +506,7 @@ def _simulate_next_open(
             if _eligible(row, policy_today):
                 ranked.append((_f(row.get("score")), symbol, row))
         ranked.sort(reverse=True)
-        for score, symbol, _row_data in ranked[:slots]:
+        for score, symbol, row_data in ranked[:slots]:
             pending.append(
                 {
                     "symbol": symbol,
@@ -515,7 +515,7 @@ def _simulate_next_open(
                     "regime": today_regime,
                     "policy": dict(policy_today),
                     "signal_atr_pct": _f(
-                        row.get("atr_pct"),
+                        row_data.get("atr_pct"),
                         _f(policy_today.get("stop_loss"), 0.015),
                     ),
                 }

--- a/test_issue170_performance_atr_integrity.py
+++ b/test_issue170_performance_atr_integrity.py
@@ -89,6 +89,55 @@ class PerformanceAtrIntegrityTests(unittest.TestCase):
         self.assertEqual(entry["initial_stop_pct"], 0.0125)
         self.assertEqual(exit_row["reason"], "stop_loss")
 
+    def test_each_ranked_symbol_keeps_its_own_signal_atr(self):
+        dates = pd.to_datetime(["2026-01-05", "2026-01-06"])
+        features = {}
+        for symbol, score, signal_atr in (
+            ("ALPHA", 0.03, 0.01),
+            ("BETA", 0.02, 0.03),
+        ):
+            features[symbol] = pd.DataFrame(
+                [
+                    {
+                        "Open": 100.0,
+                        "High": 101.0,
+                        "Low": 99.0,
+                        "Close": 100.0,
+                        "score": score,
+                        "atr_pct": signal_atr,
+                    },
+                    {
+                        "Open": 100.0,
+                        "High": 101.0,
+                        "Low": 99.0,
+                        "Close": 100.0,
+                        "score": score,
+                        "atr_pct": 0.50,
+                    },
+                ],
+                index=dates,
+            )
+        policy = _policy()
+        policy.update({"max_positions": 2, "max_exposure": 0.30})
+        with patch.object(lab, "np", np), patch.object(
+            lab.base, "np", np
+        ), patch.object(lab, "_regime", return_value="neutral"), patch.object(
+            lab, "_eligible", return_value=True
+        ):
+            result = lab._simulate_next_open(
+                features, {"neutral": policy}, list(dates)
+            )
+
+        entries = {
+            row["symbol"]: row
+            for row in result["trades"]
+            if row["action"] == "entry"
+        }
+        self.assertEqual(entries["ALPHA"]["signal_atr_pct"], 0.01)
+        self.assertEqual(entries["ALPHA"]["initial_stop_pct"], 0.0125)
+        self.assertEqual(entries["BETA"]["signal_atr_pct"], 0.03)
+        self.assertEqual(entries["BETA"]["initial_stop_pct"], 0.0375)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #198.

Corrects Performance Audit V2 so each queued candidate carries ATR from its own selected signal row, rather than the last row scanned in the universe. Adds a focused two-symbol regression that proves distinct ATR values remain bound through next-open entry and stop construction.

Also advances the bounded isolated-research request ID so a corrected five-year baseline runs after merge. The original Issue #193 artifact remains immutable and is treated as non-authoritative candidate evidence.

No production runtime hook, paper runner, broker, order authority, strategy setting, risk limit, canonical/accounting state, or AI/ML authority changes.