### PR TITLE
Bind isolated V2 validation to the frozen hold candidate

### DIFF
--- a/performance_audit_lab_v2.py
+++ b/performance_audit_lab_v2.py
@@ -28,7 +28,7 @@ import hold_period_forward_shadow as hold_shadow
 np = base.np
 pd = base.pd
 
-VERSION = "performance-audit-lab-v2-2026-09-09-v6-hold-forward-shadow"
+VERSION = "performance-audit-lab-v2-2026-09-09-v7-frozen-candidate-binding"
 ENABLED = os.environ.get("PERFORMANCE_AUDIT_V2_ENABLED", "true").lower() not in {
     "0", "false", "no", "off"
 }

--- a/performance_audit_v2_async_route.py
+++ b/performance_audit_v2_async_route.py
@@ -18,7 +18,7 @@ from typing import Any, Dict
 
 import performance_audit_lab_v2 as lab
 
-VERSION = "performance-audit-v2-resumable-route-2026-09-09-v5-hold-forward-shadow"
+VERSION = "performance-audit-v2-resumable-route-2026-09-09-v6-frozen-candidate-binding"
 
 _LOCK = threading.RLock()
 _REGISTERED: set[int] = set()
@@ -256,16 +256,40 @@ def _run_resumable_ablation(
     ranking = list(completed.values())
     ranking.sort(key=lambda row: _f(_d(row).get("objective"), -9999.0), reverse=True)
     best_name = str(_d(ranking[0] if ranking else {}).get("variant") or "")
-    best_map = variants.get(best_name)
-    candidate_validation = lab._candidate_validation(features, dates, best_map)
+    candidate_name = lab.hold_shadow.CANDIDATE_ID
+    candidate_map = variants.get(candidate_name)
+    if candidate_map is None:
+        return {
+            "status": "error",
+            "reason": "frozen_candidate_map_missing",
+            "candidate_id": candidate_name,
+            "automatic_promotion": False,
+        }
+    baseline_simulation = lab._simulate_next_open(
+        features,
+        copy.deepcopy(lab.ADAPTIVE_REGIMES),
+        dates,
+    )
+    candidate_validation = lab._candidate_validation(
+        features,
+        dates,
+        candidate_map,
+        baseline_simulation=baseline_simulation,
+    )
     return {
         "status": "ok",
         "baseline": "adaptive_baseline",
         "variant_count": len(ranking),
         "ranking": ranking,
         "best_variant": ranking[0] if ranking else None,
+        "selected_candidate": candidate_name,
+        "selection_frozen_date": lab.hold_shadow.FREEZE_DATE,
+        "selected_candidate_sensitivity": _d(candidate_validation.get("sensitivity")),
+        "selected_candidate_validation": candidate_validation,
+        # Backward-compatible aliases retained for existing evidence readers.
         "best_variant_sensitivity": _d(candidate_validation.get("sensitivity")),
         "best_variant_validation": candidate_validation,
+        "current_full_sample_best_variant": best_name,
         "interpretation": (
             "Each variant changes one parameter family from the adaptive baseline. "
             "Results remain daily-bar proxies and require forward-shadow confirmation."

--- a/test_issue202_hold_candidate_validation.py
+++ b/test_issue202_hold_candidate_validation.py
@@ -2,9 +2,95 @@ import unittest
 from unittest.mock import patch
 
 import performance_audit_lab_v2 as lab
+import performance_audit_v2_async_route as resumable
 
 
 class HoldCandidateValidationTests(unittest.TestCase):
+    def test_resumable_ablation_binds_validation_to_frozen_candidate(self):
+        frozen_map = {"neutral": {"max_hold_days": 10}}
+        dynamic_best_map = {"neutral": {"max_positions": 2}}
+        variants = {
+            "max_positions_2": dynamic_best_map,
+            lab.hold_shadow.CANDIDATE_ID: frozen_map,
+        }
+        rows = {
+            "max_positions_2": {"variant": "max_positions_2", "objective": 9.0},
+            lab.hold_shadow.CANDIDATE_ID: {
+                "variant": lab.hold_shadow.CANDIDATE_ID,
+                "objective": 1.0,
+            },
+        }
+        core = type("Core", (), {"portfolio": {}})()
+        with patch.object(lab, "_universe", return_value=["SPY"] * 10), patch.object(
+            lab.base, "_download", return_value=({"SPY": object()}, {"status": "ok"})
+        ), patch.object(
+            lab.base,
+            "_feature_frames",
+            return_value={f"SYM{index}": object() for index in range(10)},
+        ), patch.object(
+            lab, "_add_liquidity_features"
+        ), patch.object(
+            lab.base, "_calendar", return_value=list(range(315))
+        ), patch.object(
+            lab, "_ablation_maps", return_value=variants
+        ), patch.object(
+            resumable, "_ablation_row", side_effect=lambda name, *args: rows[name]
+        ), patch.object(
+            resumable, "_heartbeat"
+        ), patch.object(
+            lab, "_simulate_next_open", return_value={"metrics": {"status": "ok"}}
+        ) as simulate, patch.object(
+            lab,
+            "_candidate_validation",
+            return_value={"status": "complete", "sensitivity": {"status": "complete"}},
+        ) as validate:
+            result = resumable._run_resumable_ablation(
+                core,
+                "5y",
+                45,
+                {"profiles": {"adaptive_balanced": {"full_sample": {}}}},
+            )
+
+        self.assertEqual(result["best_variant"]["variant"], "max_positions_2")
+        self.assertEqual(result["current_full_sample_best_variant"], "max_positions_2")
+        self.assertEqual(result["selected_candidate"], "hold_10d")
+        self.assertEqual(result["selection_frozen_date"], "2026-09-09")
+        self.assertIs(result["selected_candidate_validation"], result["best_variant_validation"])
+        self.assertIs(validate.call_args.args[2], frozen_map)
+        self.assertNotEqual(validate.call_args.args[2], dynamic_best_map)
+        self.assertEqual(validate.call_args.kwargs["baseline_simulation"], {"metrics": {"status": "ok"}})
+        simulate.assert_called_once()
+
+    def test_resumable_ablation_fails_closed_when_frozen_candidate_is_missing(self):
+        core = type("Core", (), {"portfolio": {}})()
+        with patch.object(lab, "_universe", return_value=["SPY"] * 10), patch.object(
+            lab.base, "_download", return_value=({"SPY": object()}, {"status": "ok"})
+        ), patch.object(
+            lab.base,
+            "_feature_frames",
+            return_value={f"SYM{index}": object() for index in range(10)},
+        ), patch.object(
+            lab, "_add_liquidity_features"
+        ), patch.object(
+            lab.base, "_calendar", return_value=list(range(315))
+        ), patch.object(
+            lab, "_ablation_maps", return_value={"max_positions_2": {"neutral": {}}}
+        ), patch.object(
+            resumable,
+            "_ablation_row",
+            return_value={"variant": "max_positions_2", "objective": 9.0},
+        ), patch.object(resumable, "_heartbeat"):
+            result = resumable._run_resumable_ablation(
+                core,
+                "5y",
+                45,
+                {"profiles": {"adaptive_balanced": {"full_sample": {}}}},
+            )
+
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["reason"], "frozen_candidate_map_missing")
+        self.assertFalse(result["automatic_promotion"])
+
     def test_candidate_validation_is_historical_and_never_promotes(self):
         simulation = {"metrics": {"status": "ok", "total_return_pct": 12.0}}
         with patch.object(lab, "_simulate_next_open", return_value=simulation), patch.object(


### PR DESCRIPTION
Fixes #208.

The isolated/resumable ablation path now binds candidate validation explicitly to the frozen `hold_10d` policy, independently of whichever ablation currently ranks first. It passes the explicit adaptive baseline simulation, emits frozen-selection fields plus backward-compatible aliases, and fails closed if the frozen candidate map is unavailable.

Focused regressions force the dynamic best candidate to differ from `hold_10d` and prove validation still receives the frozen map. A second regression proves missing frozen configuration cannot yield eligible evidence.

The research engine/resumable versions advance so stale checkpoints fail closed. The prior Stage 2 artifact remains preserved but ineligible and will be replaced by a new isolated five-year/45-symbol run after merge.

No production strategy, holding period, exit, sizing, risk, state, broker, AI/ML, live, or order authority changes.

Local exact-head validation passed: 90 Change Safety invariants, repository safety/config validation, full structural audit with zero new critical/warnings and zero import cycles, architecture-debt gate, focused isolation tests, and diff checks.