### PR TITLE
Fail runner liveness closed on stale attempts

### DIFF
--- a/change_safety_audit.py
+++ b/change_safety_audit.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-VERSION = "change-safety-audit-2026-08-25-v11-issue82-successor-epoch"
+VERSION = "change-safety-audit-2026-09-09-v12-runner-liveness"
 
 CORE_TESTS = (
     "test_architecture_stage_b.py",
@@ -26,6 +26,7 @@ CORE_TESTS = (
 RUNTIME_TESTS = (
     "test_runtime_shadow_capture.py",
     "test_self_check_runtime_classification.py",
+    "test_daily_operational_audit.py",
 )
 STATE_TESTS = ("test_state_store_stage_c.py",)
 DECISION_TESTS = ("test_shadow_decision_stage_d.py",)
@@ -203,6 +204,9 @@ def classify_paths(paths: Iterable[str]) -> tuple[tuple[str, ...], tuple[str, ..
         if _is_runtime_research_snapshot_path(path):
             categories.add("runtime_observability")
             boundaries.add("runtime_observability")
+        if "self_check" in path or "operational_audit" in path:
+            categories.add("runtime_observability")
+            boundaries.add("runtime_observability")
         if "risk" in path:
             categories.add("risk")
             boundaries.add("risk")
@@ -224,7 +228,11 @@ def planned_regressions(paths: Iterable[str]) -> tuple[str, ...]:
     path_tuple = tuple(paths)
     categories, _ = classify_paths(path_tuple)
     tests: list[str] = list(CORE_TESTS)
-    if "runtime_composition" in categories or "workflow" in categories:
+    if (
+        "runtime_composition" in categories
+        or "runtime_observability" in categories
+        or "workflow" in categories
+    ):
         tests.extend(RUNTIME_TESTS)
     if "state_persistence" in categories:
         tests.extend(STATE_TESTS)

--- a/daily_operational_audit.py
+++ b/daily_operational_audit.py
@@ -132,17 +132,23 @@ def _runner_liveness(auto: Dict[str, Any], now_epoch: float | None = None) -> Di
         and age <= freshness_window
     )
     reported_started = auto.get("thread_started") is True
-    active = bool(reported_started or recent_auto_attempt)
+    attempt_observed = attempt_epoch > 0.0
+    startup_report_only = bool(reported_started and not attempt_observed)
+    active = bool(recent_auto_attempt or startup_report_only)
     return {
         "active": active,
         "state": (
-            "reported_started"
-            if reported_started
-            else "inferred_from_recent_auto_attempt"
+            "inferred_from_recent_auto_attempt"
             if recent_auto_attempt
+            else "reported_started_before_first_attempt"
+            if startup_report_only
+            else "stale_auto_attempt"
+            if attempt_observed
             else "not_observed"
         ),
         "reported_started": reported_started,
+        "attempt_observed": attempt_observed,
+        "startup_report_only": startup_report_only,
         "recent_auto_attempt": recent_auto_attempt,
         "last_attempt_age_seconds": round(age, 1) if age is not None else None,
         "freshness_window_seconds": round(freshness_window, 1),

--- a/fast_self_check_override.py
+++ b/fast_self_check_override.py
@@ -93,17 +93,23 @@ def _runner_liveness(auto: Dict[str, Any], now_epoch: float | None = None) -> Di
         and age <= freshness_window
     )
     reported_started = auto.get("thread_started") is True
-    active = bool(reported_started or recent_auto_attempt)
-    if reported_started:
-        state = "reported_started"
-    elif recent_auto_attempt:
+    attempt_observed = attempt_epoch > 0.0
+    startup_report_only = bool(reported_started and not attempt_observed)
+    active = bool(recent_auto_attempt or startup_report_only)
+    if recent_auto_attempt:
         state = "inferred_from_recent_auto_attempt"
+    elif startup_report_only:
+        state = "reported_started_before_first_attempt"
+    elif attempt_observed:
+        state = "stale_auto_attempt"
     else:
         state = "not_observed"
     return {
         "active": active,
         "state": state,
         "reported_started": reported_started,
+        "attempt_observed": attempt_observed,
+        "startup_report_only": startup_report_only,
         "recent_auto_attempt": recent_auto_attempt,
         "last_attempt_age_seconds": round(age, 1) if age is not None else None,
         "freshness_window_seconds": round(freshness_window, 1),

--- a/test_change_safety_audit.py
+++ b/test_change_safety_audit.py
@@ -6,6 +6,11 @@ from change_safety_audit import classify_paths, evaluate_gate, planned_regressio
 
 
 class ChangeSafetyAuditTests(unittest.TestCase):
+    def test_runner_observability_change_selects_runtime_audits(self) -> None:
+        tests = planned_regressions(("fast_self_check_override.py",))
+        self.assertIn("test_self_check_runtime_classification.py", tests)
+        self.assertIn("test_daily_operational_audit.py", tests)
+
     def test_seeded_breaking_regression_is_blocked(self) -> None:
         decision = evaluate_gate(
             expected_head="abc123",

--- a/test_daily_operational_audit.py
+++ b/test_daily_operational_audit.py
@@ -86,6 +86,20 @@ class DailyOperationalAuditTests(unittest.TestCase):
             },
         }
 
+    def test_persisted_started_flag_cannot_override_stale_attempt(self) -> None:
+        row = audit._runner_liveness(
+            {
+                "thread_started": True,
+                "interval_seconds": 300,
+                "last_attempt_ts": 1_000.0,
+                "last_attempt_source": "auto",
+            },
+            now_epoch=2_000.0,
+        )
+        self.assertFalse(row["active"])
+        self.assertTrue(row["reported_started"])
+        self.assertEqual(row["state"], "stale_auto_attempt")
+
     def test_curated_audit_has_exactly_thirteen_bounded_sections_after_integrity_overlay(self) -> None:
         core = self._core()
         composition = {

--- a/test_self_check_runtime_classification.py
+++ b/test_self_check_runtime_classification.py
@@ -40,7 +40,33 @@ class SelfCheckRuntimeClassificationTests(unittest.TestCase):
             now_epoch=2_000.0,
         )
         self.assertFalse(row["active"])
-        self.assertEqual(row["state"], "not_observed")
+        self.assertEqual(row["state"], "stale_auto_attempt")
+
+    def test_persisted_started_flag_cannot_override_stale_attempt(self) -> None:
+        row = self_check._runner_liveness(
+            {
+                "thread_started": True,
+                "interval_seconds": 300,
+                "last_attempt_ts": 1_000.0,
+                "last_attempt_source": "auto",
+            },
+            now_epoch=2_000.0,
+        )
+        self.assertFalse(row["active"])
+        self.assertTrue(row["reported_started"])
+        self.assertTrue(row["attempt_observed"])
+        self.assertFalse(row["startup_report_only"])
+        self.assertEqual(row["state"], "stale_auto_attempt")
+
+    def test_reported_started_covers_only_pre_attempt_startup(self) -> None:
+        row = self_check._runner_liveness(
+            {"thread_started": True, "interval_seconds": 300},
+            now_epoch=2_000.0,
+        )
+        self.assertTrue(row["active"])
+        self.assertFalse(row["attempt_observed"])
+        self.assertTrue(row["startup_report_only"])
+        self.assertEqual(row["state"], "reported_started_before_first_attempt")
 
     def test_isolated_not_run_research_is_deferred_not_failed(self) -> None:
         components, deferred = self_check._normalize_advisory_components(


### PR DESCRIPTION
Fixes #212.

The compact self-check and daily audit now stop treating a persisted `thread_started=true` flag as indefinite proof of liveness after an automatic attempt timestamp has been observed. A fresh automatic attempt remains authoritative; the start flag covers only the brief pre-first-attempt startup state. Stale attempts report `stale_auto_attempt` and fail the runner-liveness check.

Focused regressions cover stale-start masking and startup-only behavior. Change Safety now classifies self-check/operational-audit files as runtime observability and always selects both runtime audit suites.

Local evidence:
- focused suites: 32/32 pass
- exact-head Change Safety selection: 84/84 pass
- refactor/architecture debt delta: zero new critical or warning findings
- diff check: clean

No strategy, signal, sizing, risk limit, persistence, canonical history, broker, live, AI/ML, or order authority changed.