### PR TITLE
Keep canonical parity halt across trading-day resets

### DIFF
--- a/PROJECT_HANDOFF_CURRENT.md
+++ b/PROJECT_HANDOFF_CURRENT.md
@@ -1206,3 +1206,31 @@ ledger/history evidence remains untouched.
 Issue #202 and the frozen `hold_10d` forward-shadow program remain unchanged
 and research-only; no performance candidate was adjusted or promoted while this
 correctness containment awaits settled runtime acceptance.
+
+## 2026-09-12 Issue #222 — Cross-Day Integrity-Halt Reset — FIX IN VALIDATION
+
+Fresh authoritative Splendid evidence on current main `10b136ab5cf29fd0880e9c73ea337f83004de3f4`
+shows the hash-valid canonical ledger at 87 rows / 41 current-v4 execution IDs
+while state contains 37 current-v4 IDs. The same four execution IDs documented
+above remain absent from state, so canonical/state projection parity is still
+false and the ledger correctly reports that it is not authoritative for new
+executions. Despite that unresolved critical condition, the current risk state
+is unhalted with no self-defense active.
+
+The demonstrated cause is lifecycle ordering, not new ledger corruption. PR
+#224 latches the parity halt during canonical-ledger startup, but the ordinary
+new-trading-day reset subsequently replaces the risk-control dictionary with a
+fresh default and discards the parity marker, halt flag, reason, timestamp, and
+missing-ID evidence. The existing prospective save/transaction guards remain
+installed; the missing historical state projections are unchanged.
+
+Branch `fix/issue-222-runtime-parity-halt` makes the fresh-day baseline guard
+carry only the canonical/state projection-divergence halt and its evidence into
+the new day's otherwise normal risk-metric reset. Ordinary daily-loss halts
+continue to reset normally. It does not clear a halt, change thresholds,
+strategy, sizing, accounting, canonical rows, state/history, recovery evidence,
+live or AI/ML authority, or place orders. Focused regressions cover both legacy
+`get_risk_controls` and valuation-driven `update_daily_risk_controls` reset
+paths; the focused and affected invariant set passes 144 tests. Exact-head CI
+and settled Splendid deployment acceptance remain required before this stage is
+complete. Issue #202 remains frozen while Issue #222 is active.

--- a/fresh_risk_day_baseline_guard.py
+++ b/fresh_risk_day_baseline_guard.py
@@ -15,7 +15,9 @@ This guard is intentionally prospective and fail-closed:
 * once a sane current equity reaches the normal update boundary, the ordinary
   daily reset is allowed to initialize from that value;
 * an already-initialized current day is never rewritten, so this module does not
-  clear today's halt or rewrite today's peak after the fact.
+  clear today's halt or rewrite today's peak after the fact;
+* a canonical/state projection-divergence halt survives the ordinary new-day
+  risk-metric reset until a separately governed reconciliation resolves it.
 
 No strategy, sizing, risk thresholds, accounting history, live authority, ML
 authority, or order-placement behavior is changed.
@@ -26,8 +28,9 @@ import functools
 import math
 from typing import Any, Dict
 
-VERSION = "fresh-risk-day-baseline-guard-2026-08-20-v2-compact-check"
+VERSION = "fresh-risk-day-baseline-guard-2026-09-12-v3-integrity-halt-carry-forward"
 MIN_SANE_EQUITY = 1.0
+CANONICAL_PARITY_HALT_REASON = "canonical execution/state projection divergence"
 _APPLIED_CORE_IDS: set[int] = set()
 _REGISTERED_APP_IDS: set[int] = set()
 
@@ -72,6 +75,35 @@ def _clear_pending(rc: Dict[str, Any], source: str) -> None:
     rc["fresh_day_reset_source"] = source
 
 
+def _canonical_parity_halt_snapshot(rc: Dict[str, Any]) -> Dict[str, Any]:
+    reason = str(rc.get("halt_reason") or "").strip().lower()
+    active = bool(
+        rc.get("canonical_state_projection_parity_failed")
+        or reason == CANONICAL_PARITY_HALT_REASON
+    )
+    if not active:
+        return {}
+    return {
+        key: rc.get(key)
+        for key in (
+            "canonical_state_projection_parity_failed",
+            "canonical_state_projection_parity_failed_local",
+            "canonical_state_projection_missing_execution_ids",
+        )
+        if key in rc
+    }
+
+
+def _carry_forward_canonical_parity_halt(fresh: Dict[str, Any], snapshot: Dict[str, Any]) -> None:
+    if not snapshot:
+        return
+    fresh.update(snapshot)
+    fresh["canonical_state_projection_parity_failed"] = True
+    fresh["canonical_state_projection_parity_halt_carried_forward"] = True
+    fresh["halted"] = True
+    fresh["halt_reason"] = CANONICAL_PARITY_HALT_REASON
+
+
 def apply(core: Any = None) -> Dict[str, Any]:
     if core is None:
         return {"status": "pending", "overall": "warn", "version": VERSION, "reason": "runtime_missing"}
@@ -102,15 +134,19 @@ def apply(core: Any = None) -> Dict[str, Any]:
             rc = default_factory()
             portfolio["risk_controls"] = rc
 
+        integrity_halt = _canonical_parity_halt_snapshot(rc)
         today = _today(core)
-        if today and str(rc.get("date") or "") != today:
+        legacy_reset_required = bool(today and str(rc.get("date") or "") != today)
+        if legacy_reset_required:
             candidate = portfolio.get("equity")
             if not _sane_equity(candidate):
                 _mark_pending(rc, candidate, "portfolio.equity")
                 return rc
 
         out = prior_get()
-        if isinstance(out, dict) and today and str(out.get("date") or "") == today:
+        if isinstance(out, dict):
+            _carry_forward_canonical_parity_halt(out, integrity_halt)
+        if isinstance(out, dict) and legacy_reset_required and str(out.get("date") or "") == today:
             if _sane_equity(out.get("day_start_equity")) and _sane_equity(out.get("day_peak_equity")):
                 _clear_pending(out, "normal_get_risk_controls_reset")
         return out
@@ -123,6 +159,7 @@ def apply(core: Any = None) -> Dict[str, Any]:
             rc = default_factory()
             portfolio["risk_controls"] = rc
 
+        integrity_halt = _canonical_parity_halt_snapshot(rc)
         today = _today(core)
         if today and str(rc.get("date") or "") != today:
             if not _sane_equity(equity):
@@ -137,6 +174,7 @@ def apply(core: Any = None) -> Dict[str, Any]:
             fresh["day_start_equity"] = float(equity)
             fresh["day_peak_equity"] = float(equity)
             _clear_pending(fresh, "update_daily_risk_controls.argument")
+            _carry_forward_canonical_parity_halt(fresh, integrity_halt)
             portfolio["risk_controls"] = fresh
 
         return prior_update(equity)
@@ -173,6 +211,9 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "day_start_equity_sane": _sane_equity(rc.get("day_start_equity")),
         "day_peak_equity_sane": _sane_equity(rc.get("day_peak_equity")),
         "fresh_day_reset_pending": bool(rc.get("fresh_day_reset_pending", False)),
+        "canonical_parity_halt_carried_forward": bool(
+            rc.get("canonical_state_projection_parity_halt_carried_forward", False)
+        ),
         "authority": {
             "risk_correctness_only": True,
             "changes_risk_thresholds": False,

--- a/test_fresh_risk_day_baseline_guard.py
+++ b/test_fresh_risk_day_baseline_guard.py
@@ -118,6 +118,56 @@ def test_sane_portfolio_equity_allows_legacy_reset_path():
     assert rc["fresh_day_reset_source"] == "normal_get_risk_controls_reset"
 
 
+def test_canonical_parity_halt_survives_legacy_get_new_day_reset():
+    module = _fresh_module()
+    core = FakeCore()
+    core.portfolio["equity"] = 13190.5
+    core.portfolio["risk_controls"].update(
+        {
+            "canonical_state_projection_parity_failed": True,
+            "canonical_state_projection_parity_failed_local": "2026-09-11 14:59:59 CDT",
+            "canonical_state_projection_missing_execution_ids": ["missing-execution"],
+            "halt_reason": module.CANONICAL_PARITY_HALT_REASON,
+        }
+    )
+    module.apply(core)
+
+    rc = core.get_risk_controls()
+
+    assert rc["date"] == "2026-08-19"
+    assert rc["day_start_equity"] == 13190.5
+    assert rc["day_peak_equity"] == 13190.5
+    assert rc["halted"] is True
+    assert rc["halt_reason"] == module.CANONICAL_PARITY_HALT_REASON
+    assert rc["canonical_state_projection_parity_failed"] is True
+    assert rc["canonical_state_projection_missing_execution_ids"] == ["missing-execution"]
+    assert rc["canonical_state_projection_parity_halt_carried_forward"] is True
+
+
+def test_canonical_parity_halt_survives_guarded_update_new_day_reset():
+    module = _fresh_module()
+    core = FakeCore()
+    core.portfolio["risk_controls"].update(
+        {
+            "canonical_state_projection_parity_failed": True,
+            "canonical_state_projection_missing_execution_ids": ["missing-execution"],
+            "halt_reason": "daily loss limit hit (3.0%)",
+        }
+    )
+    module.apply(core)
+
+    rc = core.update_daily_risk_controls(13250.25)
+
+    assert rc["date"] == "2026-08-19"
+    assert rc["day_start_equity"] == 13250.25
+    assert rc["day_peak_equity"] == 13250.25
+    assert rc["day_pnl_pct"] == 0.0
+    assert rc["halted"] is True
+    assert rc["halt_reason"] == module.CANONICAL_PARITY_HALT_REASON
+    assert rc["canonical_state_projection_parity_failed"] is True
+    assert rc["canonical_state_projection_parity_halt_carried_forward"] is True
+
+
 def test_already_initialized_current_day_is_never_rewritten():
     module = _fresh_module()
     core = FakeCore()


### PR DESCRIPTION
Closes the demonstrated cross-day containment gap in #222.

PR #224 correctly latches a paper risk halt when current-epoch canonical execution IDs diverge from state. The ordinary next-day risk reset subsequently replaced the entire risk-control dictionary, unintentionally dropping that unresolved integrity halt. This change carries only the canonical/state projection-divergence marker, timestamp, missing-ID evidence, halt flag, and reason into the new day's otherwise normal risk-metric baseline. Ordinary daily-loss halts continue to reset normally.

Boundaries:
- no canonical-ledger, accounting, state/history, recovery, or day-peak rewrite
- no strategy, sizing, threshold, hard-risk, broker, live, AI/ML, or order-authority change
- no halt clearing
- Issue #202 remains frozen

Validation:
- focused and affected invariant suite: 144 passed
- impact-aware Change Safety regression: pass at local exact commit
- repository validation, Railway configuration, structural/ownership/configuration, and architecture-debt gates: pass with zero new violations
- full repository collection: 524 passed, 10 pre-existing/order-dependent legacy failures outside changed files
- authoritative exact-head GitHub gates, including exact Gunicorn smoke, remain required before merge

Settled Splendid acceptance after deployment must show the unresolved parity mismatch remains visible and the risk halt remains latched; the four historical missing projections are not repaired by this PR.