### PR TITLE
Expose bounded Issue 222 reconciliation signatures

### DIFF
--- a/PROJECT_HANDOFF_CURRENT.md
+++ b/PROJECT_HANDOFF_CURRENT.md
@@ -1260,3 +1260,20 @@ Issue #222 remains open for the separately governed successor reconciliation of
 the four pre-existing missing state projections; the halt must not be manually
 cleared. Issue #202 and all performance promotion remain frozen until parity is
 resolved and post-reconciliation forward/runtime acceptance passes.
+
+## 2026-09-12 Issue #222 — Successor Reconciliation Evidence — IN VALIDATION
+
+The cross-day halt is now accepted, so the next bounded stage is collecting the
+exact immutable signatures needed to design the four-row successor
+reconciliation without guessing or exposing a state-write control. Branch
+`fix/issue-222-reconciliation-evidence` adds the already-detected missing
+current-epoch rows to the existing read-only canonical-ledger status, capped at
+the same ten-row diagnostic boundary and limited to execution identity, chain
+hashes, epoch/version, timestamp, action, symbol, side, price, and quantity.
+
+This stage is observability only: it does not repair state, rewrite canonical
+history, clear the active parity halt, call the broker, place orders, or change
+strategy, sizing, thresholds, live, or AI/ML authority. After exact-head gates
+and deployment acceptance, use the four exact event hashes and lifecycle fields
+to define a separately tested, archival, restart-safe successor reconciliation.
+Issue #202 remains frozen.

--- a/canonical_execution_ledger.py
+++ b/canonical_execution_ledger.py
@@ -20,7 +20,7 @@ import threading
 import uuid
 from typing import Any, Dict, List, Tuple
 
-VERSION = "canonical-execution-ledger-2026-09-10-v4-parity-halt"
+VERSION = "canonical-execution-ledger-2026-09-12-v5-reconciliation-signatures"
 STATE_DIR = os.environ.get("STATE_DIR") or os.environ.get("PERSISTENT_STATE_DIR") or os.environ.get("RAILWAY_VOLUME_MOUNT_PATH") or "."
 LEDGER_FILE = os.path.join(STATE_DIR, "canonical_execution_ledger.jsonl")
 
@@ -328,6 +328,27 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
     }
     missing_from_state = sorted(ledger_ids - state_ids)
     missing_from_ledger = sorted(state_ids - ledger_ids)
+    missing_from_state_set = set(missing_from_state[:10])
+    missing_from_state_rows = [
+        {
+            key: row.get(key)
+            for key in (
+                "execution_id",
+                "event_hash",
+                "previous_event_hash",
+                "accounting_epoch_id",
+                "ledger_version",
+                "recorded_local",
+                "action",
+                "symbol",
+                "side",
+                "price",
+                "shares",
+            )
+        }
+        for row in epoch_rows
+        if str(row.get("execution_id") or "").strip() in missing_from_state_set
+    ]
     parity_checked = bool(core is not None and current_epoch)
     state_projection_parity = bool(parity_checked and not missing_from_state and not missing_from_ledger)
     hooked = core is not None and getattr(getattr(core, "record_trade", None), "_canonical_execution_ledger_version", None) == VERSION
@@ -350,6 +371,7 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
         "state_projection_parity": state_projection_parity if parity_checked else None,
         "missing_from_state_count": len(missing_from_state),
         "missing_from_state_execution_ids": missing_from_state[:10],
+        "missing_from_state_execution_rows": missing_from_state_rows,
         "missing_from_ledger_count": len(missing_from_ledger),
         "missing_from_ledger_execution_ids": missing_from_ledger[:10],
         "last_execution_id": rows[-1].get("execution_id") if rows else None,
@@ -374,6 +396,7 @@ def status_payload(core: Any = None) -> Dict[str, Any]:
             "changes_thresholds": False,
             "changes_risk_or_sizing": False,
             "latches_risk_halt_on_projection_divergence": True,
+            "exposes_bounded_missing_row_signatures": True,
             "changes_live_or_ml_authority": False,
         },
     }

--- a/test_issue222_canonical_state_parity.py
+++ b/test_issue222_canonical_state_parity.py
@@ -148,6 +148,23 @@ def test_ledger_parity_fails_audit_and_sentinel(monkeypatch):
     assert status["overall"] == "fail"
     assert status["state_projection_parity"] is False
     assert status["missing_from_state_execution_ids"] == ["gev-entry"]
+    assert status["missing_from_state_execution_rows"] == [
+        {
+            "execution_id": "gev-entry",
+            "event_hash": None,
+            "previous_event_hash": None,
+            "accounting_epoch_id": EPOCH,
+            "ledger_version": None,
+            "recorded_local": None,
+            "action": "entry",
+            "symbol": "GEV",
+            "side": "short",
+            "price": 920.93,
+            "shares": 1.091006,
+        }
+    ]
+    assert status["authority"]["exposes_bounded_missing_row_signatures"] is True
+    assert status["authority"]["repairs_historical_state"] is False
 
     monkeypatch.setattr(compact, "_ledger_status", lambda core=None: status)
     monkeypatch.setattr(compact, "_journal_status", lambda core=None: {})


### PR DESCRIPTION
Advances the separately governed evidence stage of #222 without performing a repair.

The existing canonical-ledger status already identifies up to ten execution IDs missing from state. This change adds the corresponding bounded immutable row signatures—identity, chain hashes, epoch/version, timestamp, action, symbol, side, price, and quantity—so the exact four-row production shape can be reviewed and frozen before writing any successor reconciliation.

Boundaries:
- read-only status output only
- no state, ledger, accounting, history, recovery, or risk mutation
- active parity halt remains unchanged
- no strategy, sizing, threshold, broker, live, AI/ML, or order authority
- Issue #202 remains frozen

Local focused/affected validation: 56 passed. Exact-head repository gates and settled Splendid acceptance are required before using the signatures.