### PR TITLE
Add frozen hold-period forward shadow comparator

### DIFF
--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -63,6 +63,7 @@ PERFORMANCE_EVIDENCE_INTEGRITY_TESTS = (
     "test_issue193_performance_v2_isolation.py",
     "test_issue196_performance_validation_evidence.py",
     "test_issue202_hold_candidate_validation.py",
+    "test_issue202_hold_forward_shadow.py",
 )
 SYSTEM_SENTINEL_TESTS = (
     "test_system_sentinel.py",

--- a/hold_period_forward_shadow.py
+++ b/hold_period_forward_shadow.py
@@ -1,0 +1,312 @@
+"""Fail-closed forward-shadow evidence for the frozen ``hold_10d`` candidate.
+
+The comparator consumes two already-completed Performance Audit V2 simulations.
+It never imports the runtime, fetches market data, writes state, or changes an
+exit.  Recomputing the isolated audit therefore reconstructs the entire forward
+sample from immutable policy identifiers and market inputs.
+"""
+from __future__ import annotations
+
+import collections
+import datetime as dt
+import math
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
+
+VERSION = "hold-period-forward-shadow-2026-09-09-v1-frozen-contract"
+CANDIDATE_ID = "hold_10d"
+FREEZE_DATE = "2026-09-09"
+BASELINE_ID = "adaptive_baseline"
+TRANSACTION_COST_BPS_PER_SIDE = 8.0
+STRESS_COST_BPS_PER_SIDE = 25.0
+OBSERVATION_LIMIT = 1000
+
+CRITERIA: Dict[str, Any] = {
+    "minimum_exact_matched_completed_lifecycles": 100,
+    "minimum_exit_divergences": 30,
+    "minimum_forward_sessions": 60,
+    "minimum_calendar_months": 3,
+    "minimum_neutral_entries": 20,
+    "minimum_defensive_or_risk_off_entries": 20,
+    "minimum_exact_pairing_coverage_pct": 60.0,
+    "maximum_single_symbol_share_pct": 25.0,
+    "minimum_mean_return_delta_pct_at_8bps": 0.0,
+    "minimum_mean_return_delta_pct_at_25bps": 0.0,
+    "require_nonnegative_neutral_delta": True,
+    "require_nonnegative_defensive_or_risk_off_delta": True,
+    "automatic_promotion": False,
+}
+
+
+def _d(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _rows(value: Any) -> List[Mapping[str, Any]]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [row for row in value if isinstance(row, Mapping)]
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        number = float(value)
+        return number if math.isfinite(number) else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _date(value: Any) -> str:
+    text = str(value or "")[:10]
+    try:
+        return dt.date.fromisoformat(text).isoformat()
+    except ValueError:
+        return ""
+
+
+def _entry_key(row: Mapping[str, Any]) -> Tuple[str, str, float]:
+    return (
+        str(row.get("symbol") or "").strip().upper(),
+        _date(row.get("date")),
+        round(_f(row.get("price")), 6),
+    )
+
+
+def _normalized_return(entry: Mapping[str, Any], exit_row: Mapping[str, Any]) -> float | None:
+    allocation = _f(entry.get("allocation"))
+    pnl = _f(exit_row.get("pnl"))
+    if allocation <= 0:
+        return None
+    return round(pnl / allocation * 100.0, 6)
+
+
+def _lifecycles(simulation: Mapping[str, Any]) -> Tuple[List[Dict[str, Any]], List[str]]:
+    active: Dict[str, Mapping[str, Any]] = {}
+    completed: List[Dict[str, Any]] = []
+    errors: List[str] = []
+    for row in _rows(simulation.get("trades")):
+        symbol = str(row.get("symbol") or "").strip().upper()
+        action = str(row.get("action") or "").lower()
+        if not symbol:
+            errors.append("trade_missing_symbol")
+            continue
+        if action == "entry":
+            if symbol in active:
+                errors.append(f"overlapping_entry:{symbol}")
+            else:
+                active[symbol] = row
+            continue
+        if action != "exit":
+            continue
+        entry = active.pop(symbol, None)
+        if entry is None:
+            errors.append(f"unmatched_exit:{symbol}")
+            continue
+        normalized = _normalized_return(entry, row)
+        if normalized is None:
+            errors.append(f"invalid_entry_allocation:{symbol}")
+            continue
+        completed.append({
+            "entry_key": _entry_key(entry),
+            "symbol": symbol,
+            "entry_date": _date(entry.get("date")),
+            "entry_price": round(_f(entry.get("price")), 6),
+            "entry_regime": str(row.get("entry_regime") or entry.get("regime") or "unknown"),
+            "exit_date": _date(row.get("date")),
+            "exit_price": round(_f(row.get("price")), 6),
+            "exit_reason": str(row.get("reason") or "unknown"),
+            "return_pct": normalized,
+        })
+    return completed, sorted(set(errors))
+
+
+def _index_lifecycles(rows: Iterable[Mapping[str, Any]]) -> Dict[Tuple[str, str, float], List[Mapping[str, Any]]]:
+    indexed: Dict[Tuple[str, str, float], List[Mapping[str, Any]]] = collections.defaultdict(list)
+    for row in rows:
+        key = row.get("entry_key")
+        if isinstance(key, tuple) and len(key) == 3:
+            indexed[key].append(row)
+    return dict(indexed)
+
+
+def _pair_lifecycles(
+    baseline_rows: Sequence[Mapping[str, Any]],
+    candidate_rows: Sequence[Mapping[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    baseline = _index_lifecycles(baseline_rows)
+    candidate = _index_lifecycles(candidate_rows)
+    pairs: List[Dict[str, Any]] = []
+    errors: List[str] = []
+    for key in sorted(set(baseline) | set(candidate)):
+        left = baseline.get(key, [])
+        right = candidate.get(key, [])
+        if len(left) != 1 or len(right) != 1:
+            if left or right:
+                prefix = "ambiguous_entry" if len(left) > 1 or len(right) > 1 else "unmatched_entry"
+                errors.append(f"{prefix}:{key[0]}:{key[1]}:{key[2]:.6f}")
+            continue
+        current, proposed = left[0], right[0]
+        delta = round(_f(proposed.get("return_pct")) - _f(current.get("return_pct")), 6)
+        pairs.append({
+            "observation_id": f"{key[0]}|{key[1]}|{key[2]:.6f}",
+            "symbol": key[0],
+            "entry_date": key[1],
+            "entry_price": key[2],
+            "entry_regime": current.get("entry_regime"),
+            "baseline_exit_date": current.get("exit_date"),
+            "baseline_exit_reason": current.get("exit_reason"),
+            "baseline_return_pct": current.get("return_pct"),
+            "candidate_exit_date": proposed.get("exit_date"),
+            "candidate_exit_reason": proposed.get("exit_reason"),
+            "candidate_return_pct": proposed.get("return_pct"),
+            "return_delta_pct": delta,
+            "exit_diverged": bool(
+                current.get("exit_date") != proposed.get("exit_date")
+                or current.get("exit_reason") != proposed.get("exit_reason")
+                or current.get("exit_price") != proposed.get("exit_price")
+            ),
+        })
+    return pairs, errors
+
+
+def _mean(rows: Sequence[Mapping[str, Any]], key: str) -> float | None:
+    values = [_f(row.get(key)) for row in rows]
+    return round(sum(values) / len(values), 6) if values else None
+
+
+def _group_summary(rows: Sequence[Mapping[str, Any]], field: str) -> Dict[str, Any]:
+    groups: Dict[str, List[Mapping[str, Any]]] = collections.defaultdict(list)
+    for row in rows:
+        groups[str(row.get(field) or "unknown")].append(row)
+    return {
+        name: {
+            "observations": len(group),
+            "exit_divergences": sum(bool(row.get("exit_diverged")) for row in group),
+            "mean_return_delta_pct": _mean(group, "return_delta_pct"),
+        }
+        for name, group in sorted(groups.items())
+    }
+
+
+def _coverage(
+    rows: Sequence[Mapping[str, Any]],
+    available_dates: Sequence[Any],
+    unmatched_entries: int,
+) -> Dict[str, Any]:
+    forward_dates = sorted({_date(value) for value in available_dates if _date(value) >= FREEZE_DATE})
+    months = sorted({value[:7] for value in forward_dates})
+    symbol_counts = collections.Counter(str(row.get("symbol") or "") for row in rows)
+    largest = max(symbol_counts.values(), default=0)
+    return {
+        "available_forward_sessions": len(forward_dates),
+        "calendar_months": len(months),
+        "first_forward_session": forward_dates[0] if forward_dates else None,
+        "last_forward_session": forward_dates[-1] if forward_dates else None,
+        "largest_symbol_observation_share_pct": round(largest / max(1, len(rows)) * 100.0, 2),
+        "unmatched_completed_entries": unmatched_entries,
+        "exact_pairing_coverage_pct": round(
+            len(rows) / max(1, len(rows) + unmatched_entries) * 100.0, 2
+        ),
+    }
+
+
+def _criteria_results(
+    rows: Sequence[Mapping[str, Any]],
+    coverage: Mapping[str, Any],
+    by_regime: Mapping[str, Any],
+    stress_mean_delta: float | None,
+) -> Dict[str, bool]:
+    neutral = _d(by_regime.get("neutral"))
+    defensive_count = sum(_f(_d(by_regime.get(name)).get("observations")) for name in ("defensive", "risk_off"))
+    defensive_delta_rows = [row for row in rows if row.get("entry_regime") in {"defensive", "risk_off"}]
+    return {
+        "exact_matched_completed_lifecycles": len(rows) >= CRITERIA["minimum_exact_matched_completed_lifecycles"],
+        "exit_divergences": sum(bool(row.get("exit_diverged")) for row in rows) >= CRITERIA["minimum_exit_divergences"],
+        "forward_sessions": _f(coverage.get("available_forward_sessions")) >= CRITERIA["minimum_forward_sessions"],
+        "calendar_months": _f(coverage.get("calendar_months")) >= CRITERIA["minimum_calendar_months"],
+        "neutral_entries": _f(neutral.get("observations")) >= CRITERIA["minimum_neutral_entries"],
+        "defensive_or_risk_off_entries": defensive_count >= CRITERIA["minimum_defensive_or_risk_off_entries"],
+        "symbol_concentration": _f(coverage.get("largest_symbol_observation_share_pct"), 100.0) <= CRITERIA["maximum_single_symbol_share_pct"],
+        "exact_pairing_coverage": _f(coverage.get("exact_pairing_coverage_pct")) >= CRITERIA["minimum_exact_pairing_coverage_pct"],
+        "positive_mean_delta_at_8bps": (_mean(rows, "return_delta_pct") or -999.0) > CRITERIA["minimum_mean_return_delta_pct_at_8bps"],
+        "nonnegative_mean_delta_at_25bps": stress_mean_delta is not None and stress_mean_delta >= CRITERIA["minimum_mean_return_delta_pct_at_25bps"],
+        "nonnegative_neutral_delta": neutral.get("mean_return_delta_pct") is not None and _f(neutral.get("mean_return_delta_pct")) >= 0.0,
+        "nonnegative_defensive_or_risk_off_delta": _mean(defensive_delta_rows, "return_delta_pct") is not None and (_mean(defensive_delta_rows, "return_delta_pct") or 0.0) >= 0.0,
+    }
+
+
+def build_report(
+    baseline_simulation: Mapping[str, Any],
+    candidate_simulation: Mapping[str, Any],
+    available_dates: Sequence[Any],
+    *,
+    stress_baseline_simulation: Mapping[str, Any] | None = None,
+    stress_candidate_simulation: Mapping[str, Any] | None = None,
+) -> Dict[str, Any]:
+    baseline, baseline_errors = _lifecycles(baseline_simulation)
+    candidate, candidate_errors = _lifecycles(candidate_simulation)
+    paired, pair_errors = _pair_lifecycles(
+        [row for row in baseline if row.get("entry_date", "") >= FREEZE_DATE],
+        [row for row in candidate if row.get("entry_date", "") >= FREEZE_DATE],
+    )
+    stress_mean = None
+    stress_errors: List[str] = []
+    if stress_baseline_simulation is not None and stress_candidate_simulation is not None:
+        stress_baseline, left_errors = _lifecycles(stress_baseline_simulation)
+        stress_candidate, right_errors = _lifecycles(stress_candidate_simulation)
+        stress_pairs, match_errors = _pair_lifecycles(
+            [row for row in stress_baseline if row.get("entry_date", "") >= FREEZE_DATE],
+            [row for row in stress_candidate if row.get("entry_date", "") >= FREEZE_DATE],
+        )
+        stress_mean = _mean(stress_pairs, "return_delta_pct")
+        stress_errors = left_errors + right_errors + match_errors
+    unmatched = [error for error in pair_errors if error.startswith("unmatched_entry:")]
+    integrity_errors = sorted(set(
+        baseline_errors
+        + candidate_errors
+        + [error for error in pair_errors if not error.startswith("unmatched_entry:")]
+        + [error for error in stress_errors if not error.startswith("unmatched_entry:")]
+    ))
+    coverage = _coverage(paired, available_dates, len(unmatched))
+    by_regime = _group_summary(paired, "entry_regime")
+    checks = _criteria_results(paired, coverage, by_regime, stress_mean)
+    eligible = bool(paired) and not integrity_errors
+    all_criteria_met = eligible and all(checks.values())
+    return {
+        "status": "evidence_ready" if all_criteria_met else "collecting" if not integrity_errors else "inconclusive",
+        "type": "hold_period_forward_shadow",
+        "version": VERSION,
+        "candidate_id": CANDIDATE_ID,
+        "baseline_id": BASELINE_ID,
+        "candidate_frozen_before_observation": True,
+        "freeze_date": FREEZE_DATE,
+        "transaction_cost_bps_per_side": TRANSACTION_COST_BPS_PER_SIDE,
+        "stress_cost_bps_per_side": STRESS_COST_BPS_PER_SIDE,
+        "exact_matched_completed_lifecycles": len(paired),
+        "exit_divergences": sum(bool(row.get("exit_diverged")) for row in paired),
+        "mean_return_delta_pct": _mean(paired, "return_delta_pct"),
+        "stress_mean_return_delta_pct": stress_mean,
+        "coverage": coverage,
+        "by_regime": by_regime,
+        "by_symbol": _group_summary(paired, "symbol"),
+        "integrity": {
+            "eligible": eligible,
+            "errors": integrity_errors[:100],
+            "ambiguous_or_unmatched_evidence_rejected": True,
+            "full_recomputation_from_frozen_inputs": True,
+        },
+        "predeclared_criteria": dict(CRITERIA),
+        "criteria_results": checks,
+        "all_criteria_met": all_criteria_met,
+        "automatic_promotion": False,
+        "observations": paired[-OBSERVATION_LIMIT:],
+        "authority": {
+            "isolated_research_only": True,
+            "read_only_comparator": True,
+            "writes_production_state": False,
+            "changes_runtime_exits": False,
+            "changes_strategy_or_thresholds": False,
+            "changes_risk_or_sizing": False,
+            "places_or_cancels_orders": False,
+            "changes_live_or_ml_authority": False,
+        },
+    }

--- a/hold_period_forward_shadow_contract.json
+++ b/hold_period_forward_shadow_contract.json
@@ -1,0 +1,34 @@
+{
+  "version": "hold-period-forward-shadow-2026-09-09-v1-frozen-contract",
+  "candidate_id": "hold_10d",
+  "baseline_id": "adaptive_baseline",
+  "freeze_date": "2026-09-09",
+  "candidate_frozen_before_observation": true,
+  "transaction_cost_bps_per_side": 8.0,
+  "stress_cost_bps_per_side": 25.0,
+  "criteria": {
+    "minimum_exact_matched_completed_lifecycles": 100,
+    "minimum_exit_divergences": 30,
+    "minimum_forward_sessions": 60,
+    "minimum_calendar_months": 3,
+    "minimum_neutral_entries": 20,
+    "minimum_defensive_or_risk_off_entries": 20,
+    "minimum_exact_pairing_coverage_pct": 60.0,
+    "maximum_single_symbol_share_pct": 25.0,
+    "minimum_mean_return_delta_pct_at_8bps": 0.0,
+    "minimum_mean_return_delta_pct_at_25bps": 0.0,
+    "require_nonnegative_neutral_delta": true,
+    "require_nonnegative_defensive_or_risk_off_delta": true,
+    "automatic_promotion": false
+  },
+  "authority": {
+    "isolated_research_only": true,
+    "read_only_comparator": true,
+    "writes_production_state": false,
+    "changes_runtime_exits": false,
+    "changes_strategy_or_thresholds": false,
+    "changes_risk_or_sizing": false,
+    "places_or_cancels_orders": false,
+    "changes_live_or_ml_authority": false
+  }
+}

--- a/performance_audit_lab_v2.py
+++ b/performance_audit_lab_v2.py
@@ -23,11 +23,12 @@ from typing import Any, Dict, List, Sequence, Tuple
 
 import performance_audit_lab as base
 import performance_validation_evidence as evidence
+import hold_period_forward_shadow as hold_shadow
 
 np = base.np
 pd = base.pd
 
-VERSION = "performance-audit-lab-v2-2026-09-09-v5-candidate-validation"
+VERSION = "performance-audit-lab-v2-2026-09-09-v6-hold-forward-shadow"
 ENABLED = os.environ.get("PERFORMANCE_AUDIT_V2_ENABLED", "true").lower() not in {
     "0", "false", "no", "off"
 }
@@ -925,16 +926,29 @@ def _run_ablation(
         )
     results.sort(key=lambda row: _f(row.get("objective"), -9999.0), reverse=True)
     best_name = str(_d(results[0] if results else {}).get("variant") or "")
-    best_map = _ablation_maps().get(best_name)
-    candidate_validation = _candidate_validation(features, dates, best_map)
+    candidate_name = hold_shadow.CANDIDATE_ID
+    candidate_map = _ablation_maps().get(candidate_name)
+    baseline_simulation = _simulate_next_open(features, baseline, dates)
+    candidate_validation = _candidate_validation(
+        features,
+        dates,
+        candidate_map,
+        baseline_simulation=baseline_simulation,
+    )
     return {
         "status": "ok",
         "baseline": "adaptive_baseline",
         "variant_count": len(results),
         "ranking": results,
         "best_variant": results[0] if results else None,
+        "selected_candidate": candidate_name,
+        "selection_frozen_date": hold_shadow.FREEZE_DATE,
+        "selected_candidate_sensitivity": _d(candidate_validation.get("sensitivity")),
+        "selected_candidate_validation": candidate_validation,
+        # Backward-compatible aliases retained for existing evidence readers.
         "best_variant_sensitivity": _d(candidate_validation.get("sensitivity")),
         "best_variant_validation": candidate_validation,
+        "current_full_sample_best_variant": best_name,
         "interpretation": (
             "Each variant changes one parameter family from the adaptive baseline. "
             "Results remain daily-bar proxies and should be confirmed by forward shadow data."
@@ -946,6 +960,7 @@ def _candidate_validation(
     features: Dict[str, Any],
     dates: Sequence[Any],
     regime_map: Dict[str, Dict[str, Any]] | None,
+    baseline_simulation: Dict[str, Any] | None = None,
 ) -> Dict[str, Any]:
     if not regime_map:
         return {"status": "not_available", "automatic_promotion": False}
@@ -955,6 +970,28 @@ def _candidate_validation(
     regimes = _regime_report(sim)
     diagnostics = _execution_diagnostics(sim)
     sensitivity = _sensitivity_report(features, dates, regime_map, sim)
+    baseline_simulation = baseline_simulation or _simulate_next_open(
+        features, copy.deepcopy(ADAPTIVE_REGIMES), dates
+    )
+    stress_baseline = _simulate_next_open(
+        features,
+        copy.deepcopy(ADAPTIVE_REGIMES),
+        dates,
+        transaction_cost_bps=hold_shadow.STRESS_COST_BPS_PER_SIDE,
+    )
+    stress_candidate = _simulate_next_open(
+        features,
+        regime_map,
+        dates,
+        transaction_cost_bps=hold_shadow.STRESS_COST_BPS_PER_SIDE,
+    )
+    forward_shadow = hold_shadow.build_report(
+        baseline_simulation,
+        sim,
+        dates,
+        stress_baseline_simulation=stress_baseline,
+        stress_candidate_simulation=stress_candidate,
+    )
     complete = (
         diagnostics.get("status") == "complete"
         and sensitivity.get("status") == "complete"
@@ -964,12 +1001,14 @@ def _candidate_validation(
     )
     return {
         "status": "complete" if complete else "incomplete",
+        "candidate_id": hold_shadow.CANDIDATE_ID,
         "full_sample": sim.get("metrics"),
         "execution_diagnostics": diagnostics,
         "sensitivity": sensitivity,
         "calendar_years": calendar,
         "regime_report": regimes,
         "walk_forward": walk_forward,
+        "forward_shadow": forward_shadow,
         "candidate_selected_on_full_sample": True,
         "untouched_holdout_after_selection": False,
         "requires_forward_shadow_confirmation": True,

--- a/performance_audit_v2_async_route.py
+++ b/performance_audit_v2_async_route.py
@@ -18,7 +18,7 @@ from typing import Any, Dict
 
 import performance_audit_lab_v2 as lab
 
-VERSION = "performance-audit-v2-resumable-route-2026-09-09-v4-candidate-validation"
+VERSION = "performance-audit-v2-resumable-route-2026-09-09-v5-hold-forward-shadow"
 
 _LOCK = threading.RLock()
 _REGISTERED: set[int] = set()

--- a/test_issue202_hold_candidate_validation.py
+++ b/test_issue202_hold_candidate_validation.py
@@ -23,10 +23,12 @@ class HoldCandidateValidationTests(unittest.TestCase):
             result = lab._candidate_validation({}, [], {"neutral": {}})
 
         self.assertEqual(result["status"], "complete")
+        self.assertEqual(result["candidate_id"], "hold_10d")
         self.assertTrue(result["candidate_selected_on_full_sample"])
         self.assertFalse(result["untouched_holdout_after_selection"])
         self.assertTrue(result["requires_forward_shadow_confirmation"])
         self.assertFalse(result["automatic_promotion"])
+        self.assertIn("forward_shadow", result)
         walk_forward.assert_called_once_with({}, {"neutral": {}}, [], optimize=False)
 
     def test_missing_candidate_validation_fails_closed(self):

--- a/test_issue202_hold_forward_shadow.py
+++ b/test_issue202_hold_forward_shadow.py
@@ -1,0 +1,107 @@
+import json
+import unittest
+from pathlib import Path
+
+import hold_period_forward_shadow as shadow
+
+
+def _simulation(rows):
+    return {"trades": rows}
+
+
+def _lifecycle(symbol, entry_date, exit_date, exit_price, *, regime="neutral", reason="max_hold"):
+    return [
+        {
+            "action": "entry",
+            "symbol": symbol,
+            "date": entry_date,
+            "price": 100.0,
+            "allocation": 1000.0,
+            "regime": regime,
+        },
+        {
+            "action": "exit",
+            "symbol": symbol,
+            "date": exit_date,
+            "price": exit_price,
+            "pnl": (exit_price - 100.0) * 10.0,
+            "reason": reason,
+            "entry_regime": regime,
+        },
+    ]
+
+
+class HoldPeriodForwardShadowTests(unittest.TestCase):
+    def test_contract_is_frozen_before_forward_observation(self):
+        contract = json.loads(Path("hold_period_forward_shadow_contract.json").read_text())
+        self.assertEqual(contract["version"], shadow.VERSION)
+        self.assertEqual(contract["candidate_id"], "hold_10d")
+        self.assertEqual(contract["freeze_date"], "2026-09-09")
+        self.assertTrue(contract["candidate_frozen_before_observation"])
+        self.assertEqual(contract["criteria"], shadow.CRITERIA)
+        self.assertFalse(contract["criteria"]["automatic_promotion"])
+        self.assertFalse(contract["authority"]["changes_runtime_exits"])
+
+    def test_exact_post_freeze_lifecycles_are_compared(self):
+        baseline = _simulation(_lifecycle("MU", "2026-09-09", "2026-09-16", 102.0))
+        candidate = _simulation(_lifecycle("MU", "2026-09-09", "2026-09-18", 106.0))
+        report = shadow.build_report(
+            baseline,
+            candidate,
+            ["2026-09-09", "2026-09-10", "2026-09-18"],
+            stress_baseline_simulation=baseline,
+            stress_candidate_simulation=candidate,
+        )
+        self.assertEqual(report["exact_matched_completed_lifecycles"], 1)
+        self.assertEqual(report["exit_divergences"], 1)
+        self.assertEqual(report["mean_return_delta_pct"], 4.0)
+        self.assertEqual(report["by_regime"]["neutral"]["observations"], 1)
+        self.assertFalse(report["all_criteria_met"])
+        self.assertFalse(report["automatic_promotion"])
+
+    def test_pre_freeze_rows_never_enter_forward_sample(self):
+        rows = _lifecycle("MU", "2026-09-08", "2026-09-16", 102.0)
+        report = shadow.build_report(_simulation(rows), _simulation(rows), ["2026-09-09"])
+        self.assertEqual(report["exact_matched_completed_lifecycles"], 0)
+        self.assertEqual(report["status"], "collecting")
+
+    def test_ambiguous_entries_fail_closed(self):
+        baseline_rows = _lifecycle("MU", "2026-09-09", "2026-09-16", 102.0)
+        candidate_rows = _lifecycle("MU", "2026-09-09", "2026-09-18", 106.0)
+        candidate_rows += _lifecycle("MU", "2026-09-09", "2026-09-19", 107.0)
+        report = shadow.build_report(
+            _simulation(baseline_rows),
+            _simulation(candidate_rows),
+            ["2026-09-09", "2026-09-18"],
+        )
+        self.assertEqual(report["exact_matched_completed_lifecycles"], 0)
+        self.assertEqual(report["status"], "inconclusive")
+        self.assertFalse(report["integrity"]["eligible"])
+        self.assertTrue(report["integrity"]["errors"])
+
+    def test_unmatched_entries_are_disclosed_without_becoming_false_pairs(self):
+        baseline_rows = _lifecycle("MU", "2026-09-09", "2026-09-16", 102.0)
+        candidate_rows = _lifecycle("NVDA", "2026-09-09", "2026-09-18", 106.0)
+        report = shadow.build_report(
+            _simulation(baseline_rows),
+            _simulation(candidate_rows),
+            ["2026-09-09", "2026-09-18"],
+        )
+        self.assertEqual(report["exact_matched_completed_lifecycles"], 0)
+        self.assertEqual(report["coverage"]["unmatched_completed_entries"], 2)
+        self.assertEqual(report["status"], "collecting")
+        self.assertFalse(report["all_criteria_met"])
+
+    def test_runtime_and_trading_authority_are_explicitly_absent(self):
+        report = shadow.build_report({}, {}, [])
+        authority = report["authority"]
+        self.assertTrue(authority["isolated_research_only"])
+        self.assertTrue(authority["read_only_comparator"])
+        self.assertFalse(authority["writes_production_state"])
+        self.assertFalse(authority["changes_runtime_exits"])
+        self.assertFalse(authority["places_or_cancels_orders"])
+        self.assertFalse(report["automatic_promotion"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Advances #202 with the predeclared forward-shadow stage for the historically validated `hold_10d` candidate.

## Scope
- freezes `hold_10d`, the 2026-09-09 observation boundary, and all acceptance criteria before observations
- compares exact matched completed lifecycles against the adaptive baseline
- fully recomputes 8 bps and 25 bps net deltas from preserved simulation rows
- reports pairing coverage, genuine exit divergences, calendar/session duration, regime balance, and symbol concentration
- fails closed on malformed, ambiguous, or overlapping lifecycle evidence
- keeps expected unmatched portfolio paths visible and subject to the frozen coverage threshold
- invalidates stale V2 checkpoints after the research engine version change
- adds focused regression coverage and makes it mandatory in Change Safety

## Frozen minimums
- 100 exact matched completed lifecycles
- 30 genuine exit divergences
- 60 forward sessions across 3 calendar months
- 20 neutral and 20 defensive/risk-off entries
- 60% exact pairing coverage
- no symbol above 25%
- positive 8 bps mean delta, nonnegative 25 bps and weak-regime deltas

## Authority
Research-only and advisory. No provider calls, runtime worker, state/file writes, order activity, exit blocking, strategy/risk change, AI/ML authority, or automatic promotion. Production holding behavior remains unchanged.

## Validation
Local exact-head validation passed:
- Change Safety: 88 invariants
- Repository Safety/Performance: 329 tracked Python files, zero compile/static errors
- Architecture Debt: zero violations
- full refactor/ownership/configuration/state/decision/runtime/startup/research audit: zero new critical/warnings and zero import cycles
- focused Issue #202 regressions
- Railway configuration validation
- `git diff --check`
