### PR TITLE
Issue #196: complete V2 validation evidence

### DIFF
--- a/.github/performance-audit-v2-request.json
+++ b/.github/performance-audit-v2-request.json
@@ -1,5 +1,5 @@
 {
-  "request_id": "baseline-2026-09-08-v2-issue198",
+  "request_id": "baseline-2026-09-09-v3-issue196",
   "period": "5y",
   "max_symbols": 45,
   "include_ablation": true,

--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -61,6 +61,7 @@ PERFORMANCE_EVIDENCE_INTEGRITY_TESTS = (
     "test_issue167_forward_evidence_integrity.py",
     "test_issue170_performance_atr_integrity.py",
     "test_issue193_performance_v2_isolation.py",
+    "test_issue196_performance_validation_evidence.py",
 )
 SYSTEM_SENTINEL_TESTS = (
     "test_system_sentinel.py",
@@ -145,10 +146,12 @@ def _is_performance_evidence_integrity_path(path: str) -> bool:
     return Path(path.lower()).name in {
         "performance_audit_lab.py",
         "performance_audit_lab_v2.py",
+        "performance_validation_evidence.py",
         "performance_audit_v2_offline.py",
         "test_issue167_forward_evidence_integrity.py",
         "test_issue170_performance_atr_integrity.py",
         "test_issue193_performance_v2_isolation.py",
+        "test_issue196_performance_validation_evidence.py",
     }
 
 

--- a/performance_audit_lab_v2.py
+++ b/performance_audit_lab_v2.py
@@ -22,11 +22,12 @@ import time
 from typing import Any, Dict, List, Sequence, Tuple
 
 import performance_audit_lab as base
+import performance_validation_evidence as evidence
 
 np = base.np
 pd = base.pd
 
-VERSION = "performance-audit-lab-v2-2026-09-08-v3-symbol-atr-binding"
+VERSION = "performance-audit-lab-v2-2026-09-09-v4-validation-evidence"
 ENABLED = os.environ.get("PERFORMANCE_AUDIT_V2_ENABLED", "true").lower() not in {
     "0", "false", "no", "off"
 }
@@ -39,6 +40,10 @@ STALE_HOURS = float(os.environ.get("PERFORMANCE_AUDIT_V2_STALE_HOURS", "24"))
 WATCHDOG_SECONDS = max(60, int(os.environ.get("PERFORMANCE_AUDIT_V2_WATCHDOG_SECONDS", "600")))
 INITIAL_CAPITAL = float(os.environ.get("PERFORMANCE_AUDIT_INITIAL_CAPITAL", "10000"))
 TRANSACTION_COST_BPS = float(os.environ.get("PERFORMANCE_AUDIT_TRANSACTION_COST_BPS", "8"))
+COST_SENSITIVITY_BPS = evidence.COST_SENSITIVITY_BPS
+DELAY_SENSITIVITY_SESSIONS = evidence.DELAY_SENSITIVITY_SESSIONS
+CAPACITY_PARTICIPATION_LIMIT_PCT = evidence.CAPACITY_PARTICIPATION_LIMIT_PCT
+CAPACITY_STRESS_CAPITALS = evidence.CAPACITY_STRESS_CAPITALS
 
 _LOCK = threading.RLock()
 _RUN_LOCK = threading.Lock()
@@ -329,11 +334,40 @@ def _mark_value(features: Dict[str, Any], symbol: str, date: Any, fallback: floa
     return _f((row or {}).get(field), fallback)
 
 
+def _add_liquidity_features(features: Dict[str, Any]) -> None:
+    evidence.add_liquidity_features(features, pd)
+
+
+def _close_positions_at_end(
+    features: Dict[str, Any],
+    positions: Dict[str, Dict[str, Any]],
+    trades: List[Dict[str, Any]],
+    final_date: Any,
+    cash: float,
+    cost_rate: float,
+) -> float:
+    for symbol, pos in list(positions.items()):
+        close = _mark_value(features, symbol, final_date, _f(pos.get("entry")), "Close")
+        gross = _f(pos.get("shares")) * close
+        fee = gross * cost_rate
+        cash += gross - fee
+        trades.append({
+            "action": "exit", "symbol": symbol, "date": str(final_date)[:10],
+            "price": close, "shares": _f(pos.get("shares")), "gross_notional": gross,
+            "fee": fee, "pnl": gross - fee - _f(pos.get("cost")),
+            "reason": "end_of_test", "entry_regime": pos.get("entry_regime"),
+            "entry_date": pos.get("entry_date"),
+        })
+    return cash
+
+
 def _simulate_next_open(
     features: Dict[str, Any],
     regime_map: Dict[str, Dict[str, Any]],
     dates: Sequence[Any],
     start: float = INITIAL_CAPITAL,
+    transaction_cost_bps: float | None = None,
+    execution_delay_sessions: int = 1,
 ) -> Dict[str, Any]:
     if np is None or len(dates) == 0:
         return {"metrics": {"status": "insufficient_data"}, "trades": [], "equity_curve": []}
@@ -346,15 +380,21 @@ def _simulate_next_open(
     exposure_curve: List[float] = []
     curve_dates: List[Any] = []
     regimes: List[str] = []
-    cost_rate = TRANSACTION_COST_BPS / 10000.0
+    cost_bps = TRANSACTION_COST_BPS if transaction_cost_bps is None else max(
+        0.0, _f(transaction_cost_bps)
+    )
+    cost_rate = cost_bps / 10000.0
+    delay_sessions = max(1, _i(execution_delay_sessions, 1))
 
     for index, date in enumerate(dates):
         today_regime = _regime(features, date)
         policy_today = regime_map.get(today_regime, regime_map.get("neutral", {}))
 
         if pending:
-            pending.sort(key=lambda row: _f(row.get("score")), reverse=True)
-            for order in pending:
+            ready = [order for order in pending if _i(order.get("execute_index"), index) <= index]
+            pending = [order for order in pending if _i(order.get("execute_index"), index) > index]
+            ready.sort(key=lambda row: _f(row.get("score")), reverse=True)
+            for order in ready:
                 order_policy = _d(order.get("policy"))
                 max_positions = _i(order_policy.get("max_positions"), 2)
                 if len(positions) >= max_positions:
@@ -406,11 +446,17 @@ def _simulate_next_open(
                     "entry": price,
                     "shares": shares,
                     "cost": allocation,
+                    "entry_notional": shares * price,
+                    "entry_fee": fee,
+                    "entry_date": str(date)[:10],
                     "stop": price * (1.0 - atr_stop),
                     "age": 0,
                     "policy": order_policy,
                     "entry_regime": order.get("regime"),
+                    "signal_adv20_dollars": _f(order.get("signal_adv20_dollars")),
                 }
+                entry_notional = shares * price
+                signal_adv = _f(order.get("signal_adv20_dollars"))
                 trades.append(
                     {
                         "action": "entry",
@@ -418,15 +464,22 @@ def _simulate_next_open(
                         "signal_date": str(order.get("signal_date"))[:10],
                         "date": str(date)[:10],
                         "price": price,
+                        "shares": shares,
                         "score": order.get("score"),
                         "allocation": allocation,
+                        "gross_notional": entry_notional,
+                        "fee": fee,
                         "regime": order.get("regime"),
                         "execution": "next_session_open",
+                        "execution_delay_sessions": delay_sessions,
                         "signal_atr_pct": signal_atr_pct,
                         "initial_stop_pct": atr_stop,
+                        "signal_adv20_dollars": signal_adv,
+                        "adv_participation_pct": (
+                            entry_notional / signal_adv * 100.0 if signal_adv > 0 else None
+                        ),
                     }
                 )
-        pending = []
 
         for symbol in list(positions):
             pos = positions[symbol]
@@ -462,9 +515,13 @@ def _simulate_next_open(
                         "symbol": symbol,
                         "date": str(date)[:10],
                         "price": exit_price,
+                        "shares": _f(pos.get("shares")),
+                        "gross_notional": gross,
+                        "fee": fee,
                         "pnl": pnl,
                         "reason": reason,
                         "entry_regime": pos.get("entry_regime"),
+                        "entry_date": pos.get("entry_date"),
                     }
                 )
                 del positions[symbol]
@@ -492,9 +549,10 @@ def _simulate_next_open(
         if slots <= 0:
             continue
         allowed = set(policy_today.get("allowed_symbols") or [])
+        pending_symbols = {str(order.get("symbol") or "") for order in pending}
         ranked: List[Tuple[float, str, Dict[str, float]]] = []
         for symbol in features:
-            if symbol in positions or symbol in {"SPY", "QQQ"}:
+            if symbol in positions or symbol in pending_symbols or symbol in {"SPY", "QQQ"}:
                 continue
             if allowed and symbol not in allowed:
                 continue
@@ -512,33 +570,21 @@ def _simulate_next_open(
                     "symbol": symbol,
                     "score": score,
                     "signal_date": date,
+                    "execute_index": index + delay_sessions,
                     "regime": today_regime,
                     "policy": dict(policy_today),
                     "signal_atr_pct": _f(
                         row_data.get("atr_pct"),
                         _f(policy_today.get("stop_loss"), 0.015),
                     ),
+                    "signal_adv20_dollars": _f(row_data.get("adv20_dollars")),
                 }
             )
 
     if dates:
-        final_date = dates[-1]
-        for symbol, pos in list(positions.items()):
-            close = _mark_value(features, symbol, final_date, _f(pos.get("entry")), "Close")
-            gross = _f(pos.get("shares")) * close
-            fee = gross * cost_rate
-            cash += gross - fee
-            trades.append(
-                {
-                    "action": "exit",
-                    "symbol": symbol,
-                    "date": str(final_date)[:10],
-                    "price": close,
-                    "pnl": gross - fee - _f(pos.get("cost")),
-                    "reason": "end_of_test",
-                    "entry_regime": pos.get("entry_regime"),
-                }
-            )
+        cash = _close_positions_at_end(
+            features, positions, trades, dates[-1], cash, cost_rate
+        )
         if curve:
             curve[-1] = cash
 
@@ -557,7 +603,35 @@ def _simulate_next_open(
         "exposure_curve": exposure_curve,
         "regimes": regimes,
         "daily_returns": [float(x) for x in daily_returns],
+        "assumptions": {
+            "transaction_cost_bps_per_side": cost_bps,
+            "execution_delay_sessions": delay_sessions,
+        },
     }
+
+
+def _execution_diagnostics(sim: Dict[str, Any]) -> Dict[str, Any]:
+    return evidence.execution_diagnostics(
+        sim,
+        np=np,
+        initial_capital=INITIAL_CAPITAL,
+    )
+
+
+def _sensitivity_report(
+    features: Dict[str, Any],
+    dates: Sequence[Any],
+    regime_map: Dict[str, Dict[str, Any]],
+    baseline_sim: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    return evidence.sensitivity_report(
+        _simulate_next_open,
+        features,
+        dates,
+        regime_map,
+        baseline_cost_bps=TRANSACTION_COST_BPS,
+        baseline_sim=baseline_sim,
+    )
 
 
 def _slice_metrics(
@@ -838,6 +912,7 @@ def _run_ablation(
             {
                 "variant": name,
                 **metrics,
+                "execution_diagnostics": _execution_diagnostics(sim),
                 "delta_total_return_pct": round(
                     _f(metrics.get("total_return_pct")) - baseline_return, 2
                 ),
@@ -849,12 +924,16 @@ def _run_ablation(
             }
         )
     results.sort(key=lambda row: _f(row.get("objective"), -9999.0), reverse=True)
+    best_name = str(_d(results[0] if results else {}).get("variant") or "")
+    best_map = _ablation_maps().get(best_name)
     return {
         "status": "ok",
         "baseline": "adaptive_baseline",
         "variant_count": len(results),
         "ranking": results,
         "best_variant": results[0] if results else None,
+        "best_variant_sensitivity": _sensitivity_report(features, dates, best_map)
+        if best_map else {"status": "not_available"},
         "interpretation": (
             "Each variant changes one parameter family from the adaptive baseline. "
             "Results remain daily-bar proxies and should be confirmed by forward shadow data."
@@ -871,6 +950,8 @@ def _profile_payload(
     sim = _simulate_next_open(features, regime_map, dates)
     return {
         "full_sample": sim["metrics"],
+        "execution_diagnostics": _execution_diagnostics(sim),
+        "sensitivity": _sensitivity_report(features, dates, regime_map, sim),
         "calendar_years": _calendar_years(sim),
         "regime_report": _regime_report(sim),
         "walk_forward": _walk_forward(
@@ -881,6 +962,13 @@ def _profile_payload(
         ),
         "trade_sample": _l(sim.get("trades"))[-30:],
     }
+
+
+def _validation_verdict(result: Dict[str, Any]) -> Dict[str, Any]:
+    return evidence.validation_verdict(
+        result,
+        profile_names=(*STATIC_PROFILES.keys(), "adaptive_balanced"),
+    )
 
 
 def run(
@@ -926,6 +1014,7 @@ def run(
         symbols = _universe(core, max_symbols)
         frames, provider = base._download(symbols, period)
         features = base._feature_frames(frames)
+        _add_liquidity_features(features)
         dates = base._calendar(features)
         if len(dates) < 315 or len(features) < 10:
             result = {
@@ -1049,7 +1138,11 @@ def run(
             },
             "methodology": {
                 "execution_assumption": "signals_at_close_entries_next_session_open",
-                "transaction_cost_bps": TRANSACTION_COST_BPS,
+                "transaction_cost_bps_per_side": TRANSACTION_COST_BPS,
+                "transaction_cost_sensitivity_bps_per_side": list(COST_SENSITIVITY_BPS),
+                "execution_delay_sensitivity_sessions": list(DELAY_SENSITIVITY_SESSIONS),
+                "capacity_participation_limit_pct_of_signal_adv20": CAPACITY_PARTICIPATION_LIMIT_PCT,
+                "capacity_stress_account_capitals": list(CAPACITY_STRESS_CAPITALS),
                 "full_history_walk_forward": True,
                 "walk_forward_train_days": 252,
                 "walk_forward_test_days": 63,
@@ -1090,6 +1183,7 @@ def run(
                 "places_orders": False,
             },
         }
+        result["validation_evidence"] = _validation_verdict(result)
         runs[key] = result
         section["latest_key"] = key
         section["latest"] = result

--- a/performance_audit_v2_async_route.py
+++ b/performance_audit_v2_async_route.py
@@ -18,7 +18,7 @@ from typing import Any, Dict
 
 import performance_audit_lab_v2 as lab
 
-VERSION = "performance-audit-v2-resumable-route-2026-08-03-v2"
+VERSION = "performance-audit-v2-resumable-route-2026-09-09-v3-evidence"
 
 _LOCK = threading.RLock()
 _REGISTERED: set[int] = set()
@@ -160,6 +160,7 @@ def _ablation_row(
     return {
         "variant": name,
         **metrics,
+        "execution_diagnostics": lab._execution_diagnostics(sim),
         "delta_total_return_pct": round(
             _f(metrics.get("total_return_pct"))
             - _f(baseline_metrics.get("total_return_pct")),
@@ -190,6 +191,7 @@ def _run_resumable_ablation(
     symbols = lab._universe(core, max_symbols)
     frames, provider = lab.base._download(symbols, period)
     features = lab.base._feature_frames(frames)
+    lab._add_liquidity_features(features)
     dates = list(lab.base._calendar(features))
     if len(dates) < 315 or len(features) < 10:
         return {
@@ -205,10 +207,14 @@ def _run_resumable_ablation(
     variants = lab._ablation_maps()
 
     partial = _d(section.get("resilient_ablation_partial"))
-    if not _request_matches(partial, period, max_symbols):
+    if (
+        not _request_matches(partial, period, max_symbols)
+        or partial.get("engine_version") != lab.VERSION
+    ):
         partial = {
             "period": period,
             "max_symbols": max_symbols,
+            "engine_version": lab.VERSION,
             "results": {},
             "started_local": _now(core),
         }
@@ -249,12 +255,17 @@ def _run_resumable_ablation(
 
     ranking = list(completed.values())
     ranking.sort(key=lambda row: _f(_d(row).get("objective"), -9999.0), reverse=True)
+    best_name = str(_d(ranking[0] if ranking else {}).get("variant") or "")
+    best_map = variants.get(best_name)
     return {
         "status": "ok",
         "baseline": "adaptive_baseline",
         "variant_count": len(ranking),
         "ranking": ranking,
         "best_variant": ranking[0] if ranking else None,
+        "best_variant_sensitivity": lab._sensitivity_report(
+            features, dates, best_map
+        ) if best_map else {"status": "not_available"},
         "interpretation": (
             "Each variant changes one parameter family from the adaptive baseline. "
             "Results remain daily-bar proxies and require forward-shadow confirmation."
@@ -270,6 +281,7 @@ def _matching_checkpoint(
     if (
         _request_matches(checkpoint, period, max_symbols)
         and result.get("status") == "ok"
+        and result.get("version") == lab.VERSION
     ):
         return copy.deepcopy(result)
     return None
@@ -350,6 +362,7 @@ def _background_run(
         final_result["generated_local"] = _now(core)
         final_result["generated_epoch"] = time.time()
         final_result["resumable_runner_version"] = VERSION
+        final_result["validation_evidence"] = lab._validation_verdict(final_result)
 
         section = lab._section(core)
         runs = section.setdefault("runs", {})

--- a/performance_audit_v2_offline.py
+++ b/performance_audit_v2_offline.py
@@ -88,7 +88,12 @@ def execute(
         section.pop("resilient_ablation_partial", None)
     prior_checkpoint = resumable._matching_checkpoint(section, period, max_symbols)
     prior_partial = section.get("resilient_ablation_partial")
-    can_resume = bool(prior_checkpoint or isinstance(prior_partial, dict))
+    partial_matches = bool(
+        isinstance(prior_partial, dict)
+        and resumable._request_matches(prior_partial, period, max_symbols)
+        and prior_partial.get("engine_version") == lab.VERSION
+    )
+    can_resume = bool(prior_checkpoint or partial_matches)
     section["queued_request"] = {
         "period": period,
         "max_symbols": max_symbols,

--- a/performance_validation_evidence.py
+++ b/performance_validation_evidence.py
@@ -1,0 +1,272 @@
+"""Read-only evidence calculations for Performance Audit V2.
+
+This module operates only on in-memory research simulations. It has no runtime,
+state, broker, credential, or order surface.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Sequence
+
+
+COST_SENSITIVITY_BPS = (4.0, 8.0, 15.0, 25.0)
+DELAY_SENSITIVITY_SESSIONS = (1, 2, 3)
+CAPACITY_PARTICIPATION_LIMIT_PCT = 1.0
+CAPACITY_STRESS_CAPITALS = (10_000.0, 100_000.0, 1_000_000.0)
+
+SECTOR_GROUPS = {
+    "SPY": "broad_market", "QQQ": "broad_market", "IWM": "broad_market",
+    "RSP": "broad_market", "SH": "inverse_index", "PSQ": "inverse_index",
+    "XLK": "technology", "MSFT": "technology", "AMZN": "mega_cap_growth",
+    "META": "mega_cap_growth", "GOOGL": "mega_cap_growth", "PLTR": "technology",
+    "SMH": "semiconductors", "NVDA": "semiconductors", "AMD": "semiconductors",
+    "AVGO": "semiconductors", "MU": "semiconductors", "STX": "hardware",
+    "WDC": "hardware", "DELL": "hardware", "HPE": "hardware", "ANET": "hardware",
+    "VRT": "infrastructure", "GEV": "infrastructure", "PWR": "infrastructure",
+    "CIEN": "communications", "XLE": "energy", "XLV": "healthcare",
+    "XLU": "utilities", "XLP": "consumer_defensive", "GLD": "precious_metals",
+    "SLV": "precious_metals", "GDX": "precious_metals", "TLT": "rates",
+    "IEF": "rates", "RKLB": "space", "ASTS": "space", "CIFR": "crypto_equity",
+    "IREN": "crypto_equity", "CLSK": "crypto_equity", "MARA": "crypto_equity",
+    "RIOT": "crypto_equity", "IBIT": "crypto_asset",
+}
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _l(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _percentile(np: Any, values: Sequence[float], percentile: float) -> float:
+    if np is None or not values:
+        return 0.0
+    return float(np.percentile(np.asarray(values, dtype=float), percentile))
+
+
+def add_liquidity_features(features: Dict[str, Any], pd: Any) -> None:
+    """Add signal-time ADV without changing eligibility or ranking input."""
+    if pd is None:
+        return
+    for frame in features.values():
+        if not all(column in frame.columns for column in ("Close", "Volume")):
+            frame["adv20_dollars"] = float("nan")
+            continue
+        dollar_volume = frame["Close"].astype(float) * frame["Volume"].astype(float)
+        frame["adv20_dollars"] = dollar_volume.rolling(20).mean()
+
+
+def _concentration(values: Dict[str, float]) -> Dict[str, Any]:
+    total_abs = sum(abs(value) for value in values.values())
+    rows = sorted(values.items(), key=lambda item: abs(item[1]), reverse=True)
+    shares = [abs(value) / total_abs for _, value in rows] if total_abs > 0 else []
+    return {
+        "contributors": len(rows),
+        "net_pnl": round(sum(values.values()), 2),
+        "absolute_pnl": round(total_abs, 2),
+        "top_contributor": rows[0][0] if rows else None,
+        "top_contributor_pnl": round(rows[0][1], 2) if rows else 0.0,
+        "top_contributor_abs_share_pct": round(shares[0] * 100, 2) if shares else 0.0,
+        "top_five_abs_share_pct": round(sum(shares[:5]) * 100, 2) if shares else 0.0,
+        "herfindahl_index": round(sum(value * value for value in shares), 4),
+        "ranking": [
+            {
+                "name": name,
+                "pnl": round(value, 2),
+                "absolute_share_pct": round(abs(value) / total_abs * 100, 2)
+                if total_abs > 0 else 0.0,
+            }
+            for name, value in rows
+        ],
+    }
+
+
+def _concentration_report(exits: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    symbol_pnl: Dict[str, float] = {}
+    sector_pnl: Dict[str, float] = {}
+    for row in exits:
+        symbol = str(row.get("symbol") or "unknown")
+        pnl = _f(row.get("pnl"))
+        symbol_pnl[symbol] = symbol_pnl.get(symbol, 0.0) + pnl
+        sector = SECTOR_GROUPS.get(symbol, "other")
+        sector_pnl[sector] = sector_pnl.get(sector, 0.0) + pnl
+    return {
+        "symbol": _concentration(symbol_pnl),
+        "sector_group": _concentration(sector_pnl),
+    }
+
+
+def _capacity_report(
+    np: Any,
+    entries: Sequence[Dict[str, Any]],
+    initial_capital: float,
+) -> Dict[str, Any]:
+    participations = sorted(
+        _f(row.get("adv_participation_pct"))
+        for row in entries
+        if row.get("adv_participation_pct") is not None
+        and _f(row.get("adv_participation_pct")) >= 0
+    )
+    stress = []
+    for capital in CAPACITY_STRESS_CAPITALS:
+        scale = capital / max(initial_capital, 0.01)
+        projected = [value * scale for value in participations]
+        stress.append(
+            {
+                "account_capital": capital,
+                "max_adv_participation_pct": round(max(projected, default=0.0), 6),
+                "p95_adv_participation_pct": round(_percentile(np, projected, 95), 6),
+                "entries_over_limit": sum(
+                    1 for value in projected if value > CAPACITY_PARTICIPATION_LIMIT_PCT
+                ),
+                "entry_count": len(projected),
+            }
+        )
+    limits = [
+        initial_capital * CAPACITY_PARTICIPATION_LIMIT_PCT / value
+        for value in participations if value > 0
+    ]
+    complete = len(participations) == len(entries)
+    return {
+        "status": "complete" if complete else "incomplete",
+        "adv_basis": "signal_close_20_session_average_dollar_volume",
+        "participation_limit_pct": CAPACITY_PARTICIPATION_LIMIT_PCT,
+        "entry_count": len(entries),
+        "entries_with_adv": len(participations),
+        "max_observed_adv_participation_pct": round(max(participations, default=0.0), 6),
+        "p95_observed_adv_participation_pct": round(_percentile(np, participations, 95), 6),
+        "estimated_max_account_capital_at_limit": round(min(limits), 2) if limits else None,
+        "stress": stress,
+    }
+
+
+def execution_diagnostics(
+    sim: Dict[str, Any],
+    *,
+    np: Any,
+    initial_capital: float,
+) -> Dict[str, Any]:
+    trades = _l(sim.get("trades"))
+    entries = [row for row in trades if row.get("action") == "entry"]
+    exits = [row for row in trades if row.get("action") == "exit"]
+    curve = [_f(value) for value in _l(sim.get("equity_curve"))]
+    dates = _l(sim.get("dates"))
+    if not entries or not exits or not curve:
+        return {"status": "insufficient_data", "entry_count": len(entries), "exit_count": len(exits)}
+    entry_notional = sum(_f(row.get("gross_notional")) for row in entries)
+    exit_notional = sum(_f(row.get("gross_notional")) for row in exits)
+    gross_notional = entry_notional + exit_notional
+    average_equity = sum(curve) / max(1, len(curve))
+    years = max(1.0 / 252.0, len(dates) / 252.0)
+    capacity = _capacity_report(np, entries, initial_capital)
+    return {
+        "status": capacity["status"],
+        "entry_count": len(entries),
+        "exit_count": len(exits),
+        "transaction_cost_bps_per_side": _d(sim.get("assumptions")).get(
+            "transaction_cost_bps_per_side"
+        ),
+        "total_fees": round(sum(_f(row.get("fee")) for row in trades), 2),
+        "gross_entry_notional": round(entry_notional, 2),
+        "gross_exit_notional": round(exit_notional, 2),
+        "gross_traded_notional": round(gross_notional, 2),
+        "average_equity": round(average_equity, 2),
+        "full_period_turnover_x": round(gross_notional / max(average_equity, 0.01), 3),
+        "annualized_turnover_x": round(gross_notional / max(average_equity, 0.01) / years, 3),
+        "capacity": capacity,
+        "concentration": _concentration_report(exits),
+    }
+
+
+def _metric_snapshot(sim: Dict[str, Any]) -> Dict[str, Any]:
+    metrics = _d(sim.get("metrics"))
+    return {
+        key: metrics.get(key)
+        for key in (
+            "status", "total_return_pct", "cagr_pct", "max_drawdown_pct",
+            "sharpe", "profit_factor", "win_rate_pct", "trades",
+            "average_exposure_pct", "time_in_market_pct",
+        )
+    }
+
+
+def sensitivity_report(
+    simulate: Callable[..., Dict[str, Any]],
+    features: Dict[str, Any],
+    dates: Sequence[Any],
+    regime_map: Dict[str, Dict[str, Any]],
+    *,
+    baseline_cost_bps: float,
+    baseline_sim: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    baseline = baseline_sim or simulate(features, regime_map, dates)
+    costs = []
+    for bps in COST_SENSITIVITY_BPS:
+        sim = baseline if bps == baseline_cost_bps else simulate(
+            features, regime_map, dates, transaction_cost_bps=bps
+        )
+        costs.append({"transaction_cost_bps_per_side": bps, **_metric_snapshot(sim)})
+    delays = []
+    for sessions in DELAY_SENSITIVITY_SESSIONS:
+        sim = baseline if sessions == 1 else simulate(
+            features, regime_map, dates, execution_delay_sessions=sessions
+        )
+        delays.append({"execution_delay_sessions": sessions, **_metric_snapshot(sim)})
+    return {
+        "status": "complete",
+        "cost_scenarios": costs,
+        "delay_scenarios": delays,
+        "interpretation": (
+            "Costs are charged per side. Delay scenarios preserve the signal and "
+            "execute at a later session open; they do not refresh the signal."
+        ),
+    }
+
+
+def validation_verdict(
+    result: Dict[str, Any],
+    *,
+    profile_names: Sequence[str],
+) -> Dict[str, Any]:
+    missing: list[str] = []
+    profiles = _d(result.get("profiles"))
+    for name in profile_names:
+        payload = _d(profiles.get(name))
+        diagnostics = _d(payload.get("execution_diagnostics"))
+        sensitivity = _d(payload.get("sensitivity"))
+        if diagnostics.get("status") != "complete":
+            missing.append(f"profiles.{name}.execution_diagnostics")
+        if _d(diagnostics.get("capacity")).get("status") != "complete":
+            missing.append(f"profiles.{name}.capacity")
+        if len(_l(sensitivity.get("cost_scenarios"))) < len(COST_SENSITIVITY_BPS):
+            missing.append(f"profiles.{name}.cost_sensitivity")
+        if len(_l(sensitivity.get("delay_scenarios"))) < len(DELAY_SENSITIVITY_SESSIONS):
+            missing.append(f"profiles.{name}.delay_sensitivity")
+    ablation = _d(result.get("ablation"))
+    if ablation.get("status") != "ok":
+        missing.append("ablation")
+    if _d(_d(ablation.get("best_variant")).get("execution_diagnostics")).get("status") != "complete":
+        missing.append("ablation.best_variant.execution_diagnostics")
+    if _d(ablation.get("best_variant_sensitivity")).get("status") != "complete":
+        missing.append("ablation.best_variant_sensitivity")
+    complete = not missing
+    return {
+        "status": "complete" if complete else "incomplete",
+        "candidate_selection_evidence_complete": complete,
+        "automatic_strategy_promotion": False,
+        "requires_forward_shadow_confirmation": True,
+        "missing_or_incomplete": missing,
+        "warning": (
+            "Evidence completeness permits bounded candidate review only. It does not "
+            "overcome survivorship, daily-bar, or inverse-ETF proxy limitations and does "
+            "not authorize a runtime change."
+        ),
+    }

--- a/test_change_safety_audit.py
+++ b/test_change_safety_audit.py
@@ -237,6 +237,8 @@ class ChangeSafetyAuditTests(unittest.TestCase):
             tests = planned_regressions((path,))
             self.assertIn("test_issue167_forward_evidence_integrity.py", tests)
             self.assertIn("test_issue170_performance_atr_integrity.py", tests)
+            self.assertIn("test_issue193_performance_v2_isolation.py", tests)
+            self.assertIn("test_issue196_performance_validation_evidence.py", tests)
 
     def test_system_sentinel_change_selects_complete_sentinel_regression_set(self) -> None:
         for path in ("system_sentinel.py", "system_sentinel_runtime.py"):

--- a/test_issue193_performance_v2_isolation.py
+++ b/test_issue193_performance_v2_isolation.py
@@ -63,7 +63,7 @@ class PerformanceAuditV2IsolationTests(unittest.TestCase):
             section["resilient_core_checkpoint"] = {
                 "period": "5y",
                 "max_symbols": 45,
-                "result": {"status": "ok", "profiles": {}},
+                "result": {"status": "ok", "version": lab.VERSION, "profiles": {}},
             }
             core.save_state(core.portfolio)
 
@@ -83,6 +83,16 @@ class PerformanceAuditV2IsolationTests(unittest.TestCase):
                     output=output,
                 )
             self.assertTrue(artifact["request"]["resumed"])
+
+    def test_prior_engine_checkpoint_is_not_resumed(self):
+        section = {
+            "resilient_core_checkpoint": {
+                "period": "5y",
+                "max_symbols": 45,
+                "result": {"status": "ok", "version": "obsolete-engine"},
+            }
+        }
+        self.assertIsNone(resumable._matching_checkpoint(section, "5y", 45))
 
     def test_failure_is_durable_and_fail_closed(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/test_issue196_performance_validation_evidence.py
+++ b/test_issue196_performance_validation_evidence.py
@@ -1,0 +1,149 @@
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+import performance_audit_lab_v2 as lab
+
+
+def _policy():
+    return {
+        "score_floor": 0.0,
+        "min_confirmations": 0,
+        "min_volume_ratio": 0.0,
+        "min_relative_strength": -1.0,
+        "require_ma50": False,
+        "max_positions": 1,
+        "target_allocation": 0.20,
+        "max_exposure": 0.20,
+        "stop_loss": 0.01,
+        "max_hold_days": 5,
+        "rebalance_days": 1,
+        "allowed_symbols": None,
+    }
+
+
+class PerformanceValidationEvidenceTests(unittest.TestCase):
+    def test_execution_diagnostics_cover_turnover_capacity_and_concentration(self):
+        sim = {
+            "dates": list(pd.date_range("2026-01-01", periods=252, freq="B")),
+            "equity_curve": [10_000.0] * 252,
+            "assumptions": {"transaction_cost_bps_per_side": 8.0},
+            "trades": [
+                {
+                    "action": "entry", "symbol": "NVDA", "gross_notional": 2_000.0,
+                    "fee": 1.6, "adv_participation_pct": 0.01,
+                },
+                {
+                    "action": "exit", "symbol": "NVDA", "gross_notional": 2_100.0,
+                    "fee": 1.68, "pnl": 96.72,
+                },
+                {
+                    "action": "entry", "symbol": "XLE", "gross_notional": 1_500.0,
+                    "fee": 1.2, "adv_participation_pct": 0.02,
+                },
+                {
+                    "action": "exit", "symbol": "XLE", "gross_notional": 1_450.0,
+                    "fee": 1.16, "pnl": -52.36,
+                },
+            ],
+        }
+        result = lab._execution_diagnostics(sim)
+        self.assertEqual(result["status"], "complete")
+        self.assertEqual(result["gross_traded_notional"], 7050.0)
+        self.assertEqual(result["annualized_turnover_x"], 0.705)
+        self.assertEqual(result["capacity"]["entries_with_adv"], 2)
+        self.assertEqual(result["capacity"]["stress"][-1]["entries_over_limit"], 1)
+        self.assertEqual(
+            result["concentration"]["symbol"]["top_contributor"], "NVDA"
+        )
+        self.assertEqual(
+            result["concentration"]["sector_group"]["top_contributor"],
+            "semiconductors",
+        )
+
+    def test_sensitivity_has_bounded_cost_and_delayed_open_scenarios(self):
+        baseline = {"metrics": {"status": "ok", "total_return_pct": 1.0}}
+
+        def simulated(*args, **kwargs):
+            return {
+                "metrics": {
+                    "status": "ok",
+                    "total_return_pct": 10.0 - float(kwargs.get("transaction_cost_bps", 8.0)),
+                    "trades": 10,
+                }
+            }
+
+        with patch.object(lab, "_simulate_next_open", side_effect=simulated):
+            result = lab._sensitivity_report({}, [], {}, baseline)
+        self.assertEqual(result["status"], "complete")
+        self.assertEqual(
+            [row["transaction_cost_bps_per_side"] for row in result["cost_scenarios"]],
+            list(lab.COST_SENSITIVITY_BPS),
+        )
+        self.assertEqual(
+            [row["execution_delay_sessions"] for row in result["delay_scenarios"]],
+            list(lab.DELAY_SENSITIVITY_SESSIONS),
+        )
+
+    def test_validation_verdict_fails_closed_until_every_field_exists(self):
+        self.assertFalse(lab._validation_verdict({})["candidate_selection_evidence_complete"])
+        profile = {
+            "execution_diagnostics": {
+                "status": "complete", "capacity": {"status": "complete"}
+            },
+            "sensitivity": {
+                "cost_scenarios": [{}] * len(lab.COST_SENSITIVITY_BPS),
+                "delay_scenarios": [{}] * len(lab.DELAY_SENSITIVITY_SESSIONS),
+            },
+        }
+        result = {
+            "profiles": {
+                "current_proxy": profile,
+                "balanced_static": profile,
+                "permissive": profile,
+                "adaptive_balanced": profile,
+            },
+            "ablation": {
+                "status": "ok",
+                "best_variant": {"execution_diagnostics": {"status": "complete"}},
+                "best_variant_sensitivity": {"status": "complete"},
+            },
+        }
+        verdict = lab._validation_verdict(result)
+        self.assertEqual(verdict["status"], "complete")
+        self.assertTrue(verdict["candidate_selection_evidence_complete"])
+        self.assertFalse(verdict["automatic_strategy_promotion"])
+
+    def test_delayed_execution_uses_later_open_without_refreshing_signal(self):
+        dates = pd.to_datetime(["2026-01-05", "2026-01-06", "2026-01-07"])
+        frame = pd.DataFrame(
+            [
+                {"Open": 100.0, "High": 101.0, "Low": 99.0, "Close": 100.0,
+                 "score": 0.03, "atr_pct": 0.01, "adv20_dollars": 1_000_000.0},
+                {"Open": 110.0, "High": 111.0, "Low": 109.0, "Close": 110.0,
+                 "score": -1.0, "atr_pct": 0.50, "adv20_dollars": 1_000_000.0},
+                {"Open": 120.0, "High": 121.0, "Low": 119.0, "Close": 120.0,
+                 "score": -1.0, "atr_pct": 0.50, "adv20_dollars": 1_000_000.0},
+            ],
+            index=dates,
+        )
+        with patch.object(lab, "np", np), patch.object(
+            lab.base, "np", np
+        ), patch.object(lab, "_regime", return_value="neutral"), patch.object(
+            lab, "_eligible", side_effect=lambda row, policy: row["score"] > 0
+        ):
+            result = lab._simulate_next_open(
+                {"ALPHA": frame}, {"neutral": _policy()}, list(dates),
+                execution_delay_sessions=2,
+            )
+        entry = next(row for row in result["trades"] if row["action"] == "entry")
+        self.assertEqual(entry["date"], "2026-01-07")
+        self.assertEqual(entry["price"], 120.0)
+        self.assertEqual(entry["signal_atr_pct"], 0.01)
+        self.assertEqual(entry["execution_delay_sessions"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the missing evidence-tooling stage of #196 without changing production trading behavior. Adds per-side cost sensitivity (4/8/15/25 bps), 1/2/3-session delayed-execution tests, turnover, ADV capacity stress, symbol/sector concentration, and a fail-closed evidence-completeness verdict. The isolated/resumable runner rejects stale engine checkpoints, and the request manifest triggers a fresh five-year baseline after merge. Adds focused regressions and makes them mandatory in Change Safety. Rules/order/risk authority and canonical state/history are unchanged; this remains offline advisory research only.