### PR TITLE
Recognize fresh runner completion liveness

### DIFF
--- a/daily_operational_audit.py
+++ b/daily_operational_audit.py
@@ -131,26 +131,51 @@ def _runner_liveness(auto: Dict[str, Any], now_epoch: float | None = None) -> Di
         and age >= -5.0
         and age <= freshness_window
     )
+    observations = [("attempt", attempt_epoch)] if source == "auto" and attempt_epoch > 0.0 else []
+    for label, value, source_key in (
+        ("success", auto.get("last_successful_run_ts") or auto.get("last_successful_run_local"), "last_successful_run_source"),
+        ("run", auto.get("last_run_ts") or auto.get("last_run_local"), "last_run_source"),
+    ):
+        observed_epoch = _time_key(value)
+        if str(auto.get(source_key) or "").strip().lower() == "auto" and observed_epoch > 0.0:
+            observations.append((label, observed_epoch))
+    skip_epoch = _time_key(auto.get("last_skip_ts") or auto.get("last_skip_local"))
+    if source == "auto" and skip_epoch >= attempt_epoch > 0.0:
+        observations.append(("skip", skip_epoch))
+    evidence, activity_epoch = max(observations, key=lambda row: row[1], default=(None, 0.0))
+    activity_age = now_epoch - activity_epoch if activity_epoch > 0.0 else None
+    recent_auto_activity = bool(
+        activity_age is not None
+        and activity_age >= -5.0
+        and activity_age <= freshness_window
+    )
+    recent_auto_completion = bool(recent_auto_activity and evidence != "attempt")
     reported_started = auto.get("thread_started") is True
-    attempt_observed = attempt_epoch > 0.0
-    startup_report_only = bool(reported_started and not attempt_observed)
-    active = bool(recent_auto_attempt or startup_report_only)
+    activity_observed = bool(observations)
+    startup_report_only = bool(reported_started and not activity_observed)
+    active = bool(recent_auto_activity or startup_report_only)
     return {
         "active": active,
         "state": (
-            "inferred_from_recent_auto_attempt"
+            "inferred_from_recent_auto_completion"
+            if recent_auto_completion
+            else "inferred_from_recent_auto_attempt"
             if recent_auto_attempt
             else "reported_started_before_first_attempt"
             if startup_report_only
             else "stale_auto_attempt"
-            if attempt_observed
+            if activity_observed
             else "not_observed"
         ),
         "reported_started": reported_started,
-        "attempt_observed": attempt_observed,
+        "attempt_observed": attempt_epoch > 0.0,
+        "activity_observed": activity_observed,
         "startup_report_only": startup_report_only,
         "recent_auto_attempt": recent_auto_attempt,
+        "recent_auto_completion": recent_auto_completion,
+        "liveness_evidence": evidence,
         "last_attempt_age_seconds": round(age, 1) if age is not None else None,
+        "last_activity_age_seconds": round(activity_age, 1) if activity_age is not None else None,
         "freshness_window_seconds": round(freshness_window, 1),
     }
 

--- a/fast_self_check_override.py
+++ b/fast_self_check_override.py
@@ -92,15 +92,36 @@ def _runner_liveness(auto: Dict[str, Any], now_epoch: float | None = None) -> Di
         and age >= -5.0
         and age <= freshness_window
     )
+    observations = [("attempt", attempt_epoch)] if source == "auto" and attempt_epoch > 0.0 else []
+    for label, value, source_key in (
+        ("success", auto.get("last_successful_run_ts") or auto.get("last_successful_run_local"), "last_successful_run_source"),
+        ("run", auto.get("last_run_ts") or auto.get("last_run_local"), "last_run_source"),
+    ):
+        observed_epoch = _time_key(value)
+        if str(auto.get(source_key) or "").strip().lower() == "auto" and observed_epoch > 0.0:
+            observations.append((label, observed_epoch))
+    skip_epoch = _time_key(auto.get("last_skip_ts") or auto.get("last_skip_local"))
+    if source == "auto" and skip_epoch >= attempt_epoch > 0.0:
+        observations.append(("skip", skip_epoch))
+    evidence, activity_epoch = max(observations, key=lambda row: row[1], default=(None, 0.0))
+    activity_age = now_epoch - activity_epoch if activity_epoch > 0.0 else None
+    recent_auto_activity = bool(
+        activity_age is not None
+        and activity_age >= -5.0
+        and activity_age <= freshness_window
+    )
+    recent_auto_completion = bool(recent_auto_activity and evidence != "attempt")
     reported_started = auto.get("thread_started") is True
-    attempt_observed = attempt_epoch > 0.0
-    startup_report_only = bool(reported_started and not attempt_observed)
-    active = bool(recent_auto_attempt or startup_report_only)
-    if recent_auto_attempt:
+    activity_observed = bool(observations)
+    startup_report_only = bool(reported_started and not activity_observed)
+    active = bool(recent_auto_activity or startup_report_only)
+    if recent_auto_completion:
+        state = "inferred_from_recent_auto_completion"
+    elif recent_auto_attempt:
         state = "inferred_from_recent_auto_attempt"
     elif startup_report_only:
         state = "reported_started_before_first_attempt"
-    elif attempt_observed:
+    elif activity_observed:
         state = "stale_auto_attempt"
     else:
         state = "not_observed"
@@ -108,10 +129,14 @@ def _runner_liveness(auto: Dict[str, Any], now_epoch: float | None = None) -> Di
         "active": active,
         "state": state,
         "reported_started": reported_started,
-        "attempt_observed": attempt_observed,
+        "attempt_observed": attempt_epoch > 0.0,
+        "activity_observed": activity_observed,
         "startup_report_only": startup_report_only,
         "recent_auto_attempt": recent_auto_attempt,
+        "recent_auto_completion": recent_auto_completion,
+        "liveness_evidence": evidence,
         "last_attempt_age_seconds": round(age, 1) if age is not None else None,
+        "last_activity_age_seconds": round(activity_age, 1) if activity_age is not None else None,
         "freshness_window_seconds": round(freshness_window, 1),
     }
 

--- a/test_daily_operational_audit.py
+++ b/test_daily_operational_audit.py
@@ -100,6 +100,23 @@ class DailyOperationalAuditTests(unittest.TestCase):
         self.assertTrue(row["reported_started"])
         self.assertEqual(row["state"], "stale_auto_attempt")
 
+    def test_fresh_auto_completion_proves_liveness_after_stale_attempt(self) -> None:
+        row = audit._runner_liveness(
+            {
+                "thread_started": True,
+                "interval_seconds": 300,
+                "last_attempt_ts": 1_000.0,
+                "last_attempt_source": "auto",
+                "last_successful_run_ts": 1_950.0,
+                "last_successful_run_source": "auto",
+            },
+            now_epoch=2_000.0,
+        )
+        self.assertTrue(row["active"])
+        self.assertTrue(row["recent_auto_completion"])
+        self.assertEqual(row["liveness_evidence"], "success")
+        self.assertEqual(row["state"], "inferred_from_recent_auto_completion")
+
     def test_curated_audit_has_exactly_thirteen_bounded_sections_after_integrity_overlay(self) -> None:
         core = self._core()
         composition = {

--- a/test_self_check_runtime_classification.py
+++ b/test_self_check_runtime_classification.py
@@ -68,6 +68,24 @@ class SelfCheckRuntimeClassificationTests(unittest.TestCase):
         self.assertTrue(row["startup_report_only"])
         self.assertEqual(row["state"], "reported_started_before_first_attempt")
 
+    def test_fresh_auto_completion_proves_liveness_after_stale_attempt(self) -> None:
+        row = self_check._runner_liveness(
+            {
+                "thread_started": True,
+                "interval_seconds": 300,
+                "last_attempt_ts": 1_000.0,
+                "last_attempt_source": "auto",
+                "last_successful_run_ts": 1_950.0,
+                "last_successful_run_source": "auto",
+            },
+            now_epoch=2_000.0,
+        )
+        self.assertTrue(row["active"])
+        self.assertFalse(row["recent_auto_attempt"])
+        self.assertTrue(row["recent_auto_completion"])
+        self.assertEqual(row["liveness_evidence"], "success")
+        self.assertEqual(row["state"], "inferred_from_recent_auto_completion")
+
     def test_isolated_not_run_research_is_deferred_not_failed(self) -> None:
         components, deferred = self_check._normalize_advisory_components(
             {


### PR DESCRIPTION
Fixes #214.

Runner liveness now uses the newest automatic attempt, successful run, completed run, or causally matched skip timestamp. A fresh completion correctly proves activity even if the attempt field is stale; a stale attempt with no fresh completion still fails closed. Diagnostics expose the evidence source and activity age.

Local evidence:
- focused suites: 34/34 pass
- exact-head Change Safety selection: 86/86 pass
- refactor/architecture debt delta: zero new critical or warning findings
- diff check: clean

No trading, strategy, signal, sizing, risk, persistence, canonical history, broker, live, AI/ML, or order authority changed.