### PR TITLE
Latch paper halt on canonical state divergence

### DIFF
--- a/PROJECT_HANDOFF_CURRENT.md
+++ b/PROJECT_HANDOFF_CURRENT.md
@@ -1155,3 +1155,24 @@ audit/sentinel propagation. Historical reconciliation remains explicitly out of
 scope and may occur only through a separate exact-evidence successor process
 with validation hold; do not rewrite the canonical ledger or silently backfill
 state.
+
+PR #223 passed all five exact-head workflows (Change Safety including Gunicorn,
+Repository Safety and Performance, Architecture Debt, System Sentinel Shadow,
+and the full Refactor/Ownership/Configuration/State/Decision/Runtime/Startup/
+Research audit) on `153b1bc8d4f4222419d708eceae7f58913a08ba4` and was squash-merged as
+`aa7b100355be218243feab3056a9e8a22b3af143`.
+
+Settled Splendid acceptance correctly failed closed and exposed that the scope
+is larger than the first GEV row: the 78-row hash-valid ledger has 32
+current-v4 execution IDs while state has 28. Missing state IDs are the original
+GEV entry plus `9554247470c54fe9a00598da6a346f46`,
+`96cdc732bf6b475098a9b6887ac76fa7`, and
+`c90260025d4b4eed8b3a0029e0267b5f`. Self-check is `fail` with only
+`canonical_state_parity`; daily audit is `fail` with critical successor-only
+next action; and sentinel reports one critical execution-projection incident.
+The automatic runner is otherwise fresh, the ledger chain remains valid, and
+no evidence was changed. Because diagnostics alone did not stop new paper
+entries, the bounded follow-up latches and persists a risk halt during canonical
+ledger startup whenever current-epoch parity is broken, without overwriting an
+existing halt reason or changing any execution/history evidence. Issue #222
+remains open until that halt containment is deployed and accepted.

--- a/canonical_execution_ledger.py
+++ b/canonical_execution_ledger.py
@@ -20,7 +20,7 @@ import threading
 import uuid
 from typing import Any, Dict, List, Tuple
 
-VERSION = "canonical-execution-ledger-2026-09-10-v3-state-parity"
+VERSION = "canonical-execution-ledger-2026-09-10-v4-parity-halt"
 STATE_DIR = os.environ.get("STATE_DIR") or os.environ.get("PERSISTENT_STATE_DIR") or os.environ.get("RAILWAY_VOLUME_MOUNT_PATH") or "."
 LEDGER_FILE = os.path.join(STATE_DIR, "canonical_execution_ledger.jsonl")
 
@@ -28,6 +28,8 @@ _LOCK = threading.RLock()
 _APPLIED_CORE_IDS: set[int] = set()
 _REGISTERED_APP_IDS: set[int] = set()
 _LAST_PROJECTION_COMMIT: Dict[str, Any] = {}
+_LAST_PARITY_HALT: Dict[str, Any] = {}
+PARITY_HALT_REASON = "canonical execution/state projection divergence"
 
 
 def _d(value: Any) -> Dict[str, Any]:
@@ -190,6 +192,48 @@ def _mark_projection_failure(core: Any, event: Dict[str, Any], error: Exception)
     pf["risk_controls"] = risk
 
 
+def _latch_projection_divergence(core: Any) -> Dict[str, Any]:
+    """Halt new paper entries when canonical/current-state parity is broken."""
+    global _LAST_PARITY_HALT
+    status = status_payload(core)
+    if status.get("state_projection_parity") is not False:
+        return {"status": "not_required", "state_projection_parity": status.get("state_projection_parity")}
+
+    pf = _portfolio(core)
+    risk = _d(pf.setdefault("risk_controls", {}))
+    already_halted = bool(risk.get("halted"))
+    risk["canonical_state_projection_parity_failed"] = True
+    risk["canonical_state_projection_parity_failed_local"] = _now(core)
+    risk["canonical_state_projection_missing_execution_ids"] = status.get("missing_from_state_execution_ids", [])
+    if not already_halted:
+        risk["halted"] = True
+        risk["halt_reason"] = PARITY_HALT_REASON
+    pf["risk_controls"] = risk
+
+    persisted = False
+    error = None
+    save = getattr(core, "save_state", None)
+    if callable(save):
+        try:
+            save(pf)
+            persisted = True
+        except Exception as exc:
+            error = f"{type(exc).__name__}: {exc}"
+    _LAST_PARITY_HALT = {
+        "status": "halted" if already_halted or persisted else "halted_in_memory",
+        "recorded_local": _now(core),
+        "already_halted": already_halted,
+        "halt_reason_preserved": already_halted,
+        "persisted": persisted,
+        "error": error,
+        "missing_from_state_count": status.get("missing_from_state_count"),
+        "missing_from_state_execution_ids": status.get("missing_from_state_execution_ids", []),
+        "changes_execution_history": False,
+        "clears_halt": False,
+    }
+    return dict(_LAST_PARITY_HALT)
+
+
 def _persist_projection(core: Any, event: Dict[str, Any]) -> None:
     """Durably mirror a canonical execution before execution flow continues."""
     global _LAST_PROJECTION_COMMIT
@@ -232,6 +276,7 @@ def apply(core: Any = None) -> Dict[str, Any]:
         return {"status": "error", "overall": "fail", "version": VERSION, "error": "core.record_trade_missing"}
     if getattr(current, "_canonical_execution_ledger_version", None) == VERSION:
         _APPLIED_CORE_IDS.add(core_id)
+        _latch_projection_divergence(core)
         return status_payload(core)
 
     prior = getattr(current, "_canonical_execution_ledger_prior", current)
@@ -257,6 +302,7 @@ def apply(core: Any = None) -> Dict[str, Any]:
     wrapped._canonical_execution_ledger_prior = prior  # type: ignore[attr-defined]
     core.record_trade = wrapped
     _APPLIED_CORE_IDS.add(core_id)
+    _latch_projection_divergence(core)
     return status_payload(core)
 
 
@@ -318,6 +364,7 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "authoritative_for_new_executions": bool(hooked and healthy),
         "state_projection_commit_immediate": True,
         "last_state_projection_commit": dict(_LAST_PROJECTION_COMMIT),
+        "parity_halt": dict(_LAST_PARITY_HALT),
         "authority": {
             "records_execution_events": True,
             "repairs_historical_state": False,
@@ -326,6 +373,7 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
             "changes_strategy": False,
             "changes_thresholds": False,
             "changes_risk_or_sizing": False,
+            "latches_risk_halt_on_projection_divergence": True,
             "changes_live_or_ml_authority": False,
         },
     }

--- a/test_issue222_canonical_state_parity.py
+++ b/test_issue222_canonical_state_parity.py
@@ -158,3 +158,54 @@ def test_ledger_parity_fails_audit_and_sentinel(monkeypatch):
     report = system_sentinel.report({"execution_ledger": status})
     assert report["status"] == "incident"
     assert report["incidents"][0]["reason_code"] == "execution_projection_divergence"
+
+
+def test_runtime_apply_latches_and_persists_parity_halt_without_rewriting_history(monkeypatch):
+    row = _trade("gev-entry")
+    saved = []
+    portfolio = {
+        "accounting_epoch_id": EPOCH,
+        "trades": [],
+        "history": [10000.0, 9999.0],
+        "risk_controls": {"halted": False},
+    }
+    before_history = copy.deepcopy(portfolio["history"])
+    core = types.SimpleNamespace(
+        portfolio=portfolio,
+        record_trade=lambda *args, **kwargs: None,
+        save_state=lambda state: saved.append(copy.deepcopy(state)),
+        local_ts_text=lambda: "2026-09-10 13:45:00 CDT",
+    )
+    monkeypatch.setattr(ledger, "_read_rows", lambda: ([row], []))
+    monkeypatch.setattr(ledger, "_verify_rows", lambda rows: (True, []))
+
+    status = ledger.apply(core)
+
+    assert status["state_projection_parity"] is False
+    assert portfolio["risk_controls"]["halted"] is True
+    assert portfolio["risk_controls"]["halt_reason"] == ledger.PARITY_HALT_REASON
+    assert saved[-1]["risk_controls"]["canonical_state_projection_parity_failed"] is True
+    assert portfolio["history"] == before_history
+    assert status["parity_halt"]["persisted"] is True
+
+
+def test_parity_halt_preserves_preexisting_halt_reason(monkeypatch):
+    row = _trade("gev-entry")
+    portfolio = {
+        "accounting_epoch_id": EPOCH,
+        "trades": [],
+        "risk_controls": {"halted": True, "halt_reason": "existing hard loss halt"},
+    }
+    core = types.SimpleNamespace(
+        portfolio=portfolio,
+        record_trade=lambda *args, **kwargs: None,
+        save_state=lambda state: None,
+        local_ts_text=lambda: "2026-09-10 13:45:00 CDT",
+    )
+    monkeypatch.setattr(ledger, "_read_rows", lambda: ([row], []))
+    monkeypatch.setattr(ledger, "_verify_rows", lambda rows: (True, []))
+
+    ledger.apply(core)
+
+    assert portfolio["risk_controls"]["halt_reason"] == "existing hard loss halt"
+    assert ledger.status_payload(core)["parity_halt"]["halt_reason_preserved"] is True


### PR DESCRIPTION
Follow-up containment for #222.

PR #223 made the divergence visible and blocked prospective regressive writes. Settled Splendid acceptance then proved four current-v4 canonical execution IDs are absent from mutable state while the runner continued accepting new paper entries.

This follow-up latches and persists a paper risk halt during canonical-ledger startup when current-epoch ledger/state parity is broken. It preserves any pre-existing halt reason and does not alter canonical rows, state trade/history rows, accounting, day peak, recovery evidence, strategy thresholds, hard-risk limits, live authority, or AI/ML authority.

Focused regressions prove the halt is persisted without rewriting history and that an existing halt reason is never overwritten. Local architecture debt comparison and exact-head-equivalent Change Safety selection pass. All hosted exact-head gates including Gunicorn smoke remain mandatory before merge.