### PR TITLE
Issue #202: validate hold candidate history

### DIFF
--- a/.github/performance-audit-v2-request.json
+++ b/.github/performance-audit-v2-request.json
@@ -1,5 +1,5 @@
 {
-  "request_id": "baseline-2026-09-09-v3-issue196",
+  "request_id": "baseline-2026-09-09-v4-issue202-stage1",
   "period": "5y",
   "max_symbols": 45,
   "include_ablation": true,

--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -62,6 +62,7 @@ PERFORMANCE_EVIDENCE_INTEGRITY_TESTS = (
     "test_issue170_performance_atr_integrity.py",
     "test_issue193_performance_v2_isolation.py",
     "test_issue196_performance_validation_evidence.py",
+    "test_issue202_hold_candidate_validation.py",
 )
 SYSTEM_SENTINEL_TESTS = (
     "test_system_sentinel.py",
@@ -152,6 +153,7 @@ def _is_performance_evidence_integrity_path(path: str) -> bool:
         "test_issue170_performance_atr_integrity.py",
         "test_issue193_performance_v2_isolation.py",
         "test_issue196_performance_validation_evidence.py",
+        "test_issue202_hold_candidate_validation.py",
     }
 
 

--- a/performance_audit_lab_v2.py
+++ b/performance_audit_lab_v2.py
@@ -27,7 +27,7 @@ import performance_validation_evidence as evidence
 np = base.np
 pd = base.pd
 
-VERSION = "performance-audit-lab-v2-2026-09-09-v4-validation-evidence"
+VERSION = "performance-audit-lab-v2-2026-09-09-v5-candidate-validation"
 ENABLED = os.environ.get("PERFORMANCE_AUDIT_V2_ENABLED", "true").lower() not in {
     "0", "false", "no", "off"
 }
@@ -926,17 +926,57 @@ def _run_ablation(
     results.sort(key=lambda row: _f(row.get("objective"), -9999.0), reverse=True)
     best_name = str(_d(results[0] if results else {}).get("variant") or "")
     best_map = _ablation_maps().get(best_name)
+    candidate_validation = _candidate_validation(features, dates, best_map)
     return {
         "status": "ok",
         "baseline": "adaptive_baseline",
         "variant_count": len(results),
         "ranking": results,
         "best_variant": results[0] if results else None,
-        "best_variant_sensitivity": _sensitivity_report(features, dates, best_map)
-        if best_map else {"status": "not_available"},
+        "best_variant_sensitivity": _d(candidate_validation.get("sensitivity")),
+        "best_variant_validation": candidate_validation,
         "interpretation": (
             "Each variant changes one parameter family from the adaptive baseline. "
             "Results remain daily-bar proxies and should be confirmed by forward shadow data."
+        ),
+    }
+
+
+def _candidate_validation(
+    features: Dict[str, Any],
+    dates: Sequence[Any],
+    regime_map: Dict[str, Dict[str, Any]] | None,
+) -> Dict[str, Any]:
+    if not regime_map:
+        return {"status": "not_available", "automatic_promotion": False}
+    sim = _simulate_next_open(features, regime_map, dates)
+    walk_forward = _walk_forward(features, regime_map, dates, optimize=False)
+    calendar = _calendar_years(sim)
+    regimes = _regime_report(sim)
+    diagnostics = _execution_diagnostics(sim)
+    sensitivity = _sensitivity_report(features, dates, regime_map, sim)
+    complete = (
+        diagnostics.get("status") == "complete"
+        and sensitivity.get("status") == "complete"
+        and walk_forward.get("status") == "complete"
+        and bool(calendar)
+        and bool(regimes)
+    )
+    return {
+        "status": "complete" if complete else "incomplete",
+        "full_sample": sim.get("metrics"),
+        "execution_diagnostics": diagnostics,
+        "sensitivity": sensitivity,
+        "calendar_years": calendar,
+        "regime_report": regimes,
+        "walk_forward": walk_forward,
+        "candidate_selected_on_full_sample": True,
+        "untouched_holdout_after_selection": False,
+        "requires_forward_shadow_confirmation": True,
+        "automatic_promotion": False,
+        "warning": (
+            "Rolling folds test temporal robustness, but the candidate was selected "
+            "after inspecting this history. Forward shadow evidence remains required."
         ),
     }
 

--- a/performance_audit_v2_async_route.py
+++ b/performance_audit_v2_async_route.py
@@ -18,7 +18,7 @@ from typing import Any, Dict
 
 import performance_audit_lab_v2 as lab
 
-VERSION = "performance-audit-v2-resumable-route-2026-09-09-v3-evidence"
+VERSION = "performance-audit-v2-resumable-route-2026-09-09-v4-candidate-validation"
 
 _LOCK = threading.RLock()
 _REGISTERED: set[int] = set()
@@ -257,15 +257,15 @@ def _run_resumable_ablation(
     ranking.sort(key=lambda row: _f(_d(row).get("objective"), -9999.0), reverse=True)
     best_name = str(_d(ranking[0] if ranking else {}).get("variant") or "")
     best_map = variants.get(best_name)
+    candidate_validation = lab._candidate_validation(features, dates, best_map)
     return {
         "status": "ok",
         "baseline": "adaptive_baseline",
         "variant_count": len(ranking),
         "ranking": ranking,
         "best_variant": ranking[0] if ranking else None,
-        "best_variant_sensitivity": lab._sensitivity_report(
-            features, dates, best_map
-        ) if best_map else {"status": "not_available"},
+        "best_variant_sensitivity": _d(candidate_validation.get("sensitivity")),
+        "best_variant_validation": candidate_validation,
         "interpretation": (
             "Each variant changes one parameter family from the adaptive baseline. "
             "Results remain daily-bar proxies and require forward-shadow confirmation."

--- a/performance_validation_evidence.py
+++ b/performance_validation_evidence.py
@@ -257,10 +257,20 @@ def validation_verdict(
         missing.append("ablation.best_variant.execution_diagnostics")
     if _d(ablation.get("best_variant_sensitivity")).get("status") != "complete":
         missing.append("ablation.best_variant_sensitivity")
+    candidate = _d(ablation.get("best_variant_validation"))
+    if candidate.get("status") != "complete":
+        missing.append("ablation.best_variant_validation")
+    if _d(candidate.get("walk_forward")).get("status") != "complete":
+        missing.append("ablation.best_variant_validation.walk_forward")
+    if not _d(candidate.get("calendar_years")):
+        missing.append("ablation.best_variant_validation.calendar_years")
+    if not _d(candidate.get("regime_report")):
+        missing.append("ablation.best_variant_validation.regime_report")
     complete = not missing
     return {
         "status": "complete" if complete else "incomplete",
         "candidate_selection_evidence_complete": complete,
+        "candidate_historical_validation_complete": complete,
         "automatic_strategy_promotion": False,
         "requires_forward_shadow_confirmation": True,
         "missing_or_incomplete": missing,

--- a/test_change_safety_audit.py
+++ b/test_change_safety_audit.py
@@ -239,6 +239,7 @@ class ChangeSafetyAuditTests(unittest.TestCase):
             self.assertIn("test_issue170_performance_atr_integrity.py", tests)
             self.assertIn("test_issue193_performance_v2_isolation.py", tests)
             self.assertIn("test_issue196_performance_validation_evidence.py", tests)
+            self.assertIn("test_issue202_hold_candidate_validation.py", tests)
 
     def test_system_sentinel_change_selects_complete_sentinel_regression_set(self) -> None:
         for path in ("system_sentinel.py", "system_sentinel_runtime.py"):

--- a/test_issue196_performance_validation_evidence.py
+++ b/test_issue196_performance_validation_evidence.py
@@ -109,6 +109,12 @@ class PerformanceValidationEvidenceTests(unittest.TestCase):
                 "status": "ok",
                 "best_variant": {"execution_diagnostics": {"status": "complete"}},
                 "best_variant_sensitivity": {"status": "complete"},
+                "best_variant_validation": {
+                    "status": "complete",
+                    "walk_forward": {"status": "complete"},
+                    "calendar_years": {"2026": {}},
+                    "regime_report": {"risk_on": {}},
+                },
             },
         }
         verdict = lab._validation_verdict(result)

--- a/test_issue202_hold_candidate_validation.py
+++ b/test_issue202_hold_candidate_validation.py
@@ -1,0 +1,60 @@
+import unittest
+from unittest.mock import patch
+
+import performance_audit_lab_v2 as lab
+
+
+class HoldCandidateValidationTests(unittest.TestCase):
+    def test_candidate_validation_is_historical_and_never_promotes(self):
+        simulation = {"metrics": {"status": "ok", "total_return_pct": 12.0}}
+        with patch.object(lab, "_simulate_next_open", return_value=simulation), patch.object(
+            lab, "_execution_diagnostics", return_value={"status": "complete"}
+        ), patch.object(
+            lab, "_sensitivity_report", return_value={"status": "complete"}
+        ), patch.object(
+            lab, "_calendar_years", return_value={"2026": {"status": "ok"}}
+        ), patch.object(
+            lab, "_regime_report", return_value={"risk_on": {"status": "ok"}}
+        ), patch.object(
+            lab,
+            "_walk_forward",
+            return_value={"status": "complete", "formal_walk_forward_passed": True},
+        ) as walk_forward:
+            result = lab._candidate_validation({}, [], {"neutral": {}})
+
+        self.assertEqual(result["status"], "complete")
+        self.assertTrue(result["candidate_selected_on_full_sample"])
+        self.assertFalse(result["untouched_holdout_after_selection"])
+        self.assertTrue(result["requires_forward_shadow_confirmation"])
+        self.assertFalse(result["automatic_promotion"])
+        walk_forward.assert_called_once_with({}, {"neutral": {}}, [], optimize=False)
+
+    def test_missing_candidate_validation_fails_closed(self):
+        result = {
+            "profiles": {
+                name: {
+                    "execution_diagnostics": {
+                        "status": "complete", "capacity": {"status": "complete"}
+                    },
+                    "sensitivity": {
+                        "cost_scenarios": [{}] * len(lab.COST_SENSITIVITY_BPS),
+                        "delay_scenarios": [{}] * len(lab.DELAY_SENSITIVITY_SESSIONS),
+                    },
+                }
+                for name in (
+                    "current_proxy", "balanced_static", "permissive", "adaptive_balanced"
+                )
+            },
+            "ablation": {
+                "status": "ok",
+                "best_variant": {"execution_diagnostics": {"status": "complete"}},
+                "best_variant_sensitivity": {"status": "complete"},
+            },
+        }
+        verdict = lab._validation_verdict(result)
+        self.assertFalse(verdict["candidate_historical_validation_complete"])
+        self.assertIn("ablation.best_variant_validation", verdict["missing_or_incomplete"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds candidate-specific rolling walk-forward, calendar-year, regime, sensitivity, turnover/capacity/concentration evidence for the best one-variable V2 ablation. The report explicitly records full-sample selection bias, no untouched post-selection holdout, required forward shadow confirmation, and automatic promotion false. Stale checkpoints are invalidated by the version bump, and a new isolated five-year artifact is requested. Adds mandatory focused regressions. Offline advisory research only; no production hold period, strategy, risk, state, broker, or order authority changes.