### PR TITLE
Fix runner liveness from cycle-completion evidence

### DIFF
--- a/daily_operational_audit.py
+++ b/daily_operational_audit.py
@@ -133,6 +133,11 @@ def _runner_liveness(auto: Dict[str, Any], now_epoch: float | None = None) -> Di
     )
     observations = [("attempt", attempt_epoch)] if source == "auto" and attempt_epoch > 0.0 else []
     for label, value, source_key in (
+        (
+            "cycle_completion",
+            auto.get("last_completed_cycle_ts") or auto.get("last_completed_cycle_local"),
+            "last_completed_cycle_source",
+        ),
         ("success", auto.get("last_successful_run_ts") or auto.get("last_successful_run_local"), "last_successful_run_source"),
         ("run", auto.get("last_run_ts") or auto.get("last_run_local"), "last_run_source"),
     ):
@@ -575,6 +580,8 @@ def build_payload(core: Any = None) -> Dict[str, Any]:
             "thread_started_reported": liveness["reported_started"],
             "thread_active_observed": liveness["active"],
             "liveness_state": liveness["state"],
+            "liveness_evidence": liveness["liveness_evidence"],
+            "last_activity_age_seconds": liveness["last_activity_age_seconds"],
             "interval_seconds": auto.get("interval_seconds"),
             "last_attempt": last_attempt,
             "last_attempt_source": auto.get("last_attempt_source"),

--- a/fast_self_check_override.py
+++ b/fast_self_check_override.py
@@ -94,6 +94,11 @@ def _runner_liveness(auto: Dict[str, Any], now_epoch: float | None = None) -> Di
     )
     observations = [("attempt", attempt_epoch)] if source == "auto" and attempt_epoch > 0.0 else []
     for label, value, source_key in (
+        (
+            "cycle_completion",
+            auto.get("last_completed_cycle_ts") or auto.get("last_completed_cycle_local"),
+            "last_completed_cycle_source",
+        ),
         ("success", auto.get("last_successful_run_ts") or auto.get("last_successful_run_local"), "last_successful_run_source"),
         ("run", auto.get("last_run_ts") or auto.get("last_run_local"), "last_run_source"),
     ):
@@ -444,7 +449,10 @@ def build_payload(core: Any = None) -> Dict[str, Any]:
             "thread_active_observed": runner_liveness["active"],
             "thread_liveness_state": runner_liveness["state"],
             "recent_auto_attempt": runner_liveness["recent_auto_attempt"],
+            "recent_auto_completion": runner_liveness["recent_auto_completion"],
+            "liveness_evidence": runner_liveness["liveness_evidence"],
             "last_attempt_age_seconds": runner_liveness["last_attempt_age_seconds"],
+            "last_activity_age_seconds": runner_liveness["last_activity_age_seconds"],
             "liveness_freshness_window_seconds": runner_liveness["freshness_window_seconds"],
             "interval_seconds": auto.get("interval_seconds"),
             "last_attempt": last_attempt,

--- a/test_daily_operational_audit.py
+++ b/test_daily_operational_audit.py
@@ -117,6 +117,23 @@ class DailyOperationalAuditTests(unittest.TestCase):
         self.assertEqual(row["liveness_evidence"], "success")
         self.assertEqual(row["state"], "inferred_from_recent_auto_completion")
 
+    def test_cycle_contract_completion_proves_liveness(self) -> None:
+        row = audit._runner_liveness(
+            {
+                "thread_started": True,
+                "interval_seconds": 300,
+                "last_attempt_ts": 100.0,
+                "last_attempt_source": "auto",
+                "last_completed_cycle_ts": 990.0,
+                "last_completed_cycle_source": "auto",
+            },
+            now_epoch=1000.0,
+        )
+        self.assertTrue(row["active"])
+        self.assertTrue(row["recent_auto_completion"])
+        self.assertEqual(row["liveness_evidence"], "cycle_completion")
+        self.assertEqual(row["state"], "inferred_from_recent_auto_completion")
+
     def test_curated_audit_has_exactly_thirteen_bounded_sections_after_integrity_overlay(self) -> None:
         core = self._core()
         composition = {

--- a/test_self_check_runtime_classification.py
+++ b/test_self_check_runtime_classification.py
@@ -86,6 +86,23 @@ class SelfCheckRuntimeClassificationTests(unittest.TestCase):
         self.assertEqual(row["liveness_evidence"], "success")
         self.assertEqual(row["state"], "inferred_from_recent_auto_completion")
 
+    def test_cycle_contract_completion_proves_liveness(self) -> None:
+        row = self_check._runner_liveness(
+            {
+                "thread_started": True,
+                "interval_seconds": 300,
+                "last_attempt_ts": 100.0,
+                "last_attempt_source": "auto",
+                "last_completed_cycle_ts": 990.0,
+                "last_completed_cycle_source": "auto",
+            },
+            now_epoch=1000.0,
+        )
+        self.assertTrue(row["active"])
+        self.assertTrue(row["recent_auto_completion"])
+        self.assertEqual(row["liveness_evidence"], "cycle_completion")
+        self.assertEqual(row["state"], "inferred_from_recent_auto_completion")
+
     def test_isolated_not_run_research_is_deferred_not_failed(self) -> None:
         components, deferred = self_check._normalize_advisory_components(
             {


### PR DESCRIPTION
Closes #214.

Post-deploy validation of #215 showed that successful automatic cycles update the cycle-completion contract independently of the older `last_run`/`last_attempt` fields. This bounded follow-up:

- treats the canonical `last_completed_cycle_*` telemetry as automatic completion evidence;
- exposes the selected evidence and age in self-check and daily audit;
- preserves fail-closed behavior when no recent automatic activity exists;
- adds focused regressions for both read-only audit surfaces.

No trading, strategy, sizing, risk, persistence, broker, canonical-history, live, or AI/ML authority changes.